### PR TITLE
[codex] Remove misleading 4e GSL metadata

### DIFF
--- a/config/core_rules/4th-edition.json
+++ b/config/core_rules/4th-edition.json
@@ -9,10 +9,6 @@
     "logo": "",
     "url": "http://dnd.wizards.com"
   },
-  "license": {
-    "label": "Game System License",
-    "core_faq": ""
-  },
   "entitybuilder": {
     "sheet": "default",
     "use_modifiers": "true",

--- a/test/lib/core_rules_license_test.rb
+++ b/test/lib/core_rules_license_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CoreRulesLicenseTest < ActiveSupport::TestCase
+  test "4th Edition has no license metadata" do
+    assert_nil CoreRules.license("4th Edition")
+  end
+end

--- a/test/views/license_link_test.rb
+++ b/test/views/license_link_test.rb
@@ -13,4 +13,17 @@ class LicenseLinkTest < ActionView::TestCase
     assert_no_match(/rpg-system-attribution/, rendered)
     assert_no_match(/License d20 OGL/, rendered)
   end
+
+  test "does not render a modal link for 4th Edition" do
+    render partial: "layouts/license/link", locals: { core_rules: "4th Edition" }
+
+    assert_no_match(/scrolls\/license/, rendered)
+  end
+
+  test "does not render attribution for 4th Edition" do
+    render partial: "layouts/license/attribution", locals: { core_rules: "4th Edition" }
+
+    assert_no_match(/rpg-system-attribution/, rendered)
+    assert_no_match(/Game System License/, rendered)
+  end
 end


### PR DESCRIPTION
## Summary
Remove the misleading 4e Game System License metadata because City of Brass is an interactive app and character tool, which the attached GSL/FAQ say is not licensed under the GSL.

## Changes
The 4th Edition rulebook config no longer exposes license metadata, and tests now assert that 4e renders no license modal link or attribution footer while preserving other license behavior.

## Validation
Ran focused license tests, Draw Steel regression tests, RuboCop on touched Ruby tests, JSON parsing for the edited config, and the full Rails test suite.
