### PR TITLE
Show active adventure link to non-editors; list all campaign adventures

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,3 +53,15 @@ en:
         stock_images: "Stock Images"
         stock_images_admin: "Stock Images (Admin)"
         map_images: "Map Images"
+  campaignmanager:
+    navigation:
+      active_adventure: "Active Adventure"
+    campaigns:
+      features:
+        adventures: "Adventures"
+      form:
+        adventures_label: "Adventures in this campaign"
+        adventures_hint: "Check the adventures that are part of this campaign. They appear on the campaign overview."
+        active_adventure_label: "Active adventure"
+        active_adventure_hint: "The adventure currently being run. It is highlighted on the overview and linked in the campaign menu."
+        no_active_adventure: "None"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,13 @@
+it:
+  campaignmanager:
+    navigation:
+      active_adventure: "Avventura attiva"
+    campaigns:
+      features:
+        adventures: "Avventure"
+      form:
+        adventures_label: "Avventure in questa campagna"
+        adventures_hint: "Seleziona le avventure che fanno parte di questa campagna. Appaiono nella panoramica della campagna."
+        active_adventure_label: "Avventura attiva"
+        active_adventure_hint: "L'avventura attualmente in corso. Viene evidenziata nella panoramica e collegata nel menu della campagna."
+        no_active_adventure: "Nessuna"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,13 @@
+nl:
+  campaignmanager:
+    navigation:
+      active_adventure: "Actief avontuur"
+    campaigns:
+      features:
+        adventures: "Avonturen"
+      form:
+        adventures_label: "Avonturen in deze campagne"
+        adventures_hint: "Vink de avonturen aan die onderdeel zijn van deze campagne. Ze verschijnen op het campagneoverzicht."
+        active_adventure_label: "Actief avontuur"
+        active_adventure_hint: "Het avontuur dat nu gespeeld wordt. Het wordt uitgelicht op het overzicht en gelinkt in het campagnemenu."
+        no_active_adventure: "Geen"

--- a/engines/campaignmanager/app/models/campaignmanager/campaign.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/campaign.rb
@@ -46,7 +46,7 @@ module Campaignmanager
              dependent: :destroy
 
     has_many :adventures,
-             -> { select('storybuilder_adventures.id, storybuilder_adventures.name, storybuilder_adventures.slug, storybuilder_adventures.type') },
+             -> { select('storybuilder_adventures.id, storybuilder_adventures.resident_id, storybuilder_adventures.name, storybuilder_adventures.slug, storybuilder_adventures.type, storybuilder_adventures.privacy') },
              through: :campaign_adventure_joins,
              class_name: "Storybuilder::Adventure"
 

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
@@ -9,10 +9,15 @@
     <%= link_to campaign.district.name, worldbuilder.district_path(campaign.district.slug) %>
   </li>
 <% end %>
-<% if campaign.active_adventure.present? and campaign.can_edit?(current_user, admin_signed_in?) %>
+<% visible_adventures = visible_records(campaign.adventures) %>
+<% if visible_adventures.any? %>
+  <% active_adventure_id = campaign.active_adventure&.id %>
   <li>
-    <strong>Adventure: </strong>
-    <%= link_to campaign.active_adventure.name, "#{tcob_path(campaign.active_adventure)}" %>
+    <strong>Adventures: </strong>
+    <%= safe_join(visible_adventures.map { |adventure|
+          link = link_to(adventure.name, tcob_path(adventure))
+          adventure.id == active_adventure_id ? content_tag(:strong, link) : link
+        }, ", ") %>
   </li>
 <% end %>
 <% campaign.features.each do |feature| %>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_features.html.erb
@@ -13,7 +13,7 @@
 <% if visible_adventures.any? %>
   <% active_adventure_id = campaign.active_adventure&.id %>
   <li>
-    <strong>Adventures: </strong>
+    <strong><%= t("campaignmanager.campaigns.features.adventures") %>: </strong>
     <%= safe_join(visible_adventures.map { |adventure|
           link = link_to(adventure.name, tcob_path(adventure))
           adventure.id == active_adventure_id ? content_tag(:strong, link) : link

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -14,17 +14,17 @@
             collection: current_user.resident.adventure_list(@campaign.core_rules).values.flatten,
             label_method: :name,
             value_method: :id,
-            label: 'Adventures in this campaign',
-            hint: 'Check the adventures that are part of this campaign. They appear on the campaign overview.' %>
+            label: t("campaignmanager.campaigns.form.adventures_label"),
+            hint: t("campaignmanager.campaigns.form.adventures_hint") %>
         <% if @campaign.adventures.any? %>
           <%= f.input :active_adventure_id,
               as: :select,
               collection: @campaign.adventures,
               label_method: :name,
               value_method: :id,
-              include_blank: 'None',
-              label: 'Active adventure',
-              hint: 'The adventure currently being run. It is highlighted on the overview and linked in the campaign menu.' %>
+              include_blank: t("campaignmanager.campaigns.form.no_active_adventure"),
+              label: t("campaignmanager.campaigns.form.active_adventure_label"),
+              hint: t("campaignmanager.campaigns.form.active_adventure_hint") %>
         <% end %>
       <% end %>
     </div>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -14,15 +14,17 @@
             collection: current_user.resident.adventure_list(@campaign.core_rules).values.flatten,
             label_method: :name,
             value_method: :id,
-            label: 'Adventures' %>
+            label: 'Adventures in this campaign',
+            hint: 'Check the adventures that are part of this campaign. They appear on the campaign overview.' %>
         <% if @campaign.adventures.any? %>
           <%= f.input :active_adventure_id,
               as: :select,
               collection: @campaign.adventures,
               label_method: :name,
               value_method: :id,
-              include_blank: true,
-              label: 'Active Adventure' %>
+              include_blank: 'None',
+              label: 'Active adventure',
+              hint: 'The adventure currently being run. It is highlighted on the overview and linked in the campaign menu.' %>
         <% end %>
       <% end %>
     </div>

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
@@ -18,8 +18,11 @@
   </dd>
 <% end %>
 <% if @campaign.active_adventure.present? && visible_record?(@campaign.active_adventure) %>
-  <dd class="<%= 'active' if current_page?("#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}") %>">
-    <h3><%= link_to 'Active Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
+  <% active_adventure_path = "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %>
+  <dd class="<%= 'active' if current_page?(active_adventure_path) %>">
+    <h3>
+      <%= link_to t("campaignmanager.navigation.active_adventure"), active_adventure_path, :style => 'display:block;' %>
+    </h3>
   </dd>
 <% end %>
   <dd class="<%= 'active' if page == "HouseRule" if local_assigns.has_key? :page %>">

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_campaign.html.erb
@@ -17,6 +17,11 @@
     <h3><%= link_to 'Notables', "#{campaignmanager.polymorphic_path(@campaign)}/notables/list", :style => 'display:block;' %></h3>
   </dd>
 <% end %>
+<% if @campaign.active_adventure.present? && visible_record?(@campaign.active_adventure) %>
+  <dd class="<%= 'active' if current_page?("#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}") %>">
+    <h3><%= link_to 'Active Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
+  </dd>
+<% end %>
   <dd class="<%= 'active' if page == "HouseRule" if local_assigns.has_key? :page %>">
     <h3><%= link_to 'House Rules', campaignmanager.polymorphic_path([@campaign, :house_rules]), :style => 'display:block;' %></h3>
   </dd>
@@ -32,11 +37,6 @@
 
 <% if @campaign.can_edit?(current_user, admin_signed_in?) %>
 <dl class="left-menu show-for-medium-up">
-  <% if @campaign.active_adventure.present? %>
-  <dd class="<%= 'active' if current_page?("#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}") %>">
-    <h3><%= link_to 'Active Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}", :style => 'display:block;' %></h3>
-  </dd>
-  <% end %>
   <dd class="<%= 'active' if page == "GameMasterNote" if local_assigns.has_key? :page %>">
     <h3><%= link_to 'GM Notes', campaignmanager.polymorphic_path([@campaign, :game_master_notes]), :style => 'display:block;' %></h3>
   </dd>

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
@@ -9,7 +9,8 @@
   <li><%= link_to 'Notables', "#{campaignmanager.polymorphic_path(@campaign)}/notables/list" %></li>
 <% end %>
 <% if @campaign.active_adventure.present? && visible_record?(@campaign.active_adventure) %>
-  <li><%= link_to 'Active Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %></li>
+  <% active_adventure_path = "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %>
+  <li><%= link_to t("campaignmanager.navigation.active_adventure"), active_adventure_path %></li>
 <% end %>
 <li><%= link_to 'House Rules', campaignmanager.polymorphic_path([@campaign, :house_rules]) %></li>
 <li><%= link_to 'Adventure Logs', campaignmanager.polymorphic_path([@campaign, :adventure_logs]) %></li>

--- a/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menus/_small.html.erb
@@ -8,6 +8,9 @@
 <% if visible_notables(@campaign.notables).any? %>
   <li><%= link_to 'Notables', "#{campaignmanager.polymorphic_path(@campaign)}/notables/list" %></li>
 <% end %>
+<% if @campaign.active_adventure.present? && visible_record?(@campaign.active_adventure) %>
+  <li><%= link_to 'Active Adventure', "#{storybuilder.polymorphic_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %></li>
+<% end %>
 <li><%= link_to 'House Rules', campaignmanager.polymorphic_path([@campaign, :house_rules]) %></li>
 <li><%= link_to 'Adventure Logs', campaignmanager.polymorphic_path([@campaign, :adventure_logs]) %></li>
 
@@ -16,8 +19,5 @@
 <% end %>
 
 <% if @campaign.can_edit?(current_user, admin_signed_in?) %>
-  <% if @campaign.active_adventure.present? %>
-    <li><%= link_to 'Active Adventure', "#{storybuilder.resident_adventure_path(@campaign.active_adventure)}/campaign/#{@campaign.id}" %></li>
-  <% end %>
   <li><%= link_to 'GM Notes', campaignmanager.polymorphic_path([@campaign, :game_master_notes]) %></li>
 <% end %>

--- a/test/controllers/campaignmanager/campaigns_controller_test.rb
+++ b/test/controllers/campaignmanager/campaigns_controller_test.rb
@@ -80,6 +80,27 @@ module Campaignmanager
       assert_no_match district.name, @response.body
     end
 
+    test "should show active adventure link to anonymous visitor when adventure is public" do
+      @campaign2.update!(privacy: 'Public')
+      storybuilder_adventures(:resident_two).update!(privacy: 'Public')
+
+      get :show, params: { id: @campaign2 }
+
+      assert_response :success
+      assert_match 'Active Adventure', @response.body
+      assert_match storybuilder_adventures(:resident_two).name, @response.body
+    end
+
+    test "should hide active adventure from anonymous visitor when adventure is private" do
+      @campaign2.update!(privacy: 'Public')
+
+      get :show, params: { id: @campaign2 }
+
+      assert_response :success
+      assert_no_match 'Active Adventure', @response.body
+      assert_no_match storybuilder_adventures(:resident_two).name, @response.body
+    end
+
     test "should hide private world when public campaign is shown to another resident" do
       district = worldbuilder_districts(:district_three)
       district.update!(privacy: 'Private')

--- a/test/controllers/campaignmanager/campaigns_controller_test.rb
+++ b/test/controllers/campaignmanager/campaigns_controller_test.rb
@@ -87,7 +87,7 @@ module Campaignmanager
       get :show, params: { id: @campaign2 }
 
       assert_response :success
-      assert_match 'Active Adventure', @response.body
+      assert_match I18n.t("campaignmanager.navigation.active_adventure"), @response.body
       assert_match storybuilder_adventures(:resident_two).name, @response.body
     end
 
@@ -97,7 +97,7 @@ module Campaignmanager
       get :show, params: { id: @campaign2 }
 
       assert_response :success
-      assert_no_match 'Active Adventure', @response.body
+      assert_no_match I18n.t("campaignmanager.navigation.active_adventure"), @response.body
       assert_no_match storybuilder_adventures(:resident_two).name, @response.body
     end
 


### PR DESCRIPTION
## Problem

After the publish work merged, setting a campaign **and** its active adventure to `Public` still didn't show the **Active Adventure** link to logged-out visitors. Root cause: the link (in both menu partials) and the campaign Overview's adventure line were gated on `can_edit?`, so only the owner/admin ever saw them — visibility had nothing to do with the adventure's own privacy.

## Changes

- **Menu partials** (`menus/_campaign.html.erb`, `menus/_small.html.erb`): move the *Active Adventure* link out of the `can_edit?` block and gate it on `visible_record?(@campaign.active_adventure)` — the same helper the World/district link uses. GM Notes stays editor-only. Also fixed the small menu to use `polymorphic_path` instead of the hardcoded `resident_adventure_path` (which was wrong for stock adventures).
- **Overview** (`campaigns/_features.html.erb`): replace the single editor-only "Adventure" line with an **"Adventures:"** list of every adventure the viewer is allowed to see, each linked, with the **active one in bold**.
- **Form** (`campaigns/_form.html.erb`): clearer labels/hints — *"Adventures in this campaign"* with a reminder that checked adventures are part of the campaign, *"Active adventure"* with an explanatory hint, and the blank option now reads **"None"**.
- **Model** (`campaign.rb`): add `resident_id` and `privacy` to the `adventures` association `SELECT` so `can_show?` no longer raises `missing attribute: privacy`.

## Behavior notes

- A campaign can still have **no** active adventure (the "None" option); the Overview lists all linked adventures regardless.
- Only one adventure can be active per campaign (unchanged).

## Testing

Added regression tests in `campaigns_controller_test.rb`: an anonymous visitor **sees** the Active Adventure link + name when the adventure is Public, and **doesn't** when it's Private. Local run: `test/controllers/campaignmanager/campaigns_controller_test.rb` → 24 runs, 59 assertions, 0 failures.

> Note: local pre-push test hook errors on an unrelated pre-existing issue — `main`'s `db/schema.rb` contains `# Could not dump table "rulebuilder_items"`, so loading it into local sqlite omits the table and breaks fixture loading for all tests. Verified green against a complete schema; CI runs against the real DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)