### PR TITLE
Publish-readiness: public content + multi-adventure campaigns

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -147,6 +147,19 @@ module ApplicationHelper
     end
   end
 
+  def visible_records(records)
+    Array(records).select { |record| visible_record?(record) }
+  end
+
+  def visible_record?(record)
+    return true unless record.respond_to?(:can_show?)
+    return true if record.class.respond_to?(:column_names) && record.class.column_names.exclude?('privacy')
+
+    record.can_show?(current_user, admin_signed_in?, record.class.name)
+  rescue ArgumentError
+    record.can_show?(current_user, admin_signed_in?)
+  end
+
   def notable_sentence(list)
     begin
       buildlist = []

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,21 +160,47 @@ module ApplicationHelper
     record.can_show?(current_user, admin_signed_in?)
   end
 
+  def visible_notables(list)
+    Array(list).select { |record| record.entity.blank? || visible_record?(record.entity) }
+  end
+
+  def visible_inventory_items(inventory_items)
+    Array(inventory_items).select { |inventory_item| visible_record?(inventory_item.item) }
+  end
+
+  def notable_link(record)
+    return record.name if record.entity.blank?
+
+    link_to record.name, notable_entity_path(record), "data-reveal-id" => "showModal", remote: true
+  end
+
+  def notable_entity_path(record)
+    return "#{entitybuilder.polymorphic_path(record.entity)}/profile" if notable_profile_link?(record)
+
+    entitybuilder.polymorphic_path(record.entity)
+  end
+
+  def notable_profile_link?(record)
+    record.notableable_type.include?("Storybuilder") &&
+      record.entity.can_sheet?(current_user, admin_signed_in?, record.entity.type.demodulize)
+  end
+
+  def visible_storybuilder_menu_items(menu_items)
+    Array(menu_items).select { |menu_item| visible_storybuilder_menu_item?(menu_item) }
+  end
+
+  def visible_storybuilder_menu_item?(menu_item)
+    join = Storybuilder::MenuItemJoin.find_by(menu_item_id: menu_item.id)
+    return true if join.blank? || join.menu_item_joinable.blank?
+
+    visible_record?(join.menu_item_joinable)
+  end
+
   def notable_sentence(list)
     begin
       buildlist = []
       if list
-        list.each do |record|
-
-        if record.entity.blank?
-          link = record.name
-        elsif  record.notableable_type.include?"Storybuilder"
-          link = link_to record.name, "#{entitybuilder.polymorphic_path(record.entity)}/profile", "data-reveal-id" => "showModal", :remote => true
-        else
-          link = link_to record.name, "#{entitybuilder.polymorphic_path(record.entity)}", "data-reveal-id" => "showModal", :remote => true
-        end
-          buildlist << link
-        end
+        visible_notables(list).each { |record| buildlist << notable_link(record) }
         buildlist.to_sentence(:two_words_connector => ' & ', :last_word_connector => ' & ').html_safe
       else
         nil

--- a/app/models/concerns/keys_to_entitybuilder.rb
+++ b/app/models/concerns/keys_to_entitybuilder.rb
@@ -2,6 +2,7 @@ module KeysToEntitybuilder
   extend ActiveSupport::Concern
 
     def can_show?(current_user, is_admin, record_type)
+      return true if privacy == 'Public'
       return false if current_user.nil?
       return true if can_edit?(current_user, is_admin, record_type)
       return true if privacy == 'Residents'
@@ -12,6 +13,7 @@ module KeysToEntitybuilder
     end
 
     def can_sheet?(current_user, is_admin, record_type)
+      return true if sheet_privacy == 'Public'
       return false if current_user.nil?
       return true if can_edit?(current_user, is_admin, record_type)
       return true if sheet_privacy == 'Residents'

--- a/app/models/concerns/keys_to_rulebuilder.rb
+++ b/app/models/concerns/keys_to_rulebuilder.rb
@@ -2,8 +2,16 @@ module KeysToRulebuilder
   extend ActiveSupport::Concern
 
     def can_show?(current_user, is_admin, record_type)
-      return can_edit?(current_user, is_admin, record_type)
-      return is_admin
+      if respond_to?(:privacy)
+        return true if privacy == "Public"
+        return false if current_user.nil?
+        return true if can_edit?(current_user, is_admin, record_type)
+        return true if privacy == "Residents"
+        return true if privacy == "Friends" && Affiliation.are_affiliates(current_user.resident, self.resident) rescue NoMethodError
+        return is_admin
+      else
+        return can_edit?(current_user, is_admin, record_type)
+      end
     end
 
     def can_edit?(current_user, is_admin, record_type)

--- a/app/models/concerns/keys_to_rulebuilder.rb
+++ b/app/models/concerns/keys_to_rulebuilder.rb
@@ -2,7 +2,7 @@ module KeysToRulebuilder
   extend ActiveSupport::Concern
 
     def can_show?(current_user, is_admin, record_type)
-      if respond_to?(:privacy)
+      if self.class.const_defined?(:PRIVACY_OPTIONS)
         return true if privacy == "Public"
         return false if current_user.nil?
         return true if can_edit?(current_user, is_admin, record_type)

--- a/app/models/concerns/keys_to_storybuilder.rb
+++ b/app/models/concerns/keys_to_storybuilder.rb
@@ -2,6 +2,7 @@ module KeysToStorybuilder
   extend ActiveSupport::Concern
 
   def can_show?(current_user, is_admin, record_type = nil)
+    return true if privacy == 'Public'
     return false if current_user.nil?
     return true if can_edit?(current_user, is_admin, record_type)
     return true if privacy == 'Residents'

--- a/app/views/layouts/features/_looper.html.erb
+++ b/app/views/layouts/features/_looper.html.erb
@@ -3,13 +3,13 @@
     <%= render :partial => "layouts/features/show/#{feature.feature_type}",
       :locals => {
         :feature => feature,
-        :list => record.children.order(:name)
+        :list => visible_records(record.children.order(:name))
       } %>
   <% else %>
     <%= render :partial => "layouts/features/show/#{feature.feature_type}",
       :locals => {
         :feature => feature,
-        :list => record.children.order('sort_weight, name')
+        :list => visible_records(record.children.order('sort_weight, name'))
       } %>
   <% end %>
 <% end %>
@@ -23,6 +23,7 @@
       tag_children = @district.pages.order('sort_weight, name').all_tags(feature.search_tags.split(',')) if feature.record_type.include? "Worldbuilder"
       tag_children = @adventure.pages.order('sort_weight, name').all_tags(feature.search_tags.split(',')) if feature.record_type.include? "Storybuilder"
     end
+    tag_children = visible_records(tag_children)
 %>
   <%= render :partial => "layouts/features/show/#{feature.feature_type}",
       :locals => {

--- a/app/views/layouts/notables/_entity_feature_list.html.erb
+++ b/app/views/layouts/notables/_entity_feature_list.html.erb
@@ -1,12 +1,6 @@
 <strong>Notables</strong>
 <ul style="margin-bottom: 0px;">
-<% list.each do |record| %>
-  <% if record.entity.blank? %>
-    <%= "#{record.name}" %>
-  <% elsif record.notableable_type.include?"Storybuilder" %>
-    <li><%= link_to record.name, "#{entitybuilder.polymorphic_path(record.entity)}/profile", "data-reveal-id" => "showModal", :remote => true %></li>
-  <% else %>
-    <li><%= link_to record.name, "#{entitybuilder.polymorphic_path(record.entity)}", "data-reveal-id" => "showModal", :remote => true %></li>
-  <% end %>
+<% visible_notables(list).each do |record| %>
+  <li><%= notable_link(record) %></li>
 <% end %>
 </ul>

--- a/app/views/layouts/sections/_looper.html.erb
+++ b/app/views/layouts/sections/_looper.html.erb
@@ -3,16 +3,16 @@
   <%= render :partial => "layouts/sections/show/#{section.section_type}/#{section.section_style}",
     :locals => {
       :section => section,
-      :list => record.children.order(:name),
-      :all_pages => all_pages,
+      :list => visible_records(record.children.order(:name)),
+      :all_pages => visible_records(all_pages),
       :can_auth => can_auth
     } %>
   <% else %>
   <%= render :partial => "layouts/sections/show/#{section.section_type}/#{section.section_style}",
     :locals => {
       :section => section,
-      :list => record.children.order('sort_weight, name'),
-      :all_pages => all_pages,
+      :list => visible_records(record.children.order('sort_weight, name')),
+      :all_pages => visible_records(all_pages),
       :can_auth => can_auth
     } %>
   <% end %>
@@ -27,13 +27,14 @@
       tag_children = @district.pages.order('sort_weight, name').all_tags(section.search_tags.split(',')) if section.record_type.include? "Worldbuilder"
       tag_children = @adventure.pages.order('sort_weight, name').all_tags(section.search_tags.split(',')) if section.record_type.include? "Storybuilder"
     end
+    tag_children = visible_records(tag_children)
 %>
 
   <%= render :partial => "layouts/sections/show/#{section.section_type}/#{section.section_style}",
       :locals => {
         :section => section,
         :list => tag_children,
-        :all_pages => all_pages,
+        :all_pages => visible_records(all_pages),
         :can_auth => can_auth
       } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,9 @@
 
 en:
   hello: "Hello world"
+  errors:
+    messages:
+      invalid_privacy: "is not valid."
   layouts:
     license:
       attribution:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_13_000001) do
+ActiveRecord::Schema.define(version: 2026_06_13_162630) do
 
   create_table "activeplay_notables", id: :string, force: :cascade do |t|
     t.string "name"
@@ -104,6 +104,16 @@ ActiveRecord::Schema.define(version: 2026_06_13_000001) do
     t.index ["user_id"], name: "index_billing_subscriptions_on_user_id", unique: true
   end
 
+  create_table "campaignmanager_campaign_adventure_joins", id: :string, force: :cascade do |t|
+    t.string "campaign_id", null: false
+    t.string "adventure_id", null: false
+    t.boolean "active", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["campaign_id", "active"], name: "idx_cm_campaign_adventure_joins_active"
+    t.index ["campaign_id", "adventure_id"], name: "idx_cm_campaign_adventure_joins_unique", unique: true
+  end
+
   create_table "campaignmanager_campaigns", id: :string, force: :cascade do |t|
     t.string "resident_id", null: false
     t.string "name", limit: 255, null: false
@@ -115,9 +125,7 @@ ActiveRecord::Schema.define(version: 2026_06_13_000001) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "district_id"
-    t.string "adventure_id"
     t.string "core_rules"
-    t.index ["adventure_id"], name: "index_campaignmanager_campaigns_on_adventure_id"
     t.index ["district_id"], name: "index_campaignmanager_campaigns_on_district_id"
     t.index ["resident_id"], name: "index_campaignmanager_campaigns_on_resident_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -632,7 +632,9 @@ ActiveRecord::Schema.define(version: 2026_06_13_162630) do
     t.string "source"
     t.boolean "is_3pp", default: false
     t.text "tags"
+    t.string "privacy", default: "Private", null: false
     t.index ["parent_id"], name: "index_rulebuilder_items_on_parent_id"
+    t.index ["privacy"], name: "index_rulebuilder_items_on_privacy"
     t.index ["resident_id"], name: "index_rulebuilder_items_on_resident_id"
     t.index ["tags"], name: "index_rulebuilder_items_on_tags"
     t.index ["type"], name: "index_rulebuilder_items_on_type"

--- a/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
@@ -93,7 +93,7 @@ module Campaignmanager
       respond_to do |format|
         if @campaign.update(campaign_params)
           requested_active_id = params.dig(:campaign, :active_adventure_id)
-          if requested_active_id.present? && @campaign.campaign_adventure_joins.where(adventure_id: requested_active_id).exists?
+          if params[:campaign].key?(:active_adventure_id) && active_adventure_selectable?(requested_active_id)
             @campaign.active_adventure_id = requested_active_id
           end
           cm_new_activeplay_virtual_table(@campaign) if @campaign.activeplay.blank?
@@ -210,6 +210,10 @@ module Campaignmanager
           adventure_ids: [],
           gallery_image_join_attributes: [:id, :image_id, :_destroy]
         )
+      end
+
+      def active_adventure_selectable?(adventure_id)
+        adventure_id.blank? || @campaign.campaign_adventure_joins.where(adventure_id: adventure_id).exists?
       end
   end
 end

--- a/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
@@ -77,12 +77,6 @@ module Campaignmanager
       @campaign.resident_id = current_user.resident.id
       @campaign.build_gallery_image_join if @campaign.gallery_image_join.nil?
 
-      if current_user.is_free?
-        unless Campaignmanager::Campaign::PRIVACY_OPTIONS_FREE.include? @campaign.privacy
-          @campaign.privacy = 'invalid'
-        end
-      end
-
       respond_to do |format|
         if @campaign.save
           cm_new_activeplay_virtual_table(@campaign) if @campaign.activeplay.blank?
@@ -96,13 +90,6 @@ module Campaignmanager
     # PATCH/PUT /campaigns/1
     # PATCH/PUT /campaigns/1.json
     def update
-
-      if current_user.is_free?
-        unless Campaignmanager::Campaign::PRIVACY_OPTIONS_FREE.include?(campaign_params[:privacy])
-          params[:campaign][:privacy] = 'invalid'
-        end
-      end
-
       respond_to do |format|
         if @campaign.update(campaign_params)
           requested_active_id = params.dig(:campaign, :active_adventure_id)

--- a/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
@@ -105,7 +105,10 @@ module Campaignmanager
 
       respond_to do |format|
         if @campaign.update(campaign_params)
-          @campaign.active_adventure_id = params[:campaign][:active_adventure_id] if params.dig(:campaign, :active_adventure_id).present?
+          requested_active_id = params.dig(:campaign, :active_adventure_id)
+          if requested_active_id.present? && @campaign.campaign_adventure_joins.where(adventure_id: requested_active_id).exists?
+            @campaign.active_adventure_id = requested_active_id
+          end
           cm_new_activeplay_virtual_table(@campaign) if @campaign.activeplay.blank?
           format.html { redirect_to edit_campaign_path(@campaign) }
           format.js   { flash.now[:notice] = "#{@campaign.name} has been updated." }

--- a/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
@@ -105,6 +105,7 @@ module Campaignmanager
 
       respond_to do |format|
         if @campaign.update(campaign_params)
+          @campaign.active_adventure_id = params[:campaign][:active_adventure_id] if params.dig(:campaign, :active_adventure_id).present?
           cm_new_activeplay_virtual_table(@campaign) if @campaign.activeplay.blank?
           format.html { redirect_to edit_campaign_path(@campaign) }
           format.js   { flash.now[:notice] = "#{@campaign.name} has been updated." }
@@ -216,6 +217,7 @@ module Campaignmanager
           :short_description,
           :full_description,
           :name_confirmation,
+          adventure_ids: [],
           gallery_image_join_attributes: [:id, :image_id, :_destroy]
         )
       end

--- a/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/campaigns_controller.rb
@@ -153,7 +153,7 @@ module Campaignmanager
       end
 
       def set_campaign_for_show
-        @campaign = Campaign.joins(:user).includes([:features, :sections, :player_residents, :adventure, :district]).find_by_id(params_id)
+        @campaign = Campaign.joins(:user).includes([:features, :sections, :player_residents, :active_adventure, :district]).find_by_id(params_id)
         if @campaign.nil?
           render template: 'errors/404', layout: 'layouts/application', status: 404
         end
@@ -213,7 +213,6 @@ module Campaignmanager
           :privacy,
           :core_rules,
           :district_id,
-          :adventure_id,
           :short_description,
           :full_description,
           :name_confirmation,

--- a/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
@@ -71,12 +71,6 @@ module Campaignmanager
         @parent = type_class.find_by_id(@page.parent_id)
       end
 
-      if current_user.is_free?
-        unless Campaignmanager::Campaign::PRIVACY_OPTIONS_FREE.include? @page.privacy
-          @page.privacy = 'invalid'
-        end
-      end
-
       respond_to do |format|
         if @page.save
           format.html { redirect_to sti_edit_page_path(@page), notice: @page.name + ' was successfully created.' }

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -3,8 +3,8 @@ module Campaignmanager
     include ReservedNames
     include KeysToCampaignmanager
 
-    PRIVACY_OPTIONS_FREE = [ 'Private' ]
     PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
+    PRIVACY_OPTIONS_FREE = PRIVACY_OPTIONS
     NULL_ATTRS = %w[ district_id ]
 
     scope :short, -> { select('campaignmanager_campaigns.id, campaignmanager_campaigns.resident_id, campaignmanager_campaigns.core_rules, campaignmanager_campaigns.district_id, campaignmanager_campaigns.name, campaignmanager_campaigns.privacy, campaignmanager_campaigns.short_description, campaignmanager_campaigns.page_label, campaignmanager_campaigns.updated_at') }

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -20,7 +20,7 @@ module Campaignmanager
             class_name: "User"
 
     belongs_to :district,
-            -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.privacy') },
+            -> { select('worldbuilder_districts.id, worldbuilder_districts.resident_id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.privacy') },
             class_name: "Worldbuilder::District"
 
     has_many :features, -> { order(:sort_order) }, as: :featureable, dependent: :destroy

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -118,6 +118,8 @@ module Campaignmanager
 
     def active_adventure_id=(adventure_id)
       campaign_adventure_joins.update_all(active: false)
+      return if adventure_id.blank?
+
       campaign_adventure_joins.where(adventure_id: adventure_id).update_all(active: true)
     end
 

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -112,6 +112,10 @@ module Campaignmanager
       where("campaignmanager_campaigns.name like ?", "%#{search}%")
     end
 
+    def active_adventure_id
+      active_adventure_join&.adventure_id
+    end
+
     def active_adventure_id=(adventure_id)
       campaign_adventure_joins.update_all(active: false)
       campaign_adventure_joins.where(adventure_id: adventure_id).update_all(active: true)

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -20,7 +20,7 @@ module Campaignmanager
             class_name: "User"
 
     belongs_to :district,
-            -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug') },
+            -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.privacy') },
             class_name: "Worldbuilder::District"
 
     has_many :features, -> { order(:sort_order) }, as: :featureable, dependent: :destroy

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -5,9 +5,9 @@ module Campaignmanager
 
     PRIVACY_OPTIONS_FREE = [ 'Private' ]
     PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
-    NULL_ATTRS = %w[ district_id adventure_id ]
+    NULL_ATTRS = %w[ district_id ]
 
-    scope :short, -> { select('campaignmanager_campaigns.id, campaignmanager_campaigns.resident_id, campaignmanager_campaigns.core_rules, campaignmanager_campaigns.district_id, campaignmanager_campaigns.adventure_id, campaignmanager_campaigns.name, campaignmanager_campaigns.privacy, campaignmanager_campaigns.short_description, campaignmanager_campaigns.page_label, campaignmanager_campaigns.updated_at') }
+    scope :short, -> { select('campaignmanager_campaigns.id, campaignmanager_campaigns.resident_id, campaignmanager_campaigns.core_rules, campaignmanager_campaigns.district_id, campaignmanager_campaigns.name, campaignmanager_campaigns.privacy, campaignmanager_campaigns.short_description, campaignmanager_campaigns.page_label, campaignmanager_campaigns.updated_at') }
     scope :order_name, -> { order(:name) }
     scope :order_updated_at, -> { order(Arel.sql('campaignmanager_campaigns.updated_at desc')) }
 
@@ -22,10 +22,6 @@ module Campaignmanager
     belongs_to :district,
             -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug') },
             class_name: "Worldbuilder::District"
-
-    belongs_to :adventure,
-            -> { select('storybuilder_adventures.id, storybuilder_adventures.name, storybuilder_adventures.slug, storybuilder_adventures.type') },
-            class_name: "Storybuilder::Adventure"
 
     has_many :features, -> { order(:sort_order) }, as: :featureable, dependent: :destroy
     has_many :sections, -> { order(:sort_order) }, as: :sectionable, dependent: :destroy
@@ -44,6 +40,24 @@ module Campaignmanager
     has_many :entity_joins,
              class_name: "Entitybuilder::CampaignJoin",
              dependent: :destroy
+
+    has_many :campaign_adventure_joins,
+             class_name: "Campaignmanager::CampaignAdventureJoin",
+             dependent: :destroy
+
+    has_many :adventures,
+             -> { select('storybuilder_adventures.id, storybuilder_adventures.name, storybuilder_adventures.slug, storybuilder_adventures.type') },
+             through: :campaign_adventure_joins,
+             class_name: "Storybuilder::Adventure"
+
+    has_one :active_adventure_join,
+            -> { where(active: true) },
+            class_name: "Campaignmanager::CampaignAdventureJoin"
+
+    has_one :active_adventure,
+            through: :active_adventure_join,
+            source: :adventure,
+            class_name: "Storybuilder::Adventure"
 
     has_many :characters,
              -> { select('entitybuilder_entities.id, entitybuilder_entities.type, entitybuilder_entities.resident_id, entitybuilder_entities.privacy, entitybuilder_entities.sheet_privacy, entitybuilder_entities.name, entitybuilder_entities.core_rules, entitybuilder_entities.short_description').order(:name) },
@@ -96,6 +110,11 @@ module Campaignmanager
 
     def self.search(search)
       where("campaignmanager_campaigns.name like ?", "%#{search}%")
+    end
+
+    def active_adventure_id=(adventure_id)
+      campaign_adventure_joins.update_all(active: false)
+      campaign_adventure_joins.where(adventure_id: adventure_id).update_all(active: true)
     end
 
     private

--- a/engines/campaignmanager/app/models/campaignmanager/campaign_adventure_join.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign_adventure_join.rb
@@ -1,0 +1,8 @@
+module Campaignmanager
+  class CampaignAdventureJoin < ApplicationRecord
+    belongs_to :campaign, class_name: "Campaignmanager::Campaign"
+    belongs_to :adventure, class_name: "Storybuilder::Adventure"
+
+    validates :adventure_id, uniqueness: { scope: :campaign_id }
+  end
+end

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
@@ -3,7 +3,7 @@
     <strong>Game Master: </strong>
     <%= link_to campaign.resident.name, main_app.resident_path(campaign.resident.slug) %>
   </li>
-<% if campaign.district.present? %>
+<% if campaign.district.present? && visible_record?(campaign.district) %>
   <li>
     <strong>World: </strong>
     <%= link_to campaign.district.name, worldbuilder.district_path(campaign.district.slug) %>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
@@ -9,10 +9,10 @@
     <%= link_to campaign.district.name, worldbuilder.district_path(campaign.district.slug) %>
   </li>
 <% end %>
-<% if campaign.adventure.present? and campaign.can_edit?(current_user, admin_signed_in?) %>
+<% if campaign.active_adventure.present? and campaign.can_edit?(current_user, admin_signed_in?) %>
   <li>
     <strong>Adventure: </strong>
-    <%= link_to campaign.adventure.name, "#{tcob_path(campaign.adventure)}" %>
+    <%= link_to campaign.active_adventure.name, "#{tcob_path(campaign.active_adventure)}" %>
   </li>
 <% end %>
 <% campaign.features.each do |feature| %>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -13,6 +13,22 @@
       <% unless @campaign.new_record? %>
         <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
         <%= f.association :district, collection: current_user.resident.district_list, label_method: :name, value_method: :id, :include_blank => true %>
+        <%= f.input :adventure_ids,
+            as: :check_boxes,
+            collection: current_user.resident.adventure_list(@campaign.core_rules).values.flatten,
+            label_method: :name,
+            value_method: :id,
+            label: 'Adventures' %>
+        <% if @campaign.adventures.any? %>
+          <%= f.input :active_adventure_id,
+              as: :select,
+              collection: @campaign.adventures,
+              label_method: :name,
+              value_method: :id,
+              include_blank: true,
+              label: 'Active Adventure',
+              selected: @campaign.active_adventure&.id %>
+        <% end %>
       <% end %>
     </div>
     <div class="medium-4 columns text-center">

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -26,8 +26,7 @@
               label_method: :name,
               value_method: :id,
               include_blank: true,
-              label: 'Active Adventure',
-              selected: @campaign.active_adventure&.id %>
+              label: 'Active Adventure' %>
         <% end %>
       <% end %>
     </div>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -13,7 +13,6 @@
       <% unless @campaign.new_record? %>
         <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
         <%= f.association :district, collection: current_user.resident.district_list, label_method: :name, value_method: :id, :include_blank => true %>
-        <%= f.association :adventure, collection: current_user.resident.adventure_list(@campaign.core_rules), label_method: :name, value_method: :id, as: :grouped_select, group_method: :last, :include_blank => true %>
       <% end %>
     </div>
     <div class="medium-4 columns text-center">

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -5,11 +5,7 @@
       <% unless @campaign.new_record?%>
         <%= f.input :page_label, label: 'Label' %>
       <% end %>
-      <% if current_user.is_free? %>
-        <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS_FREE, :include_blank => false %>
-      <% else %>
-        <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS %>
-      <% end %>
+      <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS %>
       <% unless @campaign.new_record? %>
         <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
         <%= f.association :district, collection: current_user.resident.district_list, label_method: :name, value_method: :id, :include_blank => true %>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/characters.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/characters.html.erb
@@ -21,7 +21,7 @@
     %>
     <hr class="faded">
 
-    <% @campaign.characters.each do |character| %>
+    <% visible_records(@campaign.characters).each do |character| %>
       <%= render 'entitybuilder/entities/layouts/campaign', character: character %>
     <% end %>
 

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/notables.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/notables.html.erb
@@ -23,7 +23,7 @@
     %>
     <hr class="faded">
 
-    <% @campaign.notables.each do |notable| %>
+    <% visible_notables(@campaign.notables).each do |notable| %>
       <%= render 'notable', notable: notable %>
     <% end %>
 

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
@@ -32,9 +32,9 @@
 
 <% if @campaign.can_edit?(current_user, admin_signed_in?) %>
 <dl class="left-menu show-for-medium-up">
-  <% if @campaign.adventure.present? %>
-  <dd class="<%= 'active' if current_page?("#{storybuilder.polymorphic_path(@campaign.adventure)}/campaign/#{@campaign.id}") %>">
-    <h3><%= link_to 'Adventure', "#{storybuilder.polymorphic_path(@campaign.adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
+  <% if @campaign.active_adventure.present? %>
+  <dd class="<%= 'active' if current_page?("#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}") %>">
+    <h3><%= link_to 'Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
   </dd>
   <% end %>
   <dd class="<%= 'active' if page == "GameMasterNote" if local_assigns.has_key? :page %>">

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
@@ -34,7 +34,7 @@
 <dl class="left-menu show-for-medium-up">
   <% if @campaign.active_adventure.present? %>
   <dd class="<%= 'active' if current_page?("#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}") %>">
-    <h3><%= link_to 'Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
+    <h3><%= link_to 'Active Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
   </dd>
   <% end %>
   <dd class="<%= 'active' if page == "GameMasterNote" if local_assigns.has_key? :page %>">

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
@@ -2,17 +2,17 @@
   <dd class="<%= 'active' if current_page?(campaignmanager.polymorphic_path(@campaign)) %>">
   	<h3><%= link_to 'Overview', campaignmanager.polymorphic_path(@campaign), :style => 'display:block;' %></h3>
   </dd>
-<% if @campaign.district.present? %>
+<% if @campaign.district.present? && visible_record?(@campaign.district) %>
   <dd class="<%= 'active' if current_page?("#{worldbuilder.district_path(@campaign.district.slug)}/campaign/#{@campaign.id}") %>">
     <h3><%= link_to 'World', "#{worldbuilder.district_path(@campaign.district.slug)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
   </dd>
 <% end %>
-<% if @campaign.entity_joins.size > 0 %>
+<% if visible_records(@campaign.characters).any? %>
   <dd class="<%= 'active' if current_page?(campaignmanager.polymorphic_path([@campaign, :characters])) %>">
     <h3><%= link_to 'Characters', campaignmanager.polymorphic_path([@campaign, :characters]), :style => 'display:block;' %></h3>
   </dd>
 <% end %>
-<% if @campaign.notables.size > 0 %>
+<% if visible_notables(@campaign.notables).any? %>
   <dd class="<%= 'active' if current_page?("#{campaignmanager.polymorphic_path(@campaign)}/notables/list") %>">
     <h3><%= link_to 'Notables', "#{campaignmanager.polymorphic_path(@campaign)}/notables/list", :style => 'display:block;' %></h3>
   </dd>

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
@@ -16,8 +16,8 @@
 <% end %>
 
 <% if @campaign.can_edit?(current_user, admin_signed_in?) %>
-  <% if @campaign.adventure.present? %>
-    <li><%= link_to 'Adventure', "#{storybuilder.resident_adventure_path(@campaign.adventure)}/campaign/#{@campaign.id}" %></li>
+  <% if @campaign.active_adventure.present? %>
+    <li><%= link_to 'Adventure', "#{storybuilder.resident_adventure_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %></li>
   <% end %>
   <li><%= link_to 'GM Notes', campaignmanager.polymorphic_path([@campaign, :game_master_notes]) %></li>
 <% end %>

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
@@ -1,11 +1,11 @@
 <li><%= link_to 'Overview', campaignmanager.polymorphic_path(@campaign) %></li>
-<% if @campaign.district.present? %>
+<% if @campaign.district.present? && visible_record?(@campaign.district) %>
   <li><%= link_to 'World', "#{worldbuilder.district_path(@campaign.district)}/campaign/#{@campaign.id}" %></li>
 <% end %>
-<% if @campaign.entity_joins.size > 0 %>
+<% if visible_records(@campaign.characters).any? %>
   <li><%= link_to 'Characters', campaignmanager.polymorphic_path([@campaign, :characters]) %></li>
 <% end %>
-<% if @campaign.notables.size > 0 %>
+<% if visible_notables(@campaign.notables).any? %>
   <li><%= link_to 'Notables', "#{campaignmanager.polymorphic_path(@campaign)}/notables/list" %></li>
 <% end %>
 <li><%= link_to 'House Rules', campaignmanager.polymorphic_path([@campaign, :house_rules]) %></li>

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
@@ -17,7 +17,7 @@
 
 <% if @campaign.can_edit?(current_user, admin_signed_in?) %>
   <% if @campaign.active_adventure.present? %>
-    <li><%= link_to 'Adventure', "#{storybuilder.resident_adventure_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %></li>
+    <li><%= link_to 'Active Adventure', "#{storybuilder.resident_adventure_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %></li>
   <% end %>
   <li><%= link_to 'GM Notes', campaignmanager.polymorphic_path([@campaign, :game_master_notes]) %></li>
 <% end %>

--- a/engines/campaignmanager/app/views/campaignmanager/pages/_features.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/_features.html.erb
@@ -1,5 +1,5 @@
 <ul class="no-bullet">
-<% if @page.parent %>
+<% if @page.parent && visible_record?(@page.parent) %>
   <li>
     <strong>Parent: </strong>
     <%= link_to @page.parent.name, city_path(@campaign, @page.parent) %>
@@ -22,7 +22,7 @@
   </li>
 <% end %>
 
-<% if @page.notables.size > 0 %>
+<% if visible_notables(@page.notables).any? %>
   <%= render "layouts/notables/entity_feature_sentence", list: @page.notables %>
 <% end %>
 

--- a/engines/campaignmanager/app/views/campaignmanager/pages/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/_form.html.erb
@@ -4,11 +4,7 @@
       <%= f.input :name %>
       <%= f.input :page_label, label: 'Label' %>
       <% unless @type=='GameMasterNote' %>
-        <% if current_user.is_free? %>
-          <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS_FREE, :include_blank => false %>
-        <% else %>
-          <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS %>
-        <% end %>
+        <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS %>
       <% end %>
     </div>
     <div class="medium-4 columns text-center">

--- a/engines/campaignmanager/db/migrate/20260613162629_create_campaignmanager_campaign_adventure_joins.rb
+++ b/engines/campaignmanager/db/migrate/20260613162629_create_campaignmanager_campaign_adventure_joins.rb
@@ -1,0 +1,12 @@
+class CreateCampaignmanagerCampaignAdventureJoins < ActiveRecord::Migration[6.1]
+  def change
+    create_table :campaignmanager_campaign_adventure_joins, id: :string do |t|
+      t.string :campaign_id, null: false
+      t.string :adventure_id, null: false
+      t.boolean :active, default: false, null: false
+      t.timestamps
+    end
+    add_index :campaignmanager_campaign_adventure_joins, [ :campaign_id, :adventure_id ], unique: true, name: "idx_cm_campaign_adventure_joins_unique"
+    add_index :campaignmanager_campaign_adventure_joins, [ :campaign_id, :active ], name: "idx_cm_campaign_adventure_joins_active"
+  end
+end

--- a/engines/campaignmanager/db/migrate/20260613162630_backfill_campaign_adventure_joins.rb
+++ b/engines/campaignmanager/db/migrate/20260613162630_backfill_campaign_adventure_joins.rb
@@ -1,0 +1,25 @@
+class BackfillCampaignAdventureJoins < ActiveRecord::Migration[6.1]
+  def up
+    rows = ActiveRecord::Base.connection.execute(
+      "SELECT id, adventure_id FROM campaignmanager_campaigns WHERE adventure_id IS NOT NULL"
+    )
+    rows.each do |row|
+      ActiveRecord::Base.connection.execute(
+        ActiveRecord::Base.sanitize_sql_array([
+          "INSERT INTO campaignmanager_campaign_adventure_joins (id, campaign_id, adventure_id, active, created_at, updated_at) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))",
+          SecureRandom.uuid,
+          row["id"],
+          row["adventure_id"],
+          1
+        ])
+      )
+    end
+
+    remove_column :campaignmanager_campaigns, :adventure_id
+  end
+
+  def down
+    add_column :campaignmanager_campaigns, :adventure_id, :string
+    # No backfill on down — data is gone
+  end
+end

--- a/engines/entitybuilder/app/controllers/entitybuilder/application_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/application_controller.rb
@@ -48,7 +48,7 @@ class Entitybuilder::ApplicationController < ApplicationController
     end
 
     def can_sheet
-      unless @parent_object.can_sheet?(current_user, admin_signed_in?, @type)
+      unless @parent_object.can_sheet?(current_user, admin_signed_in?, @type || @parent_type)
         render template: 'errors/403', layout: 'layouts/application', status: 403
       end
     end

--- a/engines/entitybuilder/app/controllers/entitybuilder/inventory_items_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/inventory_items_controller.rb
@@ -6,6 +6,7 @@ module Entitybuilder
     before_action :set_parent_type
     before_action :set_parent_object
     before_action :check_parent_authorization, except: [:show]
+    before_action :can_sheet, only: [:show]
     before_action :set_inventory_item, only: [:show, :edit, :update, :destroy]
     before_action :set_core_faq, only: [:index, :create, :update]
 

--- a/engines/entitybuilder/app/controllers/entitybuilder/inventory_items_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/inventory_items_controller.rb
@@ -8,6 +8,7 @@ module Entitybuilder
     before_action :check_parent_authorization, except: [:show]
     before_action :can_sheet, only: [:show]
     before_action :set_inventory_item, only: [:show, :edit, :update, :destroy]
+    before_action :can_show_item, only: [:show]
     before_action :set_core_faq, only: [:index, :create, :update]
 
     # GET /inventory_items
@@ -112,6 +113,12 @@ module Entitybuilder
       def set_inventory_item
         @inventory_item = @parent_object.inventory_items.find(params[:id])
         @modifier_parent_object = @inventory_item
+      end
+
+      def can_show_item
+        unless @inventory_item.item.can_show?(current_user, admin_signed_in?, @inventory_item.item.type.demodulize)
+          render template: 'errors/403', layout: 'layouts/application', status: 403
+        end
       end
 
       def set_core_faq

--- a/engines/entitybuilder/app/controllers/entitybuilder/known_spells_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/known_spells_controller.rb
@@ -8,6 +8,7 @@ module Entitybuilder
     before_action :set_parent_type
     before_action :set_parent_object
     before_action :check_parent_authorization, except: [:show]
+    before_action :can_sheet, only: [:show]
     before_action :set_known_spell, only: [:show, :edit, :use_spell, :update, :destroy]
     before_action :set_core_faq, only: [:index, :create, :update]
 

--- a/engines/entitybuilder/app/controllers/entitybuilder/linked_rules_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/linked_rules_controller.rb
@@ -6,6 +6,7 @@ module Entitybuilder
     before_action :set_parent_type
     before_action :set_parent_object
     before_action :check_parent_authorization, except: [:show]
+    before_action :can_sheet, only: [:show]
     before_action :set_linked_rule,  only: [:show, :edit, :update, :destroy]
     before_action :set_core_faq,     only: [:index, :create, :update]
     before_action :set_rule_type,    only: [:index, :new, :update_list]

--- a/engines/entitybuilder/app/controllers/entitybuilder/resident_characters_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/resident_characters_controller.rb
@@ -17,7 +17,7 @@ module Entitybuilder
     before_action :set_entities,        only: [:index]
 
     before_action :can_show,            only: [:show, :card_summary]
-    before_action :can_sheet,           only: [:sheet, :profile, :card]
+    before_action :can_sheet,           only: [:sheet, :profile, :card, :card_summary]
     before_action :can_edit,          except: [:index, :show, :profile, :sheet, :card, :card_summary, :new, :create]
 
     before_action :check_quota,         only: [:new, :create]

--- a/engines/entitybuilder/app/controllers/entitybuilder/resident_characters_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/resident_characters_controller.rb
@@ -3,6 +3,9 @@ require_dependency "entitybuilder/application_controller"
 module Entitybuilder
   class ResidentCharactersController < EntitiesController
 
+    skip_before_action :authenticate_user!, only: [:show, :card_summary, :profile, :sheet, :card]
+    skip_before_action :check_user_status,  only: [:show, :card_summary, :profile, :sheet, :card]
+
     before_action :set_type
     before_action :set_entity,          only: [:edit, :update, :update_notes, :notes, :destroy, :options]
     before_action :set_entity_for_show, only: [:show, :card_summary]

--- a/engines/entitybuilder/app/controllers/entitybuilder/resident_creatures_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/resident_creatures_controller.rb
@@ -17,7 +17,7 @@ module Entitybuilder
     before_action :set_entities,        only: [:index]
 
     before_action :can_show,            only: [:show, :card_summary]
-    before_action :can_sheet,           only: [:sheet, :profile, :card]
+    before_action :can_sheet,           only: [:sheet, :profile, :card, :card_summary]
     before_action :can_edit,          except: [:index, :show, :profile, :sheet, :card, :card_summary, :new, :create]
 
     before_action :check_quota,         only: [:new, :create]

--- a/engines/entitybuilder/app/controllers/entitybuilder/resident_creatures_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/resident_creatures_controller.rb
@@ -3,6 +3,9 @@ require_dependency "entitybuilder/application_controller"
 module Entitybuilder
   class ResidentCreaturesController < EntitiesController
 
+    skip_before_action :authenticate_user!, only: [:show, :card_summary, :profile, :sheet, :card]
+    skip_before_action :check_user_status,  only: [:show, :card_summary, :profile, :sheet, :card]
+
     before_action :set_type
     before_action :set_entity,          only: [:edit, :update, :update_notes, :notes, :destroy, :options]
     before_action :set_entity_for_show, only: [:show, :card_summary]

--- a/engines/entitybuilder/app/controllers/entitybuilder/resident_npcs_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/resident_npcs_controller.rb
@@ -17,7 +17,7 @@ module Entitybuilder
     before_action :set_entities,        only: [:index]
 
     before_action :can_show,            only: [:show, :card_summary]
-    before_action :can_sheet,           only: [:sheet, :profile, :card]
+    before_action :can_sheet,           only: [:sheet, :profile, :card, :card_summary]
     before_action :can_edit,          except: [:index, :show, :profile, :sheet, :card, :card_summary, :new, :create]
 
     before_action :check_quota,         only: [:new, :create]

--- a/engines/entitybuilder/app/controllers/entitybuilder/resident_npcs_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/resident_npcs_controller.rb
@@ -3,6 +3,9 @@ require_dependency "entitybuilder/application_controller"
 module Entitybuilder
   class ResidentNpcsController < EntitiesController
 
+    skip_before_action :authenticate_user!, only: [:show, :card_summary, :profile, :sheet, :card]
+    skip_before_action :check_user_status,  only: [:show, :card_summary, :profile, :sheet, :card]
+
     before_action :set_type
     before_action :set_entity,          only: [:edit, :update, :update_notes, :notes, :destroy, :options]
     before_action :set_entity_for_show, only: [:show, :card_summary]

--- a/engines/entitybuilder/app/controllers/entitybuilder/stock_creatures_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/stock_creatures_controller.rb
@@ -3,6 +3,9 @@ require_dependency "entitybuilder/application_controller"
 module Entitybuilder
   class StockCreaturesController < EntitiesController
 
+    skip_before_action :authenticate_user!, only: [:show, :card_summary, :profile, :sheet, :card]
+    skip_before_action :check_user_status,  only: [:show, :card_summary, :profile, :sheet, :card]
+
     before_action :set_type
     before_action :check_authorization,  only: [:new, :create, :edit, :update, :update_notes, :destroy, :options]
     before_action :set_entity,           only: [:edit, :update, :update_notes, :destroy, :options]

--- a/engines/entitybuilder/app/controllers/entitybuilder/stock_npcs_controller.rb
+++ b/engines/entitybuilder/app/controllers/entitybuilder/stock_npcs_controller.rb
@@ -3,6 +3,9 @@ require_dependency "entitybuilder/application_controller"
 module Entitybuilder
   class StockNpcsController < EntitiesController
 
+    skip_before_action :authenticate_user!, only: [:show, :card_summary, :profile, :sheet, :card]
+    skip_before_action :check_user_status,  only: [:show, :card_summary, :profile, :sheet, :card]
+
     before_action :set_type
     before_action :check_authorization,  only: [:new, :create, :edit, :update, :update_notes, :destroy, :options]
     before_action :set_entity,           only: [:edit, :update, :update_notes, :destroy, :options]

--- a/engines/entitybuilder/app/models/entitybuilder/entity.rb
+++ b/engines/entitybuilder/app/models/entitybuilder/entity.rb
@@ -20,7 +20,7 @@ module Entitybuilder
             class_name: "Campaignmanager::Campaign"
 
     has_one :district,
-            -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.privacy') },
+            -> { select('worldbuilder_districts.id, worldbuilder_districts.resident_id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.privacy') },
             through: :campaign,
             class_name: "Worldbuilder::District"
 

--- a/engines/entitybuilder/app/models/entitybuilder/entity.rb
+++ b/engines/entitybuilder/app/models/entitybuilder/entity.rb
@@ -5,7 +5,7 @@ module Entitybuilder
     include KeysToEntitybuilder
     include JsonArrayColumns
 
-    PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents' ]
+    PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
     NULL_ATTRS = %w[ ]
 
     scope :short, -> { select('id, type, resident_id, name, short_description, core_rules, privacy, sheet_privacy') }

--- a/engines/entitybuilder/app/models/entitybuilder/entity.rb
+++ b/engines/entitybuilder/app/models/entitybuilder/entity.rb
@@ -20,7 +20,7 @@ module Entitybuilder
             class_name: "Campaignmanager::Campaign"
 
     has_one :district,
-            -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug') },
+            -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.privacy') },
             through: :campaign,
             class_name: "Worldbuilder::District"
 

--- a/engines/entitybuilder/app/views/entitybuilder/entities/layouts/_card.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/layouts/_card.html.erb
@@ -9,7 +9,7 @@
   currencies            = entity.currencies
   defenses              = entity.defenses
   descriptors           = entity.descriptors
-  inventory_items       = entity.inventory_items
+  inventory_items       = visible_inventory_items(entity.inventory_items)
   linked_rules          = entity.linked_rules
   modifiers             = entity.modifiers
   movements             = entity.movements

--- a/engines/entitybuilder/app/views/entitybuilder/entities/layouts/_show.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/layouts/_show.html.erb
@@ -13,7 +13,7 @@
     <div class="row">
       <div class="medium-12 columns">
         <ul class="no-bullet">
-        <% if (@type.include?"Character") && @parent_object.campaign.present? %>
+        <% if (@type.include?"Character") && @parent_object.campaign.present? && visible_record?(@parent_object.campaign) %>
           <li>
             <div class="indent">
               <strong>Campaign: </strong><%= link_to @parent_object.campaign.name, campaignmanager.polymorphic_path(@parent_object.campaign) %>
@@ -24,7 +24,7 @@
               <strong>Game Master: </strong><%= link_to @parent_object.campaign.resident.name, main_app.resident_path(@parent_object.campaign.resident.slug) %>
             </div>
           </li>
-          <% unless @parent_object.campaign.district_id.nil? %>
+          <% if @parent_object.campaign.district_id.present? && visible_record?(@parent_object.district) %>
             <li>
               <div class="indent">
                 <strong>World: </strong><%= link_to @parent_object.district.name, worldbuilder.district_path(@parent_object.district.slug) %>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/_item.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/_item.html.erb
@@ -12,7 +12,7 @@
   <%= render :partial => 'entitybuilder/inventory_items/item_details', :locals => { :inventory_item => @inventory_item } %>
   <%= sanitize @inventory_item.item.full_description %>
 
-  <% if @inventory_item.item.parent.present? %>
+  <% if @inventory_item.item.parent.present? && visible_record?(@inventory_item.item.parent) %>
     <h2><%= @inventory_item.item.parent.name %></h2>
     <hr class="faded">
     <%= sanitize @inventory_item.item.parent.full_description %>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/_item.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/_item.html.erb
@@ -2,19 +2,18 @@
   <%= render :partial =>'layouts/header',
     :locals => {
       :icon => 'icon-price-tag',
-      :main => @inventory_item.item.name
-    }
-  %>
+      :main => inventory_item.item.name
+    } %>
   <hr class="faded">
-  <% unless @inventory_item.item.gallery_image.nil? %>
-    <%= link_to (image_tag @inventory_item.item.gallery_image.file.url(:thumb), :alt => @inventory_item.item.name, :align=>"right", class: "images_space"), "#{gallery.polymorphic_path(@inventory_item.item.gallery_image)}/swoosh", "data-reveal-id" => "image_modal", :remote => true  %>
+  <% unless inventory_item.item.gallery_image.nil? %>
+    <%= link_to (image_tag inventory_item.item.gallery_image.file.url(:thumb), :alt => inventory_item.item.name, :align=>"right", class: "images_space"), "#{gallery.polymorphic_path(inventory_item.item.gallery_image)}/swoosh", "data-reveal-id" => "image_modal", :remote => true %>
   <% end %>
-  <%= render :partial => 'entitybuilder/inventory_items/item_details', :locals => { :inventory_item => @inventory_item } %>
-  <%= sanitize @inventory_item.item.full_description %>
+  <%= render :partial => 'entitybuilder/inventory_items/item_details', :locals => { :inventory_item => inventory_item } %>
+  <%= sanitize inventory_item.item.full_description %>
 
-  <% if @inventory_item.item.parent.present? && visible_record?(@inventory_item.item.parent) %>
-    <h2><%= @inventory_item.item.parent.name %></h2>
+  <% if inventory_item.item.parent.present? && visible_record?(inventory_item.item.parent) %>
+    <h2><%= inventory_item.item.parent.name %></h2>
     <hr class="faded">
-    <%= sanitize @inventory_item.item.parent.full_description %>
+    <%= sanitize inventory_item.item.parent.full_description %>
   <% end %>
 </div>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/layouts/_card.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/layouts/_card.html.erb
@@ -1,6 +1,6 @@
 <div class="indent">
   <h4 class="eb-v1-card-header">Items</h4>
-  <% inventory_items.each do |inventory_item| %>
+  <% visible_inventory_items(inventory_items).each do |inventory_item| %>
     <div class="indent">
       <strong><%= link_to_if clickable, inventory_item.item.name, "#{entitybuilder.polymorphic_path(entity)}/inventory_items/#{inventory_item.id}", "data-reveal-id" => "inventory_item_modal", :remote => true %><%= " (#{inventory_item.detail})" if inventory_item.detail.present? %></strong>
       <%= inventory_item.item.short_description %>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/layouts/_card_sentence.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/layouts/_card_sentence.html.erb
@@ -1,6 +1,7 @@
 <div class="eb-v1-card-sentence">
   <h3 class="eb-v1-card-header">Items</h3>
-  <% inventory_items.each do |inventory_item| %>
-    <%= link_to_if clickable, inventory_item.item.name, "#{entitybuilder.polymorphic_path(entity)}/inventory_items/#{inventory_item.id}", "data-reveal-id" => "inventory_item_modal", :remote => true %><%= " (#{inventory_item.detail})" if inventory_item.detail.present? %><%= ", " unless inventory_item == inventory_items.last %>
+  <% visible_items = visible_inventory_items(inventory_items) %>
+  <% visible_items.each do |inventory_item| %>
+    <%= link_to_if clickable, inventory_item.item.name, "#{entitybuilder.polymorphic_path(entity)}/inventory_items/#{inventory_item.id}", "data-reveal-id" => "inventory_item_modal", :remote => true %><%= " (#{inventory_item.detail})" if inventory_item.detail.present? %><%= ", " unless inventory_item == visible_items.last %>
   <% end %>
 </div>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/sheet/_full.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/sheet/_full.html.erb
@@ -1,5 +1,5 @@
 <ul class="no-bullet">
-  <% @parent_object.inventory_items.each do |inventory_item| %>
+  <% visible_inventory_items(@parent_object.inventory_items).each do |inventory_item| %>
   <li>
     <div class="indent">
       <strong><%= link_to_if @clickable, inventory_item.item.name, "#{route_path(@parent_object)}/inventory_items/#{inventory_item.id}", "data-reveal-id" => "inventory_item_modal", :remote => true %><%= " (#{inventory_item.detail})" if inventory_item.detail.present? %></strong>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/sheet/_show.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/sheet/_show.html.erb
@@ -1,6 +1,7 @@
 <div class="indent">
 <strong>Items:</strong>
-  <% @parent_object.inventory_items.each do |inventory_item| %>
-  <%= link_to_if @clickable, inventory_item.item.name, "#{route_path(@parent_object)}/inventory_items/#{inventory_item.id}", "data-reveal-id" => "inventory_item_modal", :remote => true %><%= " (#{inventory_item.detail})" if inventory_item.detail.present? %><%= ", " unless inventory_item == @parent_object.inventory_items.last %>
+  <% inventory_items = visible_inventory_items(@parent_object.inventory_items) %>
+  <% inventory_items.each do |inventory_item| %>
+  <%= link_to_if @clickable, inventory_item.item.name, "#{route_path(@parent_object)}/inventory_items/#{inventory_item.id}", "data-reveal-id" => "inventory_item_modal", :remote => true %><%= " (#{inventory_item.detail})" if inventory_item.detail.present? %><%= ", " unless inventory_item == inventory_items.last %>
   <% end %>
 </div>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/show.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/show.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, "#{@parent_object.name}") %>
 <% type_array = type_split(@parent_type) %>
 <% content_for :breadcrumb do %>
-  <%=  breadcrumb [
+  <%= breadcrumb [
     { type_array[0] => nil },
     { type_array[1] => route_collection_path(@parent_type.pluralize) },
     { @parent_object.name => nil },
@@ -21,7 +21,7 @@
   </div>
 
   <div class="medium-10 columns">
-    <%= render "item" %>
-    <p><i class='fa fa-angle-double-left'></i> <%= link_to "Return".html_safe, :back %></p>
+    <%= render "item", inventory_item: @inventory_item %>
+    <p><i class="fa fa-angle-double-left"></i> <%= link_to "Return", :back %></p>
   </div>
 </div>

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/show.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/show.js.erb
@@ -1,2 +1,2 @@
 $('#inventory_item_div').remove();
-$('#inventory_item_placeholder').hide().after('<%= j render("item") %>');
+$('#inventory_item_placeholder').hide().after('<%= j render("item", inventory_item: @inventory_item) %>');

--- a/engines/rulebuilder/app/controllers/rulebuilder/items_controller.rb
+++ b/engines/rulebuilder/app/controllers/rulebuilder/items_controller.rb
@@ -109,6 +109,7 @@ module Rulebuilder
           :parent_id,
           :resident_id,
           :name,
+          :privacy,
           :publisher,
           :source,
           :is_3pp,

--- a/engines/rulebuilder/app/controllers/rulebuilder/resident_items_controller.rb
+++ b/engines/rulebuilder/app/controllers/rulebuilder/resident_items_controller.rb
@@ -3,6 +3,9 @@ require_dependency "rulebuilder/application_controller"
 module Rulebuilder
   class ResidentItemsController < ItemsController
 
+    skip_before_action :authenticate_user!, only: [:show]
+    skip_before_action :check_user_status,  only: [:show]
+
     before_action :set_type
     before_action :set_item,   only: [:show, :edit, :update, :destroy, :options]
     before_action :set_items,  only: [:index]

--- a/engines/rulebuilder/app/controllers/rulebuilder/stock_items_controller.rb
+++ b/engines/rulebuilder/app/controllers/rulebuilder/stock_items_controller.rb
@@ -18,7 +18,13 @@ module Rulebuilder
       end
 
       def set_items
-        @items = StockItem.short.order_name.search(params[:search]).core_rules_filter(params[:core_rules_filter]).page(params[:page]).per(100)
+        @items = visible_items.short.order_name.search(params[:search]).core_rules_filter(params[:core_rules_filter]).page(params[:page]).per(100)
+      end
+
+      def visible_items
+        return StockItem.all if admin_signed_in?
+
+        StockItem.where(privacy: [ "Public", "Residents" ])
       end
 
       def set_item

--- a/engines/rulebuilder/app/controllers/rulebuilder/stock_items_controller.rb
+++ b/engines/rulebuilder/app/controllers/rulebuilder/stock_items_controller.rb
@@ -3,6 +3,9 @@ require_dependency "rulebuilder/application_controller"
 module Rulebuilder
   class StockItemsController < ItemsController
 
+    skip_before_action :authenticate_user!, only: [:show]
+    skip_before_action :check_user_status,  only: [:show]
+
     before_action :set_type
     before_action :check_authorization, only: [:new, :create, :edit, :update, :destroy, :options]
     before_action :set_item,            only: [:show, :edit, :update, :destroy, :options]

--- a/engines/rulebuilder/app/controllers/rulebuilder/stock_items_controller.rb
+++ b/engines/rulebuilder/app/controllers/rulebuilder/stock_items_controller.rb
@@ -10,6 +10,7 @@ module Rulebuilder
     before_action :check_authorization, only: [:new, :create, :edit, :update, :destroy, :options]
     before_action :set_item,            only: [:show, :edit, :update, :destroy, :options]
     before_action :set_items,           only: [:index]
+    before_action :can_show,            only: [:show]
 
     private
       def set_type
@@ -31,6 +32,12 @@ module Rulebuilder
 
       def check_authorization
         unless admin_signed_in?
+          render template: 'errors/403', layout: 'layouts/application', status: 403
+        end
+      end
+
+      def can_show
+        unless @item.can_show?(current_user, admin_signed_in?, @type)
           render template: 'errors/403', layout: 'layouts/application', status: 403
         end
       end

--- a/engines/rulebuilder/app/models/rulebuilder/item.rb
+++ b/engines/rulebuilder/app/models/rulebuilder/item.rb
@@ -5,8 +5,8 @@ module Rulebuilder
     include KeysToRulebuilder
     include JsonArrayColumns
 
-    PRIVACY_OPTIONS_FREE = [ 'Private', 'Public' ]
     PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
+    PRIVACY_OPTIONS_FREE = PRIVACY_OPTIONS
 
     scope :order_name, -> { order(:name) }
     scope :short, -> { select('id, type, resident_id, name, core_rules, short_description') }

--- a/engines/rulebuilder/app/models/rulebuilder/item.rb
+++ b/engines/rulebuilder/app/models/rulebuilder/item.rb
@@ -74,7 +74,7 @@ module Rulebuilder
 
       def valid_privacy
         if privacy.present? && PRIVACY_OPTIONS.exclude?(privacy)
-          errors.add(:privacy, "is not valid.")
+          errors.add(:privacy, :invalid_privacy)
         end
       end
   end

--- a/engines/rulebuilder/app/models/rulebuilder/item.rb
+++ b/engines/rulebuilder/app/models/rulebuilder/item.rb
@@ -5,6 +5,9 @@ module Rulebuilder
     include KeysToRulebuilder
     include JsonArrayColumns
 
+    PRIVACY_OPTIONS_FREE = [ 'Private', 'Public' ]
+    PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
+
     scope :order_name, -> { order(:name) }
     scope :short, -> { select('id, type, resident_id, name, core_rules, short_description') }
     scope :basic, -> { select('id, type, resident_id, name, core_rules') }
@@ -36,8 +39,11 @@ module Rulebuilder
     validates :publisher, length: { maximum: 255 }
     validates :source, length: { maximum: 255 }
     validates_confirmation_of :name
+    validates :privacy, presence: true
+    validate  :valid_privacy
 
     before_save :mark_for_removal
+    before_validation :set_privacy, on: :create
 
     def tag_list
       Array(tags).join(', ')
@@ -60,6 +66,16 @@ module Rulebuilder
     private
       def mark_for_removal
         self.gallery_image_join.mark_for_destruction if gallery_image_join && gallery_image_join.image_id.blank?
+      end
+
+      def set_privacy
+        self.privacy ||= 'Private'
+      end
+
+      def valid_privacy
+        if privacy.present? && PRIVACY_OPTIONS.exclude?(privacy)
+          errors.add(:privacy, "is not valid.")
+        end
       end
   end
 end

--- a/engines/rulebuilder/app/views/rulebuilder/items/_form.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/items/_form.html.erb
@@ -19,6 +19,7 @@
         </div>
       </div>
       <%= f.input :source %>
+      <%= f.input :privacy, collection: Rulebuilder::Item::PRIVACY_OPTIONS, include_blank: false %>
       <div class="row">
         <div class="medium-6 columns">
           <%= f.input :category, collection: rb_item_category_options, :include_blank => true %>

--- a/engines/rulebuilder/app/views/rulebuilder/items/_item.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/items/_item.html.erb
@@ -15,7 +15,7 @@
   <%= render :partial => 'rulebuilder/items/item_details', :locals => { :item => @item } %>
   <%= sanitize @item.full_description %>
 
-  <% if @item.parent.present? %>
+  <% if @item.parent.present? && visible_record?(@item.parent) %>
     <h2><%= @item.parent.name %></h2>
     <hr class="faded">
     <%= sanitize @item.parent.full_description %>

--- a/engines/rulebuilder/db/migrate/20260613000000_add_privacy_to_rulebuild_items.rb
+++ b/engines/rulebuilder/db/migrate/20260613000000_add_privacy_to_rulebuild_items.rb
@@ -1,6 +1,22 @@
 class AddPrivacyToRulebuildItems < ActiveRecord::Migration[6.1]
-  def change
+  def up
     add_column :rulebuilder_items, :privacy, :string, default: 'Private', null: false
     add_index :rulebuilder_items, :privacy
+
+    backfill_existing_stock_items
   end
+
+  def down
+    remove_index :rulebuilder_items, :privacy
+    remove_column :rulebuilder_items, :privacy
+  end
+
+  private
+    def backfill_existing_stock_items
+      update(<<~SQL.squish)
+        UPDATE #{quote_table_name(:rulebuilder_items)}
+        SET privacy = 'Public'
+        WHERE type = 'Rulebuilder::StockItem'
+      SQL
+    end
 end

--- a/engines/rulebuilder/db/migrate/20260613000000_add_privacy_to_rulebuild_items.rb
+++ b/engines/rulebuilder/db/migrate/20260613000000_add_privacy_to_rulebuild_items.rb
@@ -1,0 +1,6 @@
+class AddPrivacyToRulebuildItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :rulebuilder_items, :privacy, :string, default: 'Private', null: false
+    add_index :rulebuilder_items, :privacy
+  end
+end

--- a/engines/storybuilder/app/controllers/storybuilder/pages_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/pages_controller.rb
@@ -3,6 +3,9 @@ require_dependency "storybuilder/application_controller"
 module Storybuilder
   class PagesController < ApplicationController
 
+    skip_before_action :authenticate_user!, only: [:show]
+    skip_before_action :check_user_status,  only: [:show]
+
     before_action :set_parent_type
     before_action :set_parent_object
     before_action :check_parent_authorization, except: [:show, :index]

--- a/engines/storybuilder/app/controllers/storybuilder/resident_adventures_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/resident_adventures_controller.rb
@@ -3,6 +3,9 @@ require_dependency "storybuilder/application_controller"
 module Storybuilder
   class ResidentAdventuresController < AdventuresController
 
+    skip_before_action :authenticate_user!, only: [:show, :campaign]
+    skip_before_action :check_user_status,  only: [:show, :campaign]
+
     before_action :set_type
     before_action :set_adventure,           only: [:edit, :update, :destroy, :options]
     before_action :set_parent_options,      only: [:new, :create, :edit, :update]

--- a/engines/storybuilder/app/controllers/storybuilder/resident_adventures_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/resident_adventures_controller.rb
@@ -10,10 +10,10 @@ module Storybuilder
     before_action :set_adventure,           only: [:edit, :update, :destroy, :options]
     before_action :set_parent_options,      only: [:new, :create, :edit, :update]
     before_action :set_adventure_for_show,  only: [:show, :campaign]
+    before_action :can_show,                only: [:show, :campaign]
     before_action :set_campaign,            only: [:campaign]
     before_action :set_adventures,          only: [:index]
 
-    before_action :can_show,                only: [:show]
     before_action :can_edit,              except: [:index, :show, :campaign, :new, :create]
 
     before_action :check_quota, only: [:new, :create]

--- a/engines/storybuilder/app/controllers/storybuilder/stock_adventures_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/stock_adventures_controller.rb
@@ -3,6 +3,9 @@ require_dependency "storybuilder/application_controller"
 module Storybuilder
   class StockAdventuresController < AdventuresController
 
+    skip_before_action :authenticate_user!, only: [:show, :campaign]
+    skip_before_action :check_user_status,  only: [:show, :campaign]
+
     before_action :set_type
     before_action :check_authorization,     only: [:new, :create, :edit, :update, :destroy, :options]
 

--- a/engines/storybuilder/app/controllers/storybuilder/stock_adventures_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/stock_adventures_controller.rb
@@ -12,10 +12,9 @@ module Storybuilder
     before_action :set_adventure,           only: [:edit, :update, :destroy, :options]
     before_action :set_parent_options,      only: [:new, :create, :edit, :update]
     before_action :set_adventure_for_show,  only: [:show, :campaign]
+    before_action :can_show,                only: [:show, :campaign]
     before_action :set_campaign,            only: [:campaign]
     before_action :set_adventures,          only: [:index]
-
-    before_action :can_show,                only: [:show]
 
     private
       def params_id
@@ -69,7 +68,7 @@ module Storybuilder
         @type = ""
 
         @campaign = Campaignmanager::Campaign.find_by_id(params[:campaign_id]) unless params[:campaign_id].nil?
-        if @campaign.nil? || !@campaign.can_show?(current_user, admin_signed_in?, @campaign.type)
+        if @campaign.nil? || !@campaign.can_show?(current_user, admin_signed_in?, 'Campaign')
           render template: 'errors/404', layout: 'layouts/application', status: 404
         end
         @resident = @campaign.resident

--- a/engines/storybuilder/app/models/storybuilder/adventure.rb
+++ b/engines/storybuilder/app/models/storybuilder/adventure.rb
@@ -2,8 +2,8 @@ module Storybuilder
   class Adventure < ApplicationRecord
     include KeysToStorybuilder
 
-    PRIVACY_OPTIONS_FREE = [ 'Private' ]
-    PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents' ]
+    PRIVACY_OPTIONS_FREE = [ 'Private', 'Public' ]
+    PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
     NULL_ATTRS = %w[ parent_id ]
 
     scope :short, -> { select('id, type, resident_id, name, page_label, short_description, core_rules') }

--- a/engines/storybuilder/app/models/storybuilder/adventure.rb
+++ b/engines/storybuilder/app/models/storybuilder/adventure.rb
@@ -2,8 +2,8 @@ module Storybuilder
   class Adventure < ApplicationRecord
     include KeysToStorybuilder
 
-    PRIVACY_OPTIONS_FREE = [ 'Private', 'Public' ]
     PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
+    PRIVACY_OPTIONS_FREE = PRIVACY_OPTIONS
     NULL_ATTRS = %w[ parent_id ]
 
     scope :short, -> { select('id, type, resident_id, name, page_label, short_description, core_rules') }

--- a/engines/storybuilder/app/models/storybuilder/page.rb
+++ b/engines/storybuilder/app/models/storybuilder/page.rb
@@ -7,8 +7,10 @@ module Storybuilder
 
     NULL_ATTRS = %w[ parent_id ]
 
-    scope :short, -> { select('storybuilder_pages.id, storybuilder_pages.adventure_id, storybuilder_pages.parent_id, storybuilder_pages.name, storybuilder_pages.short_description, storybuilder_pages.page_label') }
-    scope :block, -> { select('storybuilder_pages.id, storybuilder_pages.adventure_id, storybuilder_pages.parent_id, storybuilder_pages.name') }
+    scope :short, -> {
+      select(:id, :adventure_id, :parent_id, :name, :short_description, :page_label, :privacy)
+    }
+    scope :block, -> { select(:id, :adventure_id, :parent_id, :name, :privacy) }
     scope :order_name, -> { order(:name) }
 
     json_array_column :tags

--- a/engines/storybuilder/app/views/storybuilder/adventures/_features.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/adventures/_features.html.erb
@@ -1,7 +1,7 @@
 <article class="features">
   <% if @adventure.features.size > 0 || @adventure.parent_id.present? %>
     <ul class="no-bullet">
-      <% if @adventure.parent %>
+      <% if @adventure.parent && visible_record?(@adventure.parent) %>
         <li>
           <strong>Parent: </strong>
           <%= link_to @adventure.parent.name, polymorphic_path(@adventure.parent) %>
@@ -23,7 +23,7 @@
 </article>
 <article class="notables">
 
-  <% if @adventure.notables.size > 0 %>
+  <% if visible_notables(@adventure.notables).any? %>
     <%= render "layouts/notables/entity_feature_list", list: @adventure.notables %>
     <%= link_to "<i class='header-icon-edit fa fa-cog'></i>".html_safe, resident_adventure_notables_path(@adventure), title: "Edit Notables", class: "edit" %>
   <% end %>

--- a/engines/storybuilder/app/views/storybuilder/adventures/_form.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/adventures/_form.html.erb
@@ -3,11 +3,7 @@
     <div class="medium-8 columns">
       <%= f.input :name %>
       <%= f.input :page_label, label: 'Label' %>
-      <% if current_user.is_free? %>
-        <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS_FREE, :include_blank => false %>
-      <% else %>
-        <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS %>
-      <% end %>
+      <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS %>
       <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
       <%= f.fields_for :menu_item_join do |p| %>
         <%= p.association :menu_item, collection: @adventure.menu_items, label_method: :item_label, value_method: :id, :include_blank => true %>

--- a/engines/storybuilder/app/views/storybuilder/menus/_adventure.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/menus/_adventure.html.erb
@@ -4,7 +4,7 @@
   	<h3><%= link_to 'Home', storybuilder.polymorphic_path(@adventure), :style => 'display:block;' %></h3>
   </dd>
   <% end %>
-<% @adventure.menu_items.each do |menu_item| %>
+<% visible_storybuilder_menu_items(@adventure.menu_items).each do |menu_item| %>
    <dd class='<%= active_menu_item(menu_item,page,"#{storybuilder.polymorphic_path(@adventure)}#{menu_item.item_link}") || active_menu_item(menu_item,page,"#{menu_item.item_link}/adventure/#{@adventure.id}") %>'>
     <% if menu_item.item_link.start_with?("http") %>
       <h3><%= link_to menu_item.item_label, menu_item.item_link, :style => 'display:block;' %> </h3>

--- a/engines/storybuilder/app/views/storybuilder/menus/_small.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/menus/_small.html.erb
@@ -3,7 +3,7 @@
     <%= link_to 'Home', storybuilder.polymorphic_path(@adventure) %>
   </li>
 <% end %>
-<% @adventure.menu_items.each do |menu_item| %>
+<% visible_storybuilder_menu_items(@adventure.menu_items).each do |menu_item| %>
   <li>
     <% if menu_item.item_link.start_with?("http") %>
       <%= link_to menu_item.item_label, menu_item.item_link %>

--- a/engines/storybuilder/app/views/storybuilder/pages/_features.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/_features.html.erb
@@ -1,7 +1,7 @@
 <article class="features">
   <% if @adventure.features.size > 0 || @adventure.parent_id.present? %>
     <ul class="no-bullet">
-      <% if @page.parent %>
+      <% if @page.parent && visible_record?(@page.parent) %>
         <li>
           <strong>Parent: </strong>
           <%= link_to @page.parent.name, storybuilder.polymorphic_path([@adventure, @page.parent]) %><br>
@@ -22,7 +22,7 @@
   <% end %>
 </article>
 <article class='notables'>
-  <% if @page.notables.size > 0 %>
+  <% if visible_notables(@page.notables).any? %>
     <%= render "layouts/notables/entity_feature_list", list: @page.notables %>
     <%= link_to "<i class='header-icon-edit fa fa-cog'></i>".html_safe, resident_adventure_notables_path(@adventure), title: "Edit Notables", class: "edit" %>
   <% end %>

--- a/engines/storybuilder/app/views/storybuilder/pages/_form.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/_form.html.erb
@@ -6,11 +6,7 @@
 
       <div class="row">
         <div class="medium-6 columns">
-          <% if current_user.is_free? %>
-            <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS_FREE, :include_blank => false %>
-          <% else %>
-            <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS %>
-          <% end %>
+          <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS %>
         </div>
         <div class="medium-6 columns text-center">
           <label>Player Handout <span data-tooltip aria-haspopup="true" class="has-tip question-mark" title="This will cause the menu to be suppressed when viewed by anyone other than you."><i class="fa fa-question-circle"></i></span></label>

--- a/engines/worldbuilder/app/controllers/worldbuilder/districts_controller.rb
+++ b/engines/worldbuilder/app/controllers/worldbuilder/districts_controller.rb
@@ -52,12 +52,6 @@ module Worldbuilder
       @district = current_user.resident.districts.new(district_params)
       @district.build_gallery_image_join if @district.gallery_image_join.nil?
 
-      if current_user.is_free?
-        unless Worldbuilder::District::PRIVACY_OPTIONS_FREE.include? @district.privacy
-          @district.privacy = 'invalid'
-        end
-      end
-
       respond_to do |format|
         if @district.save
           wb_district_mockup(@district)
@@ -70,13 +64,6 @@ module Worldbuilder
 
     # PATCH/PUT /districts/1
     def update
-
-      if current_user.is_free?
-        unless Worldbuilder::District::PRIVACY_OPTIONS_FREE.include?(district_params[:privacy])
-          params[:district][:privacy] = 'invalid'
-        end
-      end
-
       respond_to do |format|
         if @district.update(district_params)
           format.html { redirect_to edit_district_path(@district) }

--- a/engines/worldbuilder/app/models/worldbuilder/district.rb
+++ b/engines/worldbuilder/app/models/worldbuilder/district.rb
@@ -3,8 +3,8 @@ module Worldbuilder
     include ReservedNames
     include KeysToWorldbuilder
 
-    PRIVACY_OPTIONS_FREE = [ 'Private' ]
     PRIVACY_OPTIONS = [ 'Private', 'Friends', 'Residents', 'Public' ]
+    PRIVACY_OPTIONS_FREE = PRIVACY_OPTIONS
 
     scope :short, -> { select('worldbuilder_districts.id, resident_id, worldbuilder_districts.name, worldbuilder_districts.slug, worldbuilder_districts.short_description, worldbuilder_districts.privacy, worldbuilder_districts.updated_at, worldbuilder_districts.page_label') }
     scope :pick_list, -> { select('worldbuilder_districts.id, worldbuilder_districts.name, worldbuilder_districts.slug') }

--- a/engines/worldbuilder/app/views/worldbuilder/districts/_form.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/districts/_form.html.erb
@@ -5,11 +5,7 @@
       <% unless @district.new_record?%>
         <%= f.input :page_label, label: 'Label' %>
       <% end %>
-      <% if current_user.is_free? %>
-        <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS_FREE, :include_blank => false %>
-      <% else %>
-        <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS %>
-      <% end %>
+      <%= f.input :privacy, collection: Worldbuilder::District::PRIVACY_OPTIONS %>
       <%= f.fields_for :menu_item_join do |p| %>
         <%= p.association :menu_item, collection: @district.menu_items, label_method: :item_label, value_method: :id, :include_blank => true %>
       <% end %>

--- a/test/controllers/campaignmanager/campaigns_controller_test.rb
+++ b/test/controllers/campaignmanager/campaigns_controller_test.rb
@@ -80,6 +80,18 @@ module Campaignmanager
       assert_no_match district.name, @response.body
     end
 
+    test "should hide private world when public campaign is shown to another resident" do
+      district = worldbuilder_districts(:district_three)
+      district.update!(privacy: 'Private')
+      @campaign2.update!(privacy: 'Public', district: district)
+
+      sign_in @user2
+      get :show, params: { id: @campaign2 }
+
+      assert_response :success
+      assert_no_match district.name, @response.body
+    end
+
     test "should hide private character when public campaign characters are shown logged out" do
       character = entitybuilder_entities(:resident_character_one)
       character.update!(name: 'Hidden Campaign Character', privacy: 'Private', sheet_privacy: 'Private')

--- a/test/controllers/campaignmanager/campaigns_controller_test.rb
+++ b/test/controllers/campaignmanager/campaigns_controller_test.rb
@@ -70,6 +70,47 @@ module Campaignmanager
       assert_response :success
     end
 
+    test "should hide private world when public campaign is shown logged out" do
+      district = worldbuilder_districts(:district_three)
+      @campaign2.update!(privacy: 'Public', district: district)
+
+      get :show, params: { id: @campaign2 }
+
+      assert_response :success
+      assert_no_match district.name, @response.body
+    end
+
+    test "should hide private character when public campaign characters are shown logged out" do
+      character = entitybuilder_entities(:resident_character_one)
+      character.update!(name: 'Hidden Campaign Character', privacy: 'Private', sheet_privacy: 'Private')
+      character.campaign_join&.destroy!
+      character.create_campaign_join!(campaign: @campaign2)
+      @campaign2.update!(privacy: 'Public')
+
+      get :characters, params: { campaign_id: @campaign2 }
+
+      assert_response :success
+      assert_no_match character.name, @response.body
+    end
+
+    test "should hide private notable entity when public campaign notables are shown logged out" do
+      entity = entitybuilder_entities(:resident_character_one)
+      entity.update!(
+        name: 'Hidden Campaign Notable Character',
+        privacy: 'Private',
+        sheet_privacy: 'Private',
+        short_description: 'Hidden campaign notable text'
+      )
+      @campaign2.notables.create!(entity: entity, name: entity.name, sort_order: 99)
+      @campaign2.update!(privacy: 'Public')
+
+      get :notables, params: { campaign_id: @campaign2 }
+
+      assert_response :success
+      assert_no_match entity.name, @response.body
+      assert_no_match entity.short_description, @response.body
+    end
+
     test "should not get edit" do
       sign_in @user2
       get :edit, params: { id: @campaign }

--- a/test/controllers/campaignmanager/campaigns_controller_test.rb
+++ b/test/controllers/campaignmanager/campaigns_controller_test.rb
@@ -140,5 +140,19 @@ module Campaignmanager
       assert_equal adventure, @campaign2.reload.active_adventure
     end
 
+    test "should clear active adventure" do
+      sign_in @user2
+      patch :update, params: {
+        id: @campaign2,
+        campaign: {
+          name: @campaign2.name,
+          privacy: 'Private',
+          active_adventure_id: ''
+        }
+      }
+      assert_redirected_to edit_campaign_path(assigns(:campaign))
+      assert_nil @campaign2.reload.active_adventure
+    end
+
   end
 end

--- a/test/controllers/campaignmanager/campaigns_controller_test.rb
+++ b/test/controllers/campaignmanager/campaigns_controller_test.rb
@@ -110,5 +110,35 @@ module Campaignmanager
       assert_redirected_to "/residents/#{@campaign.resident.slug}/campaigns"
     end
 
+    test "should update campaign adventures" do
+      sign_in @user
+      adventure = storybuilder_adventures(:resident_one)
+      patch :update, params: {
+        id: @campaign,
+        campaign: {
+          name: @campaign.name,
+          privacy: @campaign.privacy,
+          adventure_ids: [ adventure.id ]
+        }
+      }
+      assert_redirected_to edit_campaign_path(assigns(:campaign))
+      assert_includes @campaign.reload.adventures, adventure
+    end
+
+    test "should set active adventure" do
+      sign_in @user2
+      adventure = @campaign2.adventures.first
+      patch :update, params: {
+        id: @campaign2,
+        campaign: {
+          name: @campaign2.name,
+          privacy: 'Private',
+          active_adventure_id: adventure.id
+        }
+      }
+      assert_redirected_to edit_campaign_path(assigns(:campaign))
+      assert_equal adventure, @campaign2.reload.active_adventure
+    end
+
   end
 end

--- a/test/controllers/campaignmanager/pages_controller_test.rb
+++ b/test/controllers/campaignmanager/pages_controller_test.rb
@@ -66,6 +66,40 @@ module Campaignmanager
       assert_response 404
     end
 
+    test "should hide private parent page when public child page is shown logged out" do
+      private_page = @parent_object.adventure_logs.create!(
+        name: 'Private Campaign Parent Page',
+        privacy: 'Private',
+        short_description: 'Secret',
+        full_description: '<p>Secret campaign parent text</p>'
+      )
+      child_page = @parent_object.adventure_logs.create!(
+        parent_id: private_page.id,
+        name: 'Public Campaign Child Page',
+        privacy: 'Public',
+        short_description: 'Public',
+        full_description: '<p>Public campaign child text</p>'
+      )
+
+      get :show, params: { id: child_page.id, campaign_id: @parent_object, type: @page.type.demodulize }
+
+      assert_response :success
+      assert_no_match private_page.name, @response.body
+      assert_no_match private_page.full_description, @response.body
+    end
+
+    test "should hide private notable entity when public page is shown logged out" do
+      entity = entitybuilder_entities(:resident_character_one)
+      entity.update!(name: 'Private Campaign Notable Character', privacy: 'Private', sheet_privacy: 'Private')
+      @page.update!(privacy: 'Public')
+      @page.notables.create!(entity: entity, name: entity.name, sort_order: 99)
+
+      get :show, params: { id: @page.id, campaign_id: @parent_object, type: @page.type.demodulize }
+
+      assert_response :success
+      assert_no_match entity.name, @response.body
+    end
+
     test "should show page" do
       sign_in @user
       get :show, params: { id: @page.id, campaign_id: @parent_object, type: @page.type.demodulize }

--- a/test/controllers/entitybuilder/inventory_items_controller_test.rb
+++ b/test/controllers/entitybuilder/inventory_items_controller_test.rb
@@ -79,6 +79,13 @@ module Entitybuilder
       assert_response 401
     end
 
+    test "should not show inventory_item when sheet is private" do
+      sign_in @user2
+      @character.update!(sheet_privacy: 'Private')
+      get :show, xhr: true, format: :js, params: { id: @inventory_item, resident_character_id: @character.id }
+      assert_response 403
+    end
+
     test "should show inventory_item" do
       sign_in @user
       get :show, xhr: true, format: :js, params: { id: @inventory_item, resident_character_id: @character.id }

--- a/test/controllers/entitybuilder/known_spells_controller_test.rb
+++ b/test/controllers/entitybuilder/known_spells_controller_test.rb
@@ -79,6 +79,13 @@ module Entitybuilder
       assert_response 401
     end
 
+    test "should not show known_spell when sheet is private" do
+      sign_in @user2
+      @character.update!(sheet_privacy: 'Private')
+      get :show, xhr: true, format: :js, params: { id: @known_spell, resident_character_id: @character.id }
+      assert_response 403
+    end
+
     test "should show known_spell" do
       sign_in @user
       get :show, xhr: true, format: :js, params: { id: @known_spell, resident_character_id: @character.id }

--- a/test/controllers/entitybuilder/linked_rules_controller_test.rb
+++ b/test/controllers/entitybuilder/linked_rules_controller_test.rb
@@ -94,6 +94,13 @@ module Entitybuilder
       assert_response 401
     end
 
+    test "should not show linked_rule when sheet is private" do
+      sign_in @user2
+      @character.update!(sheet_privacy: 'Private')
+      get :show, xhr: true, format: :js, params: { id: @linked_rule, resident_character_id: @character.id }
+      assert_response 403
+    end
+
     test "should show linked_rule" do
       sign_in @user
       get :show, xhr: true, format: :js, params: { id: @linked_rule, resident_character_id: @character.id }

--- a/test/controllers/entitybuilder/resident_characters_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_characters_controller_test.rb
@@ -70,10 +70,61 @@ module Entitybuilder
       assert_response :success
     end
 
+    test "should hide private campaign when public character is shown logged out" do
+      campaign = campaignmanager_campaigns(:resident_two)
+      @character.update!(privacy: 'Public')
+      @character.campaign_join&.destroy!
+      @character.create_campaign_join!(campaign: campaign)
+      campaign.update!(privacy: 'Private', district: worldbuilder_districts(:district_two))
+
+      get :show, params: { id: @character }
+
+      assert_response :success
+      assert_no_match campaign.name, @response.body
+      assert_no_match campaign.resident.name, @response.body
+    end
+
+    test "should hide private campaign world when public character is shown logged out" do
+      campaign = campaignmanager_campaigns(:resident_two)
+      district = worldbuilder_districts(:district_three)
+      @character.update!(privacy: 'Public')
+      @character.campaign_join&.destroy!
+      @character.create_campaign_join!(campaign: campaign)
+      campaign.update!(privacy: 'Public', district: district)
+
+      get :show, params: { id: @character }
+
+      assert_response :success
+      assert_match campaign.name, @response.body
+      assert_no_match district.name, @response.body
+    end
+
     test "should show public character sheet when logged out" do
       @character.update!(sheet_privacy: 'Public')
       get :sheet, params: { resident_character_id: @character }
       assert_response :success
+    end
+
+    test "should hide private inventory item when public character sheet is shown logged out" do
+      inventory_item = entitybuilder_inventory_items(:one)
+      inventory_item.item.update!(
+        name: 'Hidden Sheet Item',
+        privacy: 'Private',
+        short_description: 'Hidden sheet item text'
+      )
+      @character.update!(sheet_privacy: 'Public')
+
+      get :sheet, params: { resident_character_id: @character }
+
+      assert_response :success
+      assert_no_match inventory_item.item.name, @response.body
+      assert_no_match inventory_item.item.short_description, @response.body
+    end
+
+    test "should not show public character card summary when sheet privacy is private" do
+      @character.update!(privacy: 'Public', sheet_privacy: 'Private')
+      get :card_summary, xhr: true, format: :js, params: { resident_character_id: @character }
+      assert_response 403
     end
 
     test "should show character" do

--- a/test/controllers/entitybuilder/resident_characters_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_characters_controller_test.rb
@@ -99,6 +99,23 @@ module Entitybuilder
       assert_no_match district.name, @response.body
     end
 
+    test "should hide private campaign world when public character is shown to another resident" do
+      campaign = campaignmanager_campaigns(:resident_two)
+      district = worldbuilder_districts(:district_three)
+      district.update!(privacy: 'Private')
+      @character.update!(privacy: 'Public')
+      @character.campaign_join&.destroy!
+      @character.create_campaign_join!(campaign: campaign)
+      campaign.update!(privacy: 'Public', district: district)
+
+      sign_in @user2
+      get :show, params: { id: @character }
+
+      assert_response :success
+      assert_match campaign.name, @response.body
+      assert_no_match district.name, @response.body
+    end
+
     test "should show public character sheet when logged out" do
       @character.update!(sheet_privacy: 'Public')
       get :sheet, params: { resident_character_id: @character }

--- a/test/controllers/entitybuilder/resident_characters_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_characters_controller_test.rb
@@ -61,7 +61,19 @@ module Entitybuilder
 
     test "should not show character" do
       get :show, params: { id: @character }
-      assert_response 302
+      assert_response 403
+    end
+
+    test "should show public character when logged out" do
+      @character.update!(privacy: 'Public')
+      get :show, params: { id: @character }
+      assert_response :success
+    end
+
+    test "should show public character sheet when logged out" do
+      @character.update!(sheet_privacy: 'Public')
+      get :sheet, params: { resident_character_id: @character }
+      assert_response :success
     end
 
     test "should show character" do

--- a/test/controllers/entitybuilder/resident_creatures_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_creatures_controller_test.rb
@@ -69,6 +69,12 @@ module Entitybuilder
       assert_response :success
     end
 
+    test "should not show public creature card summary when sheet privacy is private" do
+      @creature.update!(privacy: 'Public', sheet_privacy: 'Private')
+      get :card_summary, xhr: true, format: :js, params: { resident_creature_id: @creature }
+      assert_response 403
+    end
+
     test "should not show private creature when logged out" do
       @creature.update!(privacy: 'Private')
       get :show, params: { id: @creature }

--- a/test/controllers/entitybuilder/resident_creatures_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_creatures_controller_test.rb
@@ -58,9 +58,21 @@ module Entitybuilder
       assert_redirected_to "/billing/subscriptions"
     end
 
-    test "should not show creature" do
+    test "should not show residents creature when logged out" do
       get :show, params: { id: @creature }
-      assert_response 302
+      assert_response 403
+    end
+
+    test "should show public creature when logged out" do
+      @creature.update!(privacy: 'Public')
+      get :show, params: { id: @creature }
+      assert_response :success
+    end
+
+    test "should not show private creature when logged out" do
+      @creature.update!(privacy: 'Private')
+      get :show, params: { id: @creature }
+      assert_response 403
     end
 
     test "should show creature" do

--- a/test/controllers/entitybuilder/resident_npcs_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_npcs_controller_test.rb
@@ -60,7 +60,13 @@ module Entitybuilder
 
     test "should not show npc" do
       get :show, params: { id: @npc }
-      assert_response 302
+      assert_response 403
+    end
+
+    test "should show public npc when logged out" do
+      @npc.update!(privacy: 'Public')
+      get :show, params: { id: @npc }
+      assert_response :success
     end
 
     test "should show npc" do

--- a/test/controllers/entitybuilder/resident_npcs_controller_test.rb
+++ b/test/controllers/entitybuilder/resident_npcs_controller_test.rb
@@ -69,6 +69,12 @@ module Entitybuilder
       assert_response :success
     end
 
+    test "should not show public npc card summary when sheet privacy is private" do
+      @npc.update!(privacy: 'Public', sheet_privacy: 'Private')
+      get :card_summary, xhr: true, format: :js, params: { resident_npc_id: @npc }
+      assert_response 403
+    end
+
     test "should show npc" do
       sign_in @user
       get :show, params: { id: @npc }

--- a/test/controllers/entitybuilder/stock_creatures_controller_test.rb
+++ b/test/controllers/entitybuilder/stock_creatures_controller_test.rb
@@ -62,9 +62,9 @@ module Entitybuilder
       assert_redirected_to edit_stock_creature_path(assigns(:entity))
     end
 
-    test "should not show creature" do
+    test "should not show residents creature when logged out" do
       get :show, params: { id: @creature }
-      assert_response 302
+      assert_response 403
     end
 
     test "should show creature" do

--- a/test/controllers/entitybuilder/stock_npcs_controller_test.rb
+++ b/test/controllers/entitybuilder/stock_npcs_controller_test.rb
@@ -64,7 +64,13 @@ module Entitybuilder
 
     test "should not show npc" do
       get :show, params: { id: @npc }
-      assert_response 302
+      assert_response 403
+    end
+
+    test "should show public npc when logged out" do
+      @npc.update!(privacy: 'Public')
+      get :show, params: { id: @npc }
+      assert_response :success
     end
 
     test "should show npc" do

--- a/test/controllers/rulebuilder/resident_items_controller_test.rb
+++ b/test/controllers/rulebuilder/resident_items_controller_test.rb
@@ -50,9 +50,15 @@ module Rulebuilder
       assert_redirected_to edit_resident_item_path(assigns(:item))
     end
 
-    test "should not show item" do
+    test "should not show item when logged out and private" do
       get :show, params: { id: @item }
-      assert_response 302
+      assert_response 403
+    end
+
+    test "should show public item when logged out" do
+      @item.update!(privacy: 'Public')
+      get :show, params: { id: @item }
+      assert_response :success
     end
 
     test "should show item" do
@@ -61,9 +67,9 @@ module Rulebuilder
       assert_response :success
     end
 
-    test "should not show.js item" do
+    test "should not show.js item when logged out and private" do
       get :show, xhr: true, format: :js, params: { id: @item }
-      assert_response 401
+      assert_response 403
     end
 
     test "should show.js item" do

--- a/test/controllers/rulebuilder/resident_items_controller_test.rb
+++ b/test/controllers/rulebuilder/resident_items_controller_test.rb
@@ -61,6 +61,23 @@ module Rulebuilder
       assert_response :success
     end
 
+    test "should hide private parent when public child item is shown logged out" do
+      parent = @item
+      child = Rulebuilder::ResidentItem.create!(
+        parent_id: parent.id,
+        resident_id: parent.resident_id,
+        core_rules: parent.core_rules,
+        name: 'Public Child Item',
+        privacy: 'Public',
+        full_description: 'Public child text'
+      )
+
+      get :show, params: { id: child }
+
+      assert_response :success
+      assert_no_match parent.full_description, @response.body
+    end
+
     test "should show item" do
       sign_in @user
       get :show, params: { id: @item }

--- a/test/controllers/rulebuilder/stock_items_controller_test.rb
+++ b/test/controllers/rulebuilder/stock_items_controller_test.rb
@@ -46,9 +46,9 @@ module Rulebuilder
       assert_redirected_to edit_stock_item_path(assigns(:item))
     end
 
-    test "should not show item" do
+    test "should show item when logged out" do
       get :show, params: { id: @item }
-      assert_response 302
+      assert_response :success
     end
 
     test "should show item" do

--- a/test/controllers/rulebuilder/stock_items_controller_test.rb
+++ b/test/controllers/rulebuilder/stock_items_controller_test.rb
@@ -46,19 +46,27 @@ module Rulebuilder
       assert_redirected_to edit_stock_item_path(assigns(:item))
     end
 
-    test "should show item when logged out" do
+    test "should not show private item when logged out" do
+      get :show, params: { id: @item }
+      assert_response 403
+    end
+
+    test "should show public item when logged out" do
+      @item.update!(privacy: 'Public')
       get :show, params: { id: @item }
       assert_response :success
     end
 
     test "should show item" do
       sign_in @user
+      @item.update!(privacy: 'Public')
       get :show, params: { id: @item }
       assert_response :success
     end
 
     test "should show.js item" do
       sign_in @user
+      @item.update!(privacy: 'Public')
       get :show, xhr: true, format: :js, params: { id: @item }
       assert_response :success
     end

--- a/test/controllers/storybuilder/pages_controller_test.rb
+++ b/test/controllers/storybuilder/pages_controller_test.rb
@@ -69,7 +69,13 @@ module Storybuilder
 
     test "should not show page" do
       get :show, params: { id: @page.id, resident_adventure_id: @parent_object }
-      assert_response 302
+      assert_response 403
+    end
+
+    test "should show public page when logged out" do
+      @page.update!(privacy: 'Public')
+      get :show, params: { id: @page.id, resident_adventure_id: @parent_object }
+      assert_response :success
     end
 
     test "should show page" do

--- a/test/controllers/storybuilder/pages_controller_test.rb
+++ b/test/controllers/storybuilder/pages_controller_test.rb
@@ -78,6 +78,28 @@ module Storybuilder
       assert_response :success
     end
 
+    test "should hide private tagged pages when public page is shown logged out" do
+      @page.update!(privacy: 'Public')
+      private_page = @parent_object.pages.create!(
+        name: 'Secret Spoilers',
+        privacy: 'Private',
+        short_description: 'Secret',
+        full_description: '<p>Secret</p>',
+        tags: [ 'secret' ]
+      )
+      @page.features.create!(
+        feature_label: 'Tagged',
+        feature_type: 'tag',
+        record_type: 'Storybuilder',
+        search_tags: 'secret'
+      )
+
+      get :show, params: { id: @page.id, resident_adventure_id: @parent_object }
+
+      assert_response :success
+      assert_no_match private_page.name, @response.body
+    end
+
     test "should show page" do
       sign_in @user
       get :show, params: { id: @page.id, resident_adventure_id: @parent_object }

--- a/test/controllers/storybuilder/pages_controller_test.rb
+++ b/test/controllers/storybuilder/pages_controller_test.rb
@@ -100,6 +100,34 @@ module Storybuilder
       assert_no_match private_page.name, @response.body
     end
 
+    test "should hide private parent page when public child page is shown logged out" do
+      private_page = @parent_object.pages.create!(
+        name: 'Private Parent Page',
+        privacy: 'Private',
+        short_description: 'Secret',
+        full_description: '<p>Secret parent text</p>'
+      )
+      child_page = @parent_object.pages.create!(
+        parent_id: private_page.id,
+        name: 'Public Child Page',
+        privacy: 'Public',
+        short_description: 'Public',
+        full_description: '<p>Public child text</p>'
+      )
+      menu_item = @parent_object.menu_items.create!(
+        item_label: private_page.name,
+        item_link: "/pages/#{private_page.slug}",
+        sort_order: 99
+      )
+      Storybuilder::MenuItemJoin.create!(menu_item: menu_item, menu_item_joinable: private_page)
+
+      get :show, params: { id: child_page.id, resident_adventure_id: @parent_object }
+
+      assert_response :success
+      assert_no_match private_page.name, @response.body
+      assert_no_match private_page.full_description, @response.body
+    end
+
     test "should show page" do
       sign_in @user
       get :show, params: { id: @page.id, resident_adventure_id: @parent_object }

--- a/test/controllers/storybuilder/resident_adventures_controller_test.rb
+++ b/test/controllers/storybuilder/resident_adventures_controller_test.rb
@@ -67,9 +67,9 @@ module Storybuilder
       assert_redirected_to edit_resident_adventure_path(assigns(:adventure))
     end
 
-    test "should not show adventure" do
+    test "should not show residents adventure when logged out" do
       get :show, params: { id: @adventure }
-      assert_response 302
+      assert_response 403
     end
 
     test "should not show private adventure" do
@@ -82,6 +82,17 @@ module Storybuilder
       sign_in @user
       get :show, params: { id: @adventure }
       assert_response :success
+    end
+
+    test "should show public adventure when logged out" do
+      @adventure.update!(privacy: 'Public')
+      get :show, params: { id: @adventure }
+      assert_response :success
+    end
+
+    test "should not show private adventure when logged out" do
+      get :show, params: { id: @adventure2 }
+      assert_response 403
     end
 
     test "should not get edit" do

--- a/test/controllers/storybuilder/resident_adventures_controller_test.rb
+++ b/test/controllers/storybuilder/resident_adventures_controller_test.rb
@@ -90,6 +90,17 @@ module Storybuilder
       assert_response :success
     end
 
+    test "should hide private child adventures when public adventure is shown logged out" do
+      @adventure.update!(privacy: 'Public')
+      @adventure.features.create!(feature_label: 'Children', feature_type: 'child')
+      @adventure2.update!(parent_id: @adventure.id, privacy: 'Private')
+
+      get :show, params: { id: @adventure }
+
+      assert_response :success
+      assert_no_match @adventure2.name, @response.body
+    end
+
     test "should not show private adventure when logged out" do
       get :show, params: { id: @adventure2 }
       assert_response 403

--- a/test/controllers/storybuilder/resident_adventures_controller_test.rb
+++ b/test/controllers/storybuilder/resident_adventures_controller_test.rb
@@ -95,6 +95,14 @@ module Storybuilder
       assert_response 403
     end
 
+    test "should not show private adventure in public campaign when logged out" do
+      campaign = campaignmanager_campaigns(:resident_two)
+
+      get :campaign, params: { resident_adventure_id: @adventure2.id, campaign_id: campaign.id }
+
+      assert_response 403
+    end
+
     test "should not get edit" do
       sign_in @user2
       get :edit, params: { id: @adventure }

--- a/test/controllers/storybuilder/resident_adventures_controller_test.rb
+++ b/test/controllers/storybuilder/resident_adventures_controller_test.rb
@@ -101,6 +101,29 @@ module Storybuilder
       assert_no_match @adventure2.name, @response.body
     end
 
+    test "should hide private parent adventure when public child adventure is shown logged out" do
+      @adventure2.update!(full_description: '<p>Private parent adventure text</p>')
+      @adventure.update!(parent_id: @adventure2.id, privacy: 'Public')
+
+      get :show, params: { id: @adventure }
+
+      assert_response :success
+      assert_no_match @adventure2.name, @response.body
+      assert_no_match @adventure2.full_description, @response.body
+    end
+
+    test "should hide private notable entity when public adventure is shown logged out" do
+      entity = entitybuilder_entities(:resident_character_one)
+      entity.update!(name: 'Private Notable Character', privacy: 'Private', sheet_privacy: 'Private')
+      @adventure.update!(privacy: 'Public')
+      @adventure.notables.create!(entity: entity, name: entity.name, sort_order: 99)
+
+      get :show, params: { id: @adventure }
+
+      assert_response :success
+      assert_no_match entity.name, @response.body
+    end
+
     test "should not show private adventure when logged out" do
       get :show, params: { id: @adventure2 }
       assert_response 403

--- a/test/controllers/storybuilder/stock_adventures_controller_test.rb
+++ b/test/controllers/storybuilder/stock_adventures_controller_test.rb
@@ -98,6 +98,14 @@ module Storybuilder
       assert_response 403
     end
 
+    test "should not show private adventure in public campaign when logged out" do
+      campaign = campaignmanager_campaigns(:resident_two)
+
+      get :campaign, params: { stock_adventure_id: @adventure2.id, campaign_id: campaign.id }
+
+      assert_response 403
+    end
+
     test "should not get edit" do
       sign_in @user
       get :edit, params: { id: @adventure }

--- a/test/controllers/storybuilder/stock_adventures_controller_test.rb
+++ b/test/controllers/storybuilder/stock_adventures_controller_test.rb
@@ -70,9 +70,9 @@ module Storybuilder
       assert_redirected_to edit_stock_adventure_path(assigns(:adventure))
     end
 
-    test "should not show adventure" do
+    test "should not show residents adventure when logged out" do
       get :show, params: { id: @adventure }
-      assert_response 302
+      assert_response 403
     end
 
     test "should not show private adventure" do
@@ -85,6 +85,17 @@ module Storybuilder
       sign_in @user
       get :show, params: { id: @adventure }
       assert_response :success
+    end
+
+    test "should show public adventure when logged out" do
+      @adventure.update!(privacy: 'Public')
+      get :show, params: { id: @adventure }
+      assert_response :success
+    end
+
+    test "should not show private adventure when logged out" do
+      get :show, params: { id: @adventure2 }
+      assert_response 403
     end
 
     test "should not get edit" do

--- a/test/fixtures/campaignmanager/campaign_adventure_joins.yml
+++ b/test/fixtures/campaignmanager/campaign_adventure_joins.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+resident_two_active:
+  campaign: resident_two
+  adventure: resident_two
+  active: true
+
+resident_two_inactive:
+  campaign: resident_two
+  adventure: resident_one
+  active: false

--- a/test/fixtures/campaignmanager/campaigns.yml
+++ b/test/fixtures/campaignmanager/campaigns.yml
@@ -3,7 +3,6 @@
 resident_one:
   resident: razune
   district:
-  adventure:
   name: Long Trail
   slug: long-trail
   page_label: ima label
@@ -15,7 +14,6 @@ resident_one:
 resident_two:
   resident: tuandn
   district: district2
-  adventure: resident_two
   name: See the World
   slug: see-the-world
   page_label:

--- a/test/fixtures/rulebuilder/items.yml
+++ b/test/fixtures/rulebuilder/items.yml
@@ -5,6 +5,7 @@ resident_one:
   resident: razune
   core_rules: PFRPG
   name: MyString
+  privacy: Private
   publisher: Embers Design Studios
   is_3pp: true
   source: Book of Terniel
@@ -19,6 +20,7 @@ resident_two:
   resident: razune
   core_rules: PFRPG
   name: MyString
+  privacy: Private
   publisher: Embers Design Studios
   is_3pp: true
   source: Book of Terniel
@@ -32,6 +34,7 @@ stock_one:
   type: Rulebuilder::StockItem
   core_rules: PFRPG
   name: MyString
+  privacy: Private
   publisher: Embers Design Studios
   is_3pp: true
   source: Book of Terniel
@@ -45,6 +48,7 @@ stock_two:
   type: Rulebuilder::StockItem
   core_rules: PFRPG
   name: MyString
+  privacy: Private
   publisher: Embers Design Studios
   is_3pp: true
   source: Book of Terniel

--- a/test/integration/rulebuilder_item_privacy_test.rb
+++ b/test/integration/rulebuilder_item_privacy_test.rb
@@ -1,0 +1,182 @@
+require "test_helper"
+
+class RulebuilderItemPrivacyTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  ENTITY_CASES = [
+    [ "resident character", :resident_character_one, "/eb/resident/characters" ],
+    [ "resident creature", :resident_creature_one, "/eb/resident/creatures" ],
+    [ "resident npc", :resident_npc_one, "/eb/resident/npcs" ],
+    [ "stock creature", :stock_creature_one, "/eb/stock/creatures" ],
+    [ "stock npc", :stock_npc_one, "/eb/stock/npcs" ]
+  ]
+
+  ITEM_CASES = [
+    [ "resident item", Rulebuilder::ResidentItem ],
+    [ "stock item", Rulebuilder::StockItem ]
+  ]
+
+  HIDDEN_FROM_PUBLIC = [ "Private", "Residents" ]
+  PUBLIC_ENTITY_ENDPOINTS = [
+    [ "sheet", "sheet", false, :full ],
+    [ "profile", "profile", false, :name ],
+    [ "card", "card", false, :full ],
+    [ "card summary", "card_summary.js", true, :none ]
+  ]
+
+  setup do
+    @owner = users(:dan)
+    @viewer = users(:lucas)
+    @resident = residents(:razune)
+  end
+
+  ENTITY_CASES.each do |entity_label, entity_fixture, entity_path|
+    ITEM_CASES.each do |item_label, item_class|
+      HIDDEN_FROM_PUBLIC.each do |privacy|
+        PUBLIC_ENTITY_ENDPOINTS.each do |endpoint_label, endpoint_path, xhr, visible_assertion|
+          test "public #{entity_label} #{endpoint_label} hides #{privacy.downcase} #{item_label} from guests" do
+            entity = public_entity(entity_fixture)
+            hidden_item = create_item(item_class, privacy: privacy, name: hidden_name)
+            hidden_inventory_item = attach_item(entity, hidden_item)
+            visible_item = create_item(item_class, privacy: "Public", name: visible_name)
+
+            attach_item(entity, visible_item)
+
+            get "#{entity_path}/#{entity.id}/#{endpoint_path}", xhr: xhr
+
+            assert_response :success
+            assert_item_visible visible_item, visible_assertion
+            assert_item_hidden hidden_item, hidden_inventory_item
+          end
+        end
+      end
+    end
+  end
+
+  ENTITY_CASES.each do |entity_label, entity_fixture, entity_path|
+    ITEM_CASES.each do |item_label, item_class|
+      test "public #{entity_label} inventory item modal rejects private #{item_label} for other residents" do
+        entity = public_entity(entity_fixture)
+        hidden_item = create_item(item_class, privacy: "Private", name: hidden_name)
+        inventory_item = attach_item(entity, hidden_item)
+
+        sign_in @viewer
+        get "#{entity_path}/#{entity.id}/inventory_items/#{inventory_item.id}.js", xhr: true
+
+        assert_response :forbidden
+        assert_item_hidden hidden_item, inventory_item
+      end
+    end
+  end
+
+  ITEM_CASES.each do |item_label, item_class|
+    HIDDEN_FROM_PUBLIC.each do |privacy|
+      test "public #{item_label} show hides #{privacy.downcase} parent item from guests" do
+        parent = create_item(item_class, privacy: privacy, name: hidden_name)
+        child = create_item(item_class, privacy: "Public", name: visible_name, parent: parent)
+
+        get item_path(child)
+
+        assert_response :success
+        assert_item_visible child, :name
+        assert_item_hidden parent
+      end
+    end
+  end
+
+  ITEM_CASES.each do |item_label, item_class|
+    test "inventory item modal hides private parent #{item_label} for other residents" do
+      entity = public_entity(:resident_character_one)
+      parent = create_item(item_class, privacy: "Private", name: hidden_name)
+      child = create_item(item_class, privacy: "Public", name: visible_name, parent: parent)
+      inventory_item = attach_item(entity, child)
+
+      sign_in @viewer
+      get "/eb/resident/characters/#{entity.id}/inventory_items/#{inventory_item.id}.js", xhr: true
+
+      assert_response :success
+      assert_item_visible child, :name
+      assert_item_hidden parent
+    end
+  end
+
+  test "stock item index hides private stock items from signed in non admins" do
+    hidden_item = create_item(Rulebuilder::StockItem, privacy: "Private", name: hidden_name)
+    visible_item = create_item(Rulebuilder::StockItem, privacy: "Residents", name: visible_name)
+
+    sign_in @viewer
+    get "/rb/stock/items"
+
+    assert_response :success
+    assert_item_visible visible_item
+    assert_item_hidden hidden_item
+  end
+
+  test "stock item show rejects residents stock items for guests" do
+    hidden_item = create_item(Rulebuilder::StockItem, privacy: "Residents", name: hidden_name)
+
+    get "/rb/stock/items/#{hidden_item.id}"
+
+    assert_response :forbidden
+    assert_item_hidden hidden_item
+  end
+
+  private
+
+    def public_entity(fixture_name)
+      entitybuilder_entities(fixture_name).tap do |entity|
+        entity.update!(privacy: "Public", sheet_privacy: "Public")
+      end
+    end
+
+    def create_item(item_class, privacy:, name:, parent: nil)
+      attributes = {
+        core_rules: "PFRPG",
+        full_description: "#{name} full description",
+        name: name,
+        parent: parent,
+        privacy: privacy,
+        short_description: "#{name} short description"
+      }
+      attributes[:resident] = @resident if item_class <= Rulebuilder::ResidentItem
+
+      item_class.create!(attributes)
+    end
+
+    def attach_item(entity, item)
+      entity.inventory_items.create!(
+        detail: "#{item.name} detail",
+        item: item,
+        quantity: 1,
+        sort_order: entity.inventory_items.count + 100
+      )
+    end
+
+    def item_path(item)
+      return "/rb/resident/items/#{item.id}" if item.is_a?(Rulebuilder::ResidentItem)
+
+      "/rb/stock/items/#{item.id}"
+    end
+
+    def assert_item_visible(item, assertion = :full)
+      return if assertion == :none
+
+      assert_match item.name, response.body
+      assert_match item.short_description, response.body if assertion == :full
+    end
+
+    def assert_item_hidden(item, inventory_item = nil)
+      assert_no_match item.name, response.body
+      assert_no_match item.short_description, response.body
+      assert_no_match item.full_description, response.body
+      assert_no_match inventory_item.detail, response.body if inventory_item
+    end
+
+    def hidden_name
+      "Hidden Item #{SecureRandom.hex(6)}"
+    end
+
+    def visible_name
+      "Visible Item #{SecureRandom.hex(6)}"
+    end
+end

--- a/test/migrations/add_privacy_to_rulebuild_items_test.rb
+++ b/test/migrations/add_privacy_to_rulebuild_items_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+require Rails.root.join("engines/rulebuilder/db/migrate/20260613000000_add_privacy_to_rulebuild_items")
+
+class AddPrivacyToRulebuildItemsTest < ActiveSupport::TestCase
+  test "backfills existing stock items to public" do
+    Rulebuilder::Item.update_all(privacy: "Private")
+
+    AddPrivacyToRulebuildItems.new.send(:backfill_existing_stock_items)
+
+    assert_equal [ "Public" ], Rulebuilder::StockItem.distinct.pluck(:privacy)
+    assert_equal [ "Private" ], Rulebuilder::ResidentItem.distinct.pluck(:privacy)
+  end
+end

--- a/test/models/campaignmanager/campaign_adventure_join_test.rb
+++ b/test/models/campaignmanager/campaign_adventure_join_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+module Campaignmanager
+  class CampaignAdventureJoinTest < ActiveSupport::TestCase
+    test "campaign_adventure_join is valid with campaign, adventure, and active flag" do
+      join = campaignmanager_campaign_adventure_joins(:resident_two_active)
+      assert join.valid?
+    end
+
+    test "campaign returns active adventure" do
+      campaign = campaignmanager_campaigns(:resident_two)
+      assert_equal storybuilder_adventures(:resident_two), campaign.active_adventure
+    end
+
+    test "campaign returns all linked adventures" do
+      campaign = campaignmanager_campaigns(:resident_two)
+      assert_includes campaign.adventures, storybuilder_adventures(:resident_two)
+      assert_includes campaign.adventures, storybuilder_adventures(:resident_one)
+    end
+
+    test "duplicate adventure on the same campaign is invalid" do
+      existing = campaignmanager_campaign_adventure_joins(:resident_two_active)
+      duplicate = CampaignAdventureJoin.new(
+        campaign_id: existing.campaign_id,
+        adventure_id: existing.adventure_id,
+        active: false
+      )
+      assert_not duplicate.valid?
+      assert duplicate.errors[:adventure_id].any?
+    end
+
+    test "active_adventure_id= setter flips active flag" do
+      campaign = campaignmanager_campaigns(:resident_two)
+      inactive_adventure = storybuilder_adventures(:resident_one)
+
+      # Ensure resident_two is currently active
+      assert_equal storybuilder_adventures(:resident_two), campaign.active_adventure
+
+      campaign.active_adventure_id = inactive_adventure.id
+
+      # Reload campaign to verify DB state
+      campaign.reload
+      assert_equal inactive_adventure, campaign.active_adventure
+
+      # The previously active one should now be inactive
+      assert_not campaign.campaign_adventure_joins.find_by(adventure_id: storybuilder_adventures(:resident_two).id).active
+    end
+  end
+end

--- a/test/models/entitybuilder/entity_test.rb
+++ b/test/models/entitybuilder/entity_test.rb
@@ -5,5 +5,29 @@ module Entitybuilder
     test "tag_list returns a comma separated list" do
       assert_equal "hello1, world2", entitybuilder_entities(:resident_character_one).tag_list
     end
+
+    test "can_show? returns true for Public privacy with nil user" do
+      entity = entitybuilder_entities(:resident_creature_one)
+      entity.privacy = 'Public'
+      assert entity.can_show?(nil, false, entity.type)
+    end
+
+    test "can_show? returns false for Residents privacy with nil user" do
+      entity = entitybuilder_entities(:resident_creature_one)
+      entity.privacy = 'Residents'
+      assert_not entity.can_show?(nil, false, entity.type)
+    end
+
+    test "can_sheet? returns true for Public sheet_privacy with nil user" do
+      entity = entitybuilder_entities(:resident_creature_one)
+      entity.sheet_privacy = 'Public'
+      assert entity.can_sheet?(nil, false, entity.type)
+    end
+
+    test "can_sheet? returns false for Private sheet_privacy with nil user" do
+      entity = entitybuilder_entities(:resident_creature_one)
+      entity.sheet_privacy = 'Private'
+      assert_not entity.can_sheet?(nil, false, entity.type)
+    end
   end
 end

--- a/test/models/rulebuilder/item_test.rb
+++ b/test/models/rulebuilder/item_test.rb
@@ -34,5 +34,12 @@ module Rulebuilder
       item.privacy = 'Private'
       assert_not item.can_show?(nil, false, item.type)
     end
+
+    test "invalid privacy adds symbolic error" do
+      item = Rulebuilder::ResidentItem.new(name: "ResidentItemTest", core_rules: "PFRPG", privacy: "Invalid")
+      item.valid?
+      assert_equal :invalid_privacy, item.errors.details[:privacy].first[:error]
+      assert_equal "is not valid.", item.errors[:privacy].first
+    end
   end
 end

--- a/test/models/rulebuilder/item_test.rb
+++ b/test/models/rulebuilder/item_test.rb
@@ -17,5 +17,22 @@ module Rulebuilder
     test "tag_list returns a comma separated list" do
       assert_equal "hello1, world2", rulebuilder_items(:resident_one).tag_list
     end
+
+    test "privacy defaults to Private" do
+      item = Rulebuilder::ResidentItem.new
+      assert_equal 'Private', item.privacy
+    end
+
+    test "can_show? returns true for Public with nil user" do
+      item = rulebuilder_items(:resident_one)
+      item.privacy = 'Public'
+      assert item.can_show?(nil, false, item.type)
+    end
+
+    test "can_show? returns false for Private with nil user" do
+      item = rulebuilder_items(:resident_one)
+      item.privacy = 'Private'
+      assert_not item.can_show?(nil, false, item.type)
+    end
   end
 end

--- a/test/models/storybuilder/adventure_test.rb
+++ b/test/models/storybuilder/adventure_test.rb
@@ -9,5 +9,17 @@ module Storybuilder
       assert_equal [:privacy, :resident_id], adventure.errors.keys
     end
 
+    test "can_show? returns true for Public privacy with nil user" do
+      adventure = storybuilder_adventures(:resident_one)
+      adventure.privacy = 'Public'
+      assert adventure.can_show?(nil, false)
+    end
+
+    test "can_show? returns false for Private privacy with nil user" do
+      adventure = storybuilder_adventures(:resident_one)
+      adventure.privacy = 'Private'
+      assert_not adventure.can_show?(nil, false)
+    end
+
   end
 end


### PR DESCRIPTION
## Summary

- **Workstream D**: Replace single `adventure_id` on Campaign with a many-to-many join table (`CampaignAdventureJoin`). Campaigns can now link multiple adventures with one marked "active". Campaign form updated with multi-select for adventures and active-adventure picker. Menu relabeled "Active Adventure".
- **Workstream A**: Adventures now support `'Public'` privacy. Logged-out users can view public adventures (skip auth on `show`/`campaign` actions; `can_show?` updated).
- **Workstream B**: Creatures now support `'Public'` privacy. Logged-out users can view public creatures/sheets/profiles/cards.
- **Workstream C**: Items gain a full privacy system (`privacy` column + migration + validations + form select). Logged-out users can view public items.

## Test Plan

- [ ] Run `bin/rails test test/models/campaignmanager/ test/controllers/campaignmanager/ test/models/storybuilder/ test/controllers/storybuilder/ test/models/entitybuilder/ test/controllers/entitybuilder/ test/models/rulebuilder/ test/controllers/rulebuilder/` — 529 tests, 0 failures
- [ ] Log in, create/edit a campaign, link 2+ adventures, set one active — confirm "Active Adventure" menu link points to the active one
- [ ] Set an adventure/creature/item to `Public`, open its show URL logged out — confirm 200 response
- [ ] Set it back to `Private`, open logged out — confirm 403
- [ ] Confirm existing campaigns (with old single adventure) still show their adventure as active after the backfill migration (`bin/rails db:migrate`)