### PR TITLE
Fix stale uuid() DB-side default causing SQLite INSERT failures

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,13 +1,19 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  before_create :assign_uuid_if_blank
+  UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  before_create :assign_uuid_if_missing
 
   private
 
-  def assign_uuid_if_blank
-    if self.class.columns_hash[self.class.primary_key.to_s]&.type == :string && self[self.class.primary_key].blank?
-      self[self.class.primary_key] = SecureRandom.uuid
-    end
+  def assign_uuid_if_missing
+    pk = self.class.primary_key
+    return unless self.class.columns_hash[pk.to_s]&.type == :string
+
+    current = self[pk]
+    return if current.is_a?(String) && current.match?(UUID_PATTERN)
+
+    self[pk] = SecureRandom.uuid
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,9 +7,15 @@ class ApplicationRecord < ActiveRecord::Base
 
   private
 
+  # Skip integer PKs (auto-increment); allow :string, :uuid, and any other
+  # string-like column that doesn't match Rails' integer type patterns.
+  INTEGER_PK_TYPES = %i[integer bigint].freeze
+
   def assign_uuid_if_missing
     pk = self.class.primary_key
-    return unless self.class.columns_hash[pk.to_s]&.type == :string
+    col = self.class.columns_hash[pk.to_s]
+    return unless col
+    return if INTEGER_PK_TYPES.include?(col.type)
 
     current = self[pk]
     return if current.is_a?(String) && current.match?(UUID_PATTERN)

--- a/test/models/application_record_test.rb
+++ b/test/models/application_record_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class ApplicationRecordTest < ActiveSupport::TestCase
+  UUID_RE = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  def new_campaign(overrides = {})
+    Campaignmanager::Campaign.new({
+      resident_id: SecureRandom.uuid,
+      name: "Test Campaign",
+      slug: "test-#{SecureRandom.hex(6)}",
+      privacy: "private"
+    }.merge(overrides))
+  end
+
+  test "assigns a UUID when id is blank on create" do
+    campaign = new_campaign(id: nil)
+    campaign.save!(validate: false)
+    assert_match UUID_RE, campaign.id
+  end
+
+  test "overwrites the uuid() sentinel with a real UUID on create" do
+    campaign = new_campaign(id: "uuid()")
+    campaign.save!(validate: false)
+    assert_match UUID_RE, campaign.id
+    assert_not_equal "uuid()", campaign.id
+  end
+
+  test "preserves an explicit UUID on create" do
+    fixed_uuid = "12345678-1234-1234-1234-123456789012"
+    campaign = new_campaign(id: fixed_uuid)
+    campaign.save!(validate: false)
+    assert_equal fixed_uuid, campaign.id
+  end
+
+  test "does not assign a UUID on integer-PK models" do
+    admin = Admin.new(email: "callback-test-#{SecureRandom.hex}@example.com")
+    admin.save!(validate: false)
+    assert_kind_of Integer, admin.id
+  end
+end


### PR DESCRIPTION
## Summary

- Replaces the `assign_uuid_if_blank` callback with `assign_uuid_if_missing`, which uses a `UUID_PATTERN` regex to detect and overwrite any non-UUID value (including the `"uuid()"` sentinel, nil, and blank strings)
- Fixes a crash in controller-driven creates (e.g. `Campaignmanager::Campaign`) where SQLite read a stale `DEFAULT uuid()` column default back as the literal string `"uuid()"`, fooling the old `blank?` guard and causing Rails to omit `id` from the INSERT, after which the DB crashed trying to evaluate `uuid()`
- Adds `ApplicationRecordTest` covering all four cases: blank id, the `"uuid()"` sentinel, an explicit UUID preserved, and an integer-PK model left untouched

## Test Plan
- [ ] All 703 existing tests pass (`bundle exec rails test`)
- [ ] Boot dev server against a database with the stale `DEFAULT uuid()` columns and create a new Campaign via the UI — expect a successful redirect with a real UUID `id`, no `SQLite3::SQLException`