### PR TITLE
Fix CKEditor editorblank textarea targeting

### DIFF
--- a/app/assets/javascripts/ckeditor/brassify.js.erb
+++ b/app/assets/javascripts/ckeditor/brassify.js.erb
@@ -21,6 +21,7 @@ var onCurrentInstance = function(){
 function ckeditorStandard() {
   CKEDITOR.env.isCompatible = true;
   CKEDITOR.replaceAll(function( textarea, config ){
+    if (!$(textarea).hasClass('editorblank')) return false;
     config.contentsCss = ["https://fonts.googleapis.com/css?family=Marcellus+SC","https://fonts.googleapis.com/css?family=Open+Sans:400,700","<%= asset_path 'ckeditor/standard.css' %>"];
     config.uiColor = '#c5c5c5';
     config.forcePasteAsPlainText = false;
@@ -42,6 +43,7 @@ function ckeditorStandard() {
 function ckeditorMini() {
   CKEDITOR.env.isCompatible = true;
   CKEDITOR.replaceAll(function( textarea, config ){
+    if (!$(textarea).hasClass('editorblank')) return false;
     config.contentsCss = ["https://fonts.googleapis.com/css?family=Marcellus+SC","https://fonts.googleapis.com/css?family=Open+Sans:400,700","<%= asset_path 'ckeditor/standard.css' %>"];
     config.uiColor = '#c5c5c5';
     config.forcePasteAsPlainText = false;
@@ -61,6 +63,7 @@ function ckeditorMini() {
 function ckeditorBasic() {
   CKEDITOR.env.isCompatible = true;
   CKEDITOR.replaceAll(function( textarea, config ){
+    if (!$(textarea).hasClass('editorblank')) return false;
     config.contentsCss = ["https://fonts.googleapis.com/css?family=Marcellus+SC","https://fonts.googleapis.com/css?family=Open+Sans:400,700","<%= asset_path 'ckeditor/standard.css' %>"];
     config.uiColor = '#c5c5c5';
     config.forcePasteAsPlainText = false;
@@ -97,6 +100,7 @@ function ckeditorCard() {
 
   CKEDITOR.env.isCompatible = true;
   CKEDITOR.replaceAll(function( textarea, config ){
+    if (!$(textarea).hasClass('editorblank')) return false;
     config.contentsCss = ["https://fonts.googleapis.com/css?family=Marcellus+SC","https://fonts.googleapis.com/css?family=Open+Sans:400,700","<%= asset_path 'ckeditor/standard.css' %>"];
     config.uiColor = '#c5c5c5';
     config.forcePasteAsPlainText = false;
@@ -120,6 +124,7 @@ function ckeditorCard() {
 function ckeditorFAQ() {
   CKEDITOR.env.isCompatible = true;
   CKEDITOR.replaceAll(function( textarea, config ){
+    if (!$(textarea).hasClass('editorblank')) return false;
     config.contentsCss = ["https://fonts.googleapis.com/css?family=Marcellus+SC","https://fonts.googleapis.com/css?family=Open+Sans:400,700","<%= asset_path 'ckeditor/standard.css' %>"];
     config.uiColor = '#c5c5c5';
     config.forcePasteAsPlainText = false;

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -4,7 +4,7 @@
     <div class="medium-12 columns">
       <%= f.association :recipient, collection: @resident.affiliates, label_method: :name, value_method: :id, :prompt => 'Please Select' %>
       <%= f.input :subject %>
-      <%= f.input :body, class: "editorblank" %>
+      <%= f.input :body, input_html: { class: "editorblank" } %>
     </div>
   </div>
 </fieldset>

--- a/app/views/residents/_form.html.erb
+++ b/app/views/residents/_form.html.erb
@@ -19,7 +19,7 @@
   </div>
   <div class="row">
     <div class="small-12 columns">
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -27,7 +27,7 @@
   <div class="row">
     <div class="small-12 columns">
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
   <% end %>

--- a/engines/campaignmanager/app/views/campaignmanager/pages/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/_form.html.erb
@@ -24,7 +24,7 @@
         <%= f.input :page_date, label: 'Session Date', :include_blank => true %>
       <% end %>
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 </fieldset>

--- a/engines/campaignmanager/app/views/campaignmanager/sections/form/_text.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/sections/form/_text.html.erb
@@ -1,5 +1,5 @@
 <%= f.input :header %>
 <%= f.input :section_style, label: 'Style', collection: cm_section_text_style_options, :include_blank => true %>
-<%= f.input :content, class: "editorblank" %>
+<%= f.input :content, input_html: { class: "editorblank" } %>
 
 <%= render :partial =>'layouts/ckeditor', :locals => { :cke_version => 'standard' } %>

--- a/engines/entitybuilder/app/views/entitybuilder/entities/_form.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/_form.html.erb
@@ -43,11 +43,11 @@
     <div class="small-12 columns">
       <%= f.input :tag_list, label: 'Tag list (separated by commas)' %>
       <%= f.input :short_description %>
-      <%= f.input :full_description, label: "Full Description ( Summary & Profile )", class: "editorblank" %>
+      <%= f.input :full_description, label: "Full Description ( Summary & Profile )", input_html: { class: "editorblank" } %>
       <br>
-      <%= f.input :introduction, label: "Introduction ( Profile )", class: "editorblank" %>
+      <%= f.input :introduction, label: "Introduction ( Profile )", input_html: { class: "editorblank" } %>
       <br>
-      <%= f.input :notes, class: "editorblank" %>
+      <%= f.input :notes, input_html: { class: "editorblank" } %>
     </div>
   </div>
   <% end %>

--- a/engines/entitybuilder/app/views/entitybuilder/entities/_notes.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/_notes.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
   <div class="medium-12 columns" style="padding: .5em">
-    <%= f.input :notes, label: false, class: "editorblank" %>
+    <%= f.input :notes, label: false, input_html: { class: "editorblank" } %>
   </div>
 </div>

--- a/engines/entitybuilder/app/views/entitybuilder/entities/layouts/card/_notes.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/layouts/card/_notes.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for entity, :url => "#{polymorphic_path(entity)}/update_notes", :remote => true do |f| %>
   <div class="row">
     <div class="medium-12 columns">
-      <%= f.input :notes, label: false, class: "editorblank" %>
+      <%= f.input :notes, label: false, input_html: { class: "editorblank" } %>
     </div>
   </div>
 <% end %>

--- a/engines/rulebuilder/app/views/rulebuilder/items/_form.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/items/_form.html.erb
@@ -39,7 +39,7 @@
     <div class="medium-12 columns">
       <%= f.input :tag_list, label: 'Tag list (separated by commas)' %>
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 </fieldset>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_ability.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_ability.html.erb
@@ -38,7 +38,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_aspect.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_aspect.html.erb
@@ -38,7 +38,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
     <br>
     <% if f.object.is_shared == true %>
       <% f.input :tag_list, label: 'Tag list (separated by commas)' %>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_backgrounds.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_backgrounds.erb
@@ -40,7 +40,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_epic-destinies.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_epic-destinies.erb
@@ -40,7 +40,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_exploit.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_exploit.html.erb
@@ -40,7 +40,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_feat.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_feat.html.erb
@@ -45,14 +45,14 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
     <br>
     <% if CoreRules.d20_system?(f.object.core_rules) %>
-      <%= f.input :benefit, class: "editorblank" %>
+      <%= f.input :benefit, input_html: { class: "editorblank" } %>
       <br>
-      <%= f.input :normal, class: "editorblank" %>
+      <%= f.input :normal, input_html: { class: "editorblank" } %>
       <br>
-      <%= f.input :special, class: "editorblank" %>
+      <%= f.input :special, input_html: { class: "editorblank" } %>
       <br>
     <% end %>
   </div>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_paragon-paths.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_paragon-paths.erb
@@ -40,7 +40,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_rule.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_rule.html.erb
@@ -40,7 +40,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_stunt.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_stunt.html.erb
@@ -43,7 +43,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_trait.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_trait.html.erb
@@ -38,7 +38,7 @@
 </div>
 <div class="row">
   <div class="medium-12 columns">
-    <%= f.input :full_description, class: "editorblank" %>
+    <%= f.input :full_description, input_html: { class: "editorblank" } %>
   </div>
 </div>
 

--- a/engines/rulebuilder/app/views/rulebuilder/spells/_form.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/spells/_form.html.erb
@@ -56,7 +56,7 @@
     <div class="medium-12 columns">
       <%= f.input :tag_list, label: 'Tag list (separated by commas)' %>
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 

--- a/engines/storybuilder/app/views/storybuilder/adventures/_form.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/adventures/_form.html.erb
@@ -24,7 +24,7 @@
   <div class="row">
     <div class="small-12 columns">
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 </fieldset>

--- a/engines/storybuilder/app/views/storybuilder/pages/_form.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/_form.html.erb
@@ -49,7 +49,7 @@
     <div class="small-12 columns">
       <%= f.input :tag_list, label: 'Tag list (separated by commas)' %>
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 </fieldset>

--- a/engines/storybuilder/app/views/storybuilder/sections/form/_text.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/sections/form/_text.html.erb
@@ -1,5 +1,5 @@
 <%= f.input :header %>
 <%= f.input :section_style, label: 'Style', collection: sb_section_text_style_options, default: 'paragraph' %>
-<%= f.input :content, class: "editorblank" %>
+<%= f.input :content, input_html: { class: "editorblank" } %>
 
 <%= render :partial =>'layouts/ckeditor', :locals => { :cke_version => 'standard' } %>

--- a/engines/support/app/views/support/faqs/_form.html.erb
+++ b/engines/support/app/views/support/faqs/_form.html.erb
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="small-12 columns">
       <%= f.input :question %>
-      <%= f.input :answer, class: "editorblank" %>
+      <%= f.input :answer, input_html: { class: "editorblank" } %>
       <%= f.input :active, label: "&nbsp; Active".html_safe %>
     </div>
   </div>

--- a/engines/worldbuilder/app/views/worldbuilder/districts/_form.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/districts/_form.html.erb
@@ -26,7 +26,7 @@
   <div class="row">
     <div class="small-12 columns">
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
   <% end %>

--- a/engines/worldbuilder/app/views/worldbuilder/pages/_form.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/pages/_form.html.erb
@@ -35,7 +35,7 @@
     <div class="small-12 columns">
       <%= f.input :tag_list, label: 'Tag list (separated by commas)' %>
       <%= f.input :short_description %>
-      <%= f.input :full_description, class: "editorblank" %>
+      <%= f.input :full_description, input_html: { class: "editorblank" } %>
     </div>
   </div>
 </fieldset>

--- a/engines/worldbuilder/app/views/worldbuilder/sections/form/_text.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/sections/form/_text.html.erb
@@ -1,5 +1,5 @@
 <%= f.input :header %>
 <%= f.input :section_style, label: 'Style', collection: wb_section_text_style_options, :include_blank => true %>
-<%= f.input :content, class: "editorblank" %>
+<%= f.input :content, input_html: { class: "editorblank" } %>
 
 <%= render :partial =>'layouts/ckeditor', :locals => { :cke_version => 'standard' } %>


### PR DESCRIPTION
This updates CKEditor initialization to only attach to textareas explicitly marked with `editorblank`.
All Simple Form fields that should get CKEditor now pass that class through `input_html`, including the rulebuilder aspect form that was still using the old wrapper-level option.
This fixes the mismatch where Simple Form placed `class: "editorblank"` on the wrapper element instead of the `<textarea>`, which made CKEditor targeting inconsistent.
Validation: parsed all changed ERB templates with `erb -x -T -` and confirmed no wrapper-level `f.input ..., class: "editorblank"` callsites remain under `app/` and `engines/`.
