### PR TITLE
Add Dependabot config with 1-week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/activeplay"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/billing"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/campaignmanager"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/entitybuilder"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/gallery"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/report"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/rulebuilder"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/storybuilder"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/support"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/engines/worldbuilder"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` configuring weekly updates with a 7-day cooldown for the root `Gemfile`, all 10 engine Gemfiles, and `github-actions`.

## Test plan
- [ ] Confirm GitHub recognizes the config (Insights → Dependency graph → Dependabot)
- [ ] Verify first scheduled runs respect the cooldown window

🤖 Generated with [Claude Code](https://claude.com/claude-code)