### PR TITLE
Remove explicit Activeplay notable form URL

### DIFF
--- a/engines/activeplay/app/views/activeplay/notables/_form.html.erb
+++ b/engines/activeplay/app/views/activeplay/notables/_form.html.erb
@@ -1,5 +1,5 @@
 <div id="form_div">
-<%= simple_form_for [@virtual_table, @notable], :url => "#{virtual_table_path(@virtual_table)}/notables/#{@notable.id}", :remote => true, :html => {'data-no-transition-cache' => ''} do |f| %>
+<%= simple_form_for [@virtual_table, @notable], :remote => true, :html => {'data-no-transition-cache' => ''} do |f| %>
   <fieldset>
     <div class="row inline text-right">
       <div class="small-12 columns">


### PR DESCRIPTION
This removes the hand-built URL from the Activeplay notable form and lets Rails infer the nested virtual table notable route from the form objects. The change keeps create and update submissions aligned with the engine routes while avoiding manual string construction. Validation: pre-push checks reported no changed Ruby files to lint and no changed test files to run.