### PR TITLE
Separate ruleset slugs from display names; rename PFRPG to Pathfinder 1E

### DIFF
--- a/app/models/concerns/dice.rb
+++ b/app/models/concerns/dice.rb
@@ -5,16 +5,16 @@ module Dice
   VALID_DICE_MECHANIC = /\A([0-9]+)(d)([0-9]+)(\+*([0-9]+)(d)([0-9]+))*\z|\b(Standard)\b|\b(Fate)\b|\b(Roll Under)\b/
 
   CORE_RULES_DICE = [
-    { core_rules: "3.5 Edition",       dice: "1d20" },
-    { core_rules: "4th Edition",       dice: "1d20" },
-    { core_rules: "5th Edition",       dice: "1d20" },
-    { core_rules: "d20 Future",        dice: "1d20" },
-    { core_rules: "d20 Modern",        dice: "1d20" },
-    { core_rules: "Dungeon World",     dice: "2d6" },
-    { core_rules: "Fate Core",         dice: "Fate" },
-    { core_rules: "PFRPG",             dice: "1d20" },
-    { core_rules: "W.O.I.N",           dice: "1d20" },
-    { core_rules: "Generic",           dice: "1d20" },
+    { core_rules: "dnd35e",           dice: "1d20" },
+    { core_rules: "dnd4e",            dice: "1d20" },
+    { core_rules: "dnd5e",            dice: "1d20" },
+    { core_rules: "d20Future",        dice: "1d20" },
+    { core_rules: "d20Modern",        dice: "1d20" },
+    { core_rules: "Dungeon World",    dice: "2d6" },
+    { core_rules: "fateCore",         dice: "Fate" },
+    { core_rules: "pf1e",             dice: "1d20" },
+    { core_rules: "woin",             dice: "1d20" },
+    { core_rules: "generic",          dice: "1d20" },
     { core_rules: "Mutant Chronicles", dice: "2d20" }
   ]
 

--- a/app/views/layouts/form/_search_with_rules.html.erb
+++ b/app/views/layouts/form/_search_with_rules.html.erb
@@ -6,7 +6,7 @@
         <span class="prefix core-rules">Core Rules</span>
       </div>
       <div class="medium-7 small-12 columns">
-        <%= select_tag :core_rules_filter, options_for_select(CoreRules.options(admin_signed_in?), params[:core_rules_filter]), {prompt: 'All', onchange: "javascript: $( this ).trigger('submit.rails')", class: 'postfix'} %>
+        <%= select_tag :core_rules_filter, options_from_collection_for_select(CoreRules.all(admin_signed_in?), :slug, :name, params[:core_rules_filter]), {prompt: 'All', onchange: "javascript: $( this ).trigger('submit.rails')", class: 'postfix'} %>
       </div>
     </div>
   </div>

--- a/app/views/residents/campaigns.html.erb
+++ b/app/views/residents/campaigns.html.erb
@@ -33,7 +33,7 @@
         <% @cm_gm_campaigns.each do |campaign| %>
           <% if campaign.can_show?(current_user, admin_signed_in?) %>
             <h2><%= link_to campaign.name, campaignmanager.campaign_path(campaign)  %><span class="subheader"><%= " - #{campaign.page_label}" if campaign.page_label.present? %></span></h2>
-            <% if campaign.core_rules.present? %><strong>Core Rules:</strong> <%= campaign.core_rules %></br><% end %>
+            <% if campaign.core_rules.present? %><strong>Core Rules:</strong> <%= CoreRules.display_name(campaign.core_rules) %></br><% end %>
             <h4 style="color:#c5c5c5;">Updated: <span data-timestamp="<%= campaign.updated_at.to_i*1000 %>"></span></h4>
             <p><%= campaign.short_description %></p>
           <% end %>

--- a/config/core_rules/3-5-edition.json
+++ b/config/core_rules/3-5-edition.json
@@ -1,5 +1,6 @@
 {
   "name": "3.5 Edition",
+  "slug": "dnd35e",
   "active": "true",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/4th-edition.json
+++ b/config/core_rules/4th-edition.json
@@ -1,5 +1,6 @@
 {
   "name": "4th Edition",
+  "slug": "dnd4e",
   "active": "true",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/5th-edition.json
+++ b/config/core_rules/5th-edition.json
@@ -1,5 +1,6 @@
 {
   "name": "5th Edition",
+  "slug": "dnd5e",
   "active": "true",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/d20-future.json
+++ b/config/core_rules/d20-future.json
@@ -1,5 +1,6 @@
 {
   "name": "d20 Future",
+  "slug": "d20Future",
   "active": "true",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/d20-modern.json
+++ b/config/core_rules/d20-modern.json
@@ -1,5 +1,6 @@
 {
   "name": "d20 Modern",
+  "slug": "d20Modern",
   "active": "false",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/draw-steel.json
+++ b/config/core_rules/draw-steel.json
@@ -1,5 +1,6 @@
 {
   "name": "Draw Steel",
+  "slug": "drawSteel",
   "active": "true",
   "stock": "true",
   "default_dice": "2d10",

--- a/config/core_rules/fate-core.json
+++ b/config/core_rules/fate-core.json
@@ -1,5 +1,6 @@
 {
   "name": "Fate Core",
+  "slug": "fateCore",
   "active": "true",
   "stock": "true",
   "default_dice": "Fate",

--- a/config/core_rules/generic.json
+++ b/config/core_rules/generic.json
@@ -1,5 +1,6 @@
 {
   "name": "Generic",
+  "slug": "generic",
   "active": "true",
   "stock": "false",
   "default_dice": "1d20",

--- a/config/core_rules/pathfinder-2e.json
+++ b/config/core_rules/pathfinder-2e.json
@@ -1,5 +1,6 @@
 {
-  "name": "Pathfinder 2e",
+  "name": "Pathfinder 2E",
+  "slug": "pf2e",
   "active": "true",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/pfrpg.json
+++ b/config/core_rules/pfrpg.json
@@ -1,5 +1,6 @@
 {
-  "name": "PFRPG",
+  "name": "Pathfinder 1E",
+  "slug": "pf1e",
   "active": "true",
   "stock": "true",
   "default_dice": "1d20",

--- a/config/core_rules/w-o-i-n.json
+++ b/config/core_rules/w-o-i-n.json
@@ -1,5 +1,6 @@
 {
   "name": "W.O.I.N",
+  "slug": "woin",
   "active": "true",
   "stock": "true",
   "default_dice": "1d6",

--- a/db/migrate/20260616053635_convert_core_rules_display_names_to_slugs.rb
+++ b/db/migrate/20260616053635_convert_core_rules_display_names_to_slugs.rb
@@ -1,0 +1,52 @@
+class ConvertCoreRulesDisplayNamesToSlugs < ActiveRecord::Migration[6.1]
+  TABLES = %w[
+    campaignmanager_campaigns
+    entitybuilder_entities
+    rulebuilder_abilities
+    rulebuilder_feats
+    rulebuilder_items
+    rulebuilder_rules
+    rulebuilder_spells
+    storybuilder_adventures
+  ].freeze
+
+  DISPLAY_NAME_TO_SLUG = {
+    "PFRPG"         => "pf1e",
+    "Pathfinder 2e" => "pf2e",
+    "3.5 Edition"   => "dnd35e",
+    "4th Edition"   => "dnd4e",
+    "5th Edition"   => "dnd5e",
+    "d20 Future"    => "d20Future",
+    "d20 Modern"    => "d20Modern",
+    "Draw Steel"    => "drawSteel",
+    "Fate Core"     => "fateCore",
+    "Generic"       => "generic",
+    "W.O.I.N"      => "woin"
+  }.freeze
+
+  SLUG_TO_DISPLAY_NAME = DISPLAY_NAME_TO_SLUG.invert.freeze
+
+  def up
+    TABLES.each do |table|
+      DISPLAY_NAME_TO_SLUG.each do |display_name, slug|
+        execute <<~SQL
+          UPDATE #{table}
+          SET core_rules = #{quote(slug)}
+          WHERE core_rules = #{quote(display_name)}
+        SQL
+      end
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      SLUG_TO_DISPLAY_NAME.each do |slug, display_name|
+        execute <<~SQL
+          UPDATE #{table}
+          SET core_rules = #{quote(display_name)}
+          WHERE core_rules = #{quote(slug)}
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,9 +31,9 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "admins", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
+    t.string "email", limit: 255, default: "", null: false
+    t.string "encrypted_password", limit: 255, default: "", null: false
+    t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
-    t.string "unlock_token"
+    t.string "unlock_token", limit: 255
     t.datetime "locked_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "affiliations", id: :string, force: :cascade do |t|
     t.string "resident_id", null: false
     t.string "affiliate_id", null: false
-    t.string "status", null: false
+    t.string "status", limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["affiliate_id", "resident_id"], name: "index_affiliations_on_affiliate_id_and_resident_id"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "beta_invites", id: :string, force: :cascade do |t|
-    t.string "email"
+    t.string "email", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["email"], name: "index_beta_invites_on_email", unique: true
@@ -116,10 +116,10 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
 
   create_table "campaignmanager_campaigns", id: :string, force: :cascade do |t|
     t.string "resident_id", null: false
-    t.string "name", null: false
-    t.string "slug", null: false
-    t.string "page_label"
-    t.string "privacy", null: false
+    t.string "name", limit: 255, null: false
+    t.string "slug", limit: 255, null: false
+    t.string "page_label", limit: 255
+    t.string "privacy", limit: 255, null: false
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
@@ -134,11 +134,11 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "featureable_id"
     t.string "featureable_type"
     t.integer "sort_order"
-    t.string "feature_label"
+    t.string "feature_label", limit: 255
     t.text "feature_text"
-    t.string "feature_type"
-    t.string "record_type"
-    t.string "search_tags"
+    t.string "feature_type", limit: 255
+    t.string "record_type", limit: 255
+    t.string "search_tags", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["featureable_id", "featureable_type"], name: "index_campaignmanager_features_id_and_type"
@@ -157,13 +157,13 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "campaignmanager_pages", id: :string, force: :cascade do |t|
-    t.string "type", null: false
+    t.string "type", limit: 255, null: false
     t.string "campaign_id"
     t.string "parent_id"
-    t.string "name"
-    t.string "slug"
-    t.string "page_label"
-    t.string "privacy"
+    t.string "name", limit: 255
+    t.string "slug", limit: 255
+    t.string "page_label", limit: 255
+    t.string "privacy", limit: 255
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
@@ -185,12 +185,12 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "sectionable_id"
     t.string "sectionable_type"
     t.integer "sort_order"
-    t.string "header"
+    t.string "header", limit: 255
     t.text "content"
-    t.string "section_type"
-    t.string "section_style"
-    t.string "record_type"
-    t.string "search_tags"
+    t.string "section_type", limit: 255
+    t.string "section_style", limit: 255
+    t.string "record_type", limit: 255
+    t.string "search_tags", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["sectionable_id", "sectionable_type"], name: "index_campaignmanager_sections_id_and_type"
@@ -199,12 +199,12 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_ability_scores", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
     t.integer "base"
     t.integer "score"
     t.integer "modifier"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["entity_id"], name: "index_entitybuilder_ability_scores_on_entity_id"
@@ -213,42 +213,42 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_attacks", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
-    t.string "attack_type"
-    t.string "attack_range"
-    t.string "attack_ability_score"
-    t.string "attack_dice"
+    t.string "attack_type", limit: 255
+    t.string "attack_range", limit: 255
+    t.string "attack_ability_score", limit: 255
+    t.string "attack_dice", limit: 255
     t.integer "attack_bonus"
     t.integer "attack_misc_modifier"
-    t.string "damage_ability_score"
-    t.string "damage_dice"
+    t.string "damage_ability_score", limit: 255
+    t.string "damage_dice", limit: 255
     t.integer "damage_bonus"
     t.integer "damage_misc_modifier"
-    t.string "critical_range"
+    t.string "critical_range", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "proficient"
-    t.string "damage_type"
+    t.string "damage_type", limit: 255
     t.string "critical_damage_ability_score"
-    t.string "critical_damage_dice"
+    t.string "critical_damage_dice", limit: 255
     t.integer "critical_damage_bonus"
     t.integer "critical_damage_misc_modifier"
-    t.string "special_damage_ability_score"
-    t.string "special_damage_dice"
+    t.string "special_damage_ability_score", limit: 255
+    t.string "special_damage_dice", limit: 255
     t.integer "special_damage_bonus"
     t.integer "special_damage_misc_modifier"
-    t.string "special_damage_name"
+    t.string "special_damage_name", limit: 255
     t.index ["entity_id"], name: "index_entitybuilder_attacks_on_entity_id"
   end
 
   create_table "entitybuilder_base_values", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
     t.integer "value"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["entity_id"], name: "index_entitybuilder_base_values_on_entity_id"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_caster_levels", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "caster_class"
+    t.string "caster_class", limit: 255
     t.integer "level"
     t.integer "per_day"
     t.integer "bonus_per_day"
@@ -281,10 +281,10 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_class_levels", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
     t.integer "level"
-    t.string "hit_dice"
+    t.string "hit_dice", limit: 255
     t.integer "hit_points"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -294,10 +294,10 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_currencies", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name"
+    t.string "name", limit: 255
     t.text "description"
     t.decimal "weight"
-    t.integer "quantity"
+    t.bigint "quantity"
     t.boolean "carried"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -307,13 +307,13 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_defenses", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
     t.integer "base"
     t.integer "bonus"
     t.string "ability_score"
     t.integer "misc_modifier"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["entity_id"], name: "index_entitybuilder_defenses_on_entity_id"
@@ -322,7 +322,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_descriptors", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.string "description"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -420,10 +420,10 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "modifierable_type"
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "category"
-    t.string "item"
+    t.string "category", limit: 255
+    t.string "item", limit: 255
     t.integer "value"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "original_mod_type"
@@ -434,15 +434,15 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_movements", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.integer "base"
-    t.string "description"
+    t.string "description", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "bonus"
     t.string "ability_score"
     t.integer "misc_modifier"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.index ["entity_id"], name: "index_entitybuilder_movements_on_entity_id"
   end
 
@@ -461,13 +461,13 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_saving_throws", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name"
+    t.string "name", limit: 255
     t.text "description"
     t.integer "base"
     t.integer "bonus"
     t.string "ability_score"
     t.integer "misc_modifier"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "proficient"
@@ -477,14 +477,14 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_skills", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
     t.integer "bonus"
     t.boolean "class_skill"
     t.string "ability_score"
     t.integer "ranks"
     t.integer "misc_modifier"
-    t.string "dice"
+    t.string "dice", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "proficient"
@@ -496,7 +496,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "entitybuilder_trackables", id: :string, force: :cascade do |t|
     t.string "entity_id"
     t.integer "sort_order"
-    t.string "name", null: false
+    t.string "name", limit: 255, null: false
     t.text "description"
     t.integer "minimum"
     t.integer "maximum"
@@ -529,12 +529,12 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "gallery_images", id: :string, force: :cascade do |t|
-    t.string "type", null: false
+    t.string "type", limit: 255, null: false
     t.string "resident_id"
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "file_file_name"
+    t.string "file_file_name", limit: 255
     t.string "file_content_type"
     t.integer "file_file_size"
     t.datetime "file_updated_at"
@@ -547,7 +547,7 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "recipient_id"
     t.boolean "sender_deleted", default: false
     t.boolean "recipient_deleted", default: false
-    t.string "subject", null: false
+    t.string "subject", limit: 255, null: false
     t.text "body"
     t.datetime "read_at"
     t.datetime "created_at"
@@ -558,8 +558,8 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
 
   create_table "residents", id: :string, force: :cascade do |t|
     t.string "user_id", null: false
-    t.string "name", null: false
-    t.string "slug", null: false
+    t.string "name", limit: 255, null: false
+    t.string "slug", limit: 255, null: false
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
@@ -703,10 +703,10 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   create_table "storybuilder_adventures", id: :string, force: :cascade do |t|
     t.string "resident_id"
     t.string "parent_id"
-    t.string "name", null: false
-    t.string "slug", null: false
-    t.string "page_label"
-    t.string "privacy", null: false
+    t.string "name", limit: 255, null: false
+    t.string "slug", limit: 255, null: false
+    t.string "page_label", limit: 255
+    t.string "privacy", limit: 255, null: false
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
@@ -721,11 +721,11 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "featureable_id"
     t.string "featureable_type"
     t.integer "sort_order"
-    t.string "feature_label"
+    t.string "feature_label", limit: 255
     t.text "feature_text"
-    t.string "feature_type"
-    t.string "record_type"
-    t.string "search_tags"
+    t.string "feature_type", limit: 255
+    t.string "record_type", limit: 255
+    t.string "search_tags", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["featureable_id", "featureable_type"], name: "index_storybuilder_features_id_and_type"
@@ -745,8 +745,8 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "menu_itemable_id"
     t.string "menu_itemable_type"
     t.integer "sort_order"
-    t.string "item_label"
-    t.string "item_link"
+    t.string "item_label", limit: 255
+    t.string "item_link", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["menu_itemable_id", "menu_itemable_type"], name: "sb_menu_item_id_and_type"
@@ -765,12 +765,12 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "storybuilder_pages", id: :string, force: :cascade do |t|
-    t.string "type"
+    t.string "type", limit: 255
     t.string "parent_id"
-    t.string "name"
-    t.string "slug"
-    t.string "page_label"
-    t.string "privacy"
+    t.string "name", limit: 255
+    t.string "slug", limit: 255
+    t.string "page_label", limit: 255
+    t.string "privacy", limit: 255
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
@@ -788,12 +788,12 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "sectionable_id"
     t.string "sectionable_type"
     t.integer "sort_order"
-    t.string "header"
+    t.string "header", limit: 255
     t.text "content"
-    t.string "section_type"
-    t.string "section_style"
-    t.string "record_type"
-    t.string "search_tags"
+    t.string "section_type", limit: 255
+    t.string "section_style", limit: 255
+    t.string "record_type", limit: 255
+    t.string "search_tags", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["sectionable_id", "sectionable_type"], name: "index_storybuilder_sections_id_and_type"
@@ -808,8 +808,8 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "support_faqs", id: :string, force: :cascade do |t|
-    t.string "topic"
-    t.string "question", null: false
+    t.string "topic", limit: 255
+    t.string "question", limit: 255, null: false
     t.text "answer"
     t.boolean "active", null: false
     t.datetime "created_at"
@@ -817,26 +817,26 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
   end
 
   create_table "users", id: :string, force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
+    t.string "email", limit: 255, default: "", null: false
+    t.string "encrypted_password", limit: 255, default: "", null: false
+    t.string "reset_password_token", limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "confirmation_token"
+    t.string "current_sign_in_ip", limit: 255
+    t.string "last_sign_in_ip", limit: 255
+    t.string "confirmation_token", limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
+    t.string "unconfirmed_email", limit: 255
     t.integer "failed_attempts", default: 0, null: false
-    t.string "unlock_token"
+    t.string "unlock_token", limit: 255
     t.datetime "locked_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "status", default: "trial", null: false
+    t.string "status", limit: 255, default: "trial", null: false
     t.string "stripe_customer_token"
     t.string "locale", default: "en", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
@@ -857,14 +857,14 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
 
   create_table "worldbuilder_districts", id: :string, force: :cascade do |t|
     t.string "resident_id"
-    t.string "name", null: false
-    t.string "slug", null: false
+    t.string "name", limit: 255, null: false
+    t.string "slug", limit: 255, null: false
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "privacy"
-    t.string "page_label"
+    t.string "privacy", limit: 255
+    t.string "page_label", limit: 255
     t.index ["resident_id"], name: "index_worldbuilder_districts_on_resident_id"
     t.index ["slug"], name: "index_worldbuilder_districts_on_slug", unique: true
   end
@@ -873,11 +873,11 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "featureable_id"
     t.string "featureable_type"
     t.integer "sort_order"
-    t.string "feature_label"
+    t.string "feature_label", limit: 255
     t.text "feature_text"
-    t.string "feature_type"
-    t.string "record_type"
-    t.string "search_tags"
+    t.string "feature_type", limit: 255
+    t.string "record_type", limit: 255
+    t.string "search_tags", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["featureable_id", "featureable_type"], name: "index_worldbuilder_features_id_and_type"
@@ -897,20 +897,19 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "menu_itemable_id"
     t.string "menu_itemable_type"
     t.integer "sort_order"
-    t.string "item_label"
-    t.string "item_link"
+    t.string "item_label", limit: 255
+    t.string "item_link", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["menu_itemable_id", "menu_itemable_type"], name: "wb_menu_items_id_and_type"
   end
 
   create_table "worldbuilder_pages", id: :string, force: :cascade do |t|
-    t.string "type"
+    t.string "type", limit: 255
     t.string "district_id"
     t.string "parent_id"
-    t.string "name"
-    t.string "slug"
-    t.string "page_label"
+    t.string "name", limit: 255
+    t.string "slug", limit: 255
+    t.string "page_label", limit: 255
     t.string "short_description"
     t.text "full_description"
     t.datetime "created_at"
@@ -926,12 +925,12 @@ ActiveRecord::Schema.define(version: 2026_06_16_053635) do
     t.string "sectionable_id"
     t.string "sectionable_type"
     t.integer "sort_order"
-    t.string "header"
+    t.string "header", limit: 255
     t.text "content"
-    t.string "section_type"
-    t.string "section_style"
-    t.string "record_type"
-    t.string "search_tags"
+    t.string "section_type", limit: 255
+    t.string "section_style", limit: 255
+    t.string "record_type", limit: 255
+    t.string "search_tags", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["sectionable_id", "sectionable_type"], name: "index_worldbuilder_sections_id_and_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_16_000001) do
+ActiveRecord::Schema.define(version: 2026_06_16_053635) do
 
   create_table "activeplay_notables", id: :string, force: :cascade do |t|
     t.string "name"

--- a/db/seeds/5th-edition/animals.json
+++ b/db/seeds/5th-edition/animals.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Allosaurus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast (Dinosaur), Unaligned",
@@ -152,7 +152,7 @@
   },
   {
     "name": "Ankylosaurus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast (Dinosaur), Unaligned",
@@ -287,7 +287,7 @@
   },
   {
     "name": "Ape",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -448,7 +448,7 @@
   },
   {
     "name": "Archelon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast (Dinosaur), Unaligned",
@@ -594,7 +594,7 @@
   },
   {
     "name": "Baboon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -731,7 +731,7 @@
   },
   {
     "name": "Badger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -880,7 +880,7 @@
   },
   {
     "name": "Bat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -1019,7 +1019,7 @@
   },
   {
     "name": "Black Bear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -1170,7 +1170,7 @@
   },
   {
     "name": "Blood Hawk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -1316,7 +1316,7 @@
   },
   {
     "name": "Boar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -1448,7 +1448,7 @@
   },
   {
     "name": "Brown Bear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -1601,7 +1601,7 @@
   },
   {
     "name": "Camel",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -1736,7 +1736,7 @@
   },
   {
     "name": "Cat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -1884,7 +1884,7 @@
   },
   {
     "name": "Constrictor Snake",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -2035,7 +2035,7 @@
   },
   {
     "name": "Crab",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -2178,7 +2178,7 @@
   },
   {
     "name": "Crocodile",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -2324,7 +2324,7 @@
   },
   {
     "name": "Deer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -2465,7 +2465,7 @@
   },
   {
     "name": "Dire Wolf",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -2608,7 +2608,7 @@
   },
   {
     "name": "Draft Horse",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -2743,7 +2743,7 @@
   },
   {
     "name": "Eagle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -2889,7 +2889,7 @@
   },
   {
     "name": "Elephant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -3024,7 +3024,7 @@
   },
   {
     "name": "Elk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -3165,7 +3165,7 @@
   },
   {
     "name": "Flying Snake",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Monstrosity, Unaligned",
@@ -3310,7 +3310,7 @@
   },
   {
     "name": "Frog",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -3460,7 +3460,7 @@
   },
   {
     "name": "Giant Ape",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -3616,7 +3616,7 @@
   },
   {
     "name": "Giant Badger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -3766,7 +3766,7 @@
   },
   {
     "name": "Giant Bat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -3906,7 +3906,7 @@
   },
   {
     "name": "Giant Boar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -4041,7 +4041,7 @@
   },
   {
     "name": "Giant Centipede",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -4181,7 +4181,7 @@
   },
   {
     "name": "Giant Constrictor Snake",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -4327,7 +4327,7 @@
   },
   {
     "name": "Giant Crab",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -4470,7 +4470,7 @@
   },
   {
     "name": "Giant Crocodile",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -4626,7 +4626,7 @@
   },
   {
     "name": "Giant Eagle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial, Neutral Good",
@@ -4776,7 +4776,7 @@
   },
   {
     "name": "Giant Elk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Celestial, Neutral Good",
@@ -4921,7 +4921,7 @@
   },
   {
     "name": "Giant Fire Beetle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -5064,7 +5064,7 @@
   },
   {
     "name": "Giant Frog",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -5212,7 +5212,7 @@
   },
   {
     "name": "Giant Goat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -5355,7 +5355,7 @@
   },
   {
     "name": "Giant Hyena",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -5496,7 +5496,7 @@
   },
   {
     "name": "Giant Lizard",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -5636,7 +5636,7 @@
   },
   {
     "name": "Giant Octopus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -5787,7 +5787,7 @@
   },
   {
     "name": "Giant Owl",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial, Neutral",
@@ -5942,7 +5942,7 @@
   },
   {
     "name": "Giant Rat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -6088,7 +6088,7 @@
   },
   {
     "name": "Giant Scorpion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -6230,7 +6230,7 @@
   },
   {
     "name": "Giant Seahorse",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -6370,7 +6370,7 @@
   },
   {
     "name": "Giant Shark",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -6505,7 +6505,7 @@
   },
   {
     "name": "Giant Spider",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -6656,7 +6656,7 @@
   },
   {
     "name": "Giant Toad",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -6796,7 +6796,7 @@
   },
   {
     "name": "Giant Venomous Snake",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -6942,7 +6942,7 @@
   },
   {
     "name": "Giant Vulture",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Neutral Evil",
@@ -7092,7 +7092,7 @@
   },
   {
     "name": "Giant Wasp",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -7232,7 +7232,7 @@
   },
   {
     "name": "Giant Weasel",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -7388,7 +7388,7 @@
   },
   {
     "name": "Giant Wolf Spider",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -7539,7 +7539,7 @@
   },
   {
     "name": "Goat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -7685,7 +7685,7 @@
   },
   {
     "name": "Hawk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -7828,7 +7828,7 @@
   },
   {
     "name": "Hippopotamus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -7974,7 +7974,7 @@
   },
   {
     "name": "Hunter Shark",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -8109,7 +8109,7 @@
   },
   {
     "name": "Hyena",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -8250,7 +8250,7 @@
   },
   {
     "name": "Jackal",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -8393,7 +8393,7 @@
   },
   {
     "name": "Killer Whale",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -8554,7 +8554,7 @@
   },
   {
     "name": "Lizard",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -8693,7 +8693,7 @@
   },
   {
     "name": "Mammoth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Beast, Unaligned",
@@ -8828,7 +8828,7 @@
   },
   {
     "name": "Mastiff",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -8966,7 +8966,7 @@
   },
   {
     "name": "Mule",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -9101,7 +9101,7 @@
   },
   {
     "name": "Octopus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Beast, Unaligned",
@@ -9251,7 +9251,7 @@
   },
   {
     "name": "Owl",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -9399,7 +9399,7 @@
   },
   {
     "name": "Panther",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -9550,7 +9550,7 @@
   },
   {
     "name": "Piranha",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -9679,7 +9679,7 @@
   },
   {
     "name": "Plesiosaurus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast (Dinosaur), Unaligned",
@@ -9830,7 +9830,7 @@
   },
   {
     "name": "Polar Bear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Beast, Unaligned",
@@ -9985,7 +9985,7 @@
   },
   {
     "name": "Pony",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast, Unaligned",
@@ -10120,7 +10120,7 @@
   },
   {
     "name": "Pteranodon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Beast (Dinosaur), Unaligned",
@@ -10266,7 +10266,7 @@
   },
   {
     "name": "Rat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",
@@ -10411,7 +10411,7 @@
   },
   {
     "name": "Raven",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Beast, Unaligned",

--- a/db/seeds/5th-edition/backgrounds.json
+++ b/db/seeds/5th-edition/backgrounds.json
@@ -2,7 +2,7 @@
   {
     "name": "Acolyte",
     "rule_type": "Backgrounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "Criminal",
     "rule_type": "Backgrounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Sage",
     "rule_type": "Backgrounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Soldier",
     "rule_type": "Backgrounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/classes.json
+++ b/db/seeds/5th-edition/classes.json
@@ -2,7 +2,7 @@
   {
     "name": "Barbarian",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "Bard",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Cleric",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Druid",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -54,7 +54,7 @@
   {
     "name": "Fighter",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -67,7 +67,7 @@
   {
     "name": "Monk",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -80,7 +80,7 @@
   {
     "name": "Paladin",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -93,7 +93,7 @@
   {
     "name": "Ranger",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -106,7 +106,7 @@
   {
     "name": "Rogue",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -119,7 +119,7 @@
   {
     "name": "Sorcerer",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -132,7 +132,7 @@
   {
     "name": "Warlock",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -145,7 +145,7 @@
   {
     "name": "Wizard",
     "rule_type": "Class",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/conditions.json
+++ b/db/seeds/5th-edition/conditions.json
@@ -2,7 +2,7 @@
   {
     "name": "Blinded",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "Charmed",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Deafened",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Exhaustion",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -54,7 +54,7 @@
   {
     "name": "Frightened",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -67,7 +67,7 @@
   {
     "name": "Grappled",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -80,7 +80,7 @@
   {
     "name": "Incapacitated",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -93,7 +93,7 @@
   {
     "name": "Invisible",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -106,7 +106,7 @@
   {
     "name": "Paralyzed",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -119,7 +119,7 @@
   {
     "name": "Petrified",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -132,7 +132,7 @@
   {
     "name": "Poisoned",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -145,7 +145,7 @@
   {
     "name": "Prone",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -158,7 +158,7 @@
   {
     "name": "Restrained",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -171,7 +171,7 @@
   {
     "name": "Stunned",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -184,7 +184,7 @@
   {
     "name": "Unconscious",
     "rule_type": "Condition",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/creatures.json
+++ b/db/seeds/5th-edition/creatures.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Aboleth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Aberration, Lawful Evil",
@@ -152,7 +152,7 @@
   },
   {
     "name": "Air Elemental",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental, Neutral",
@@ -289,7 +289,7 @@
   },
   {
     "name": "Animated Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Construct, Unaligned",
@@ -428,7 +428,7 @@
   },
   {
     "name": "Animated Flying Sword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Construct, Unaligned",
@@ -572,7 +572,7 @@
   },
   {
     "name": "Animated Rug of Smothering",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Construct, Unaligned",
@@ -711,7 +711,7 @@
   },
   {
     "name": "Ankheg",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -840,7 +840,7 @@
   },
   {
     "name": "Assassin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -1009,7 +1009,7 @@
   },
   {
     "name": "Awakened Shrub",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Plant, Neutral",
@@ -1149,7 +1149,7 @@
   },
   {
     "name": "Awakened Tree",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Plant, Neutral",
@@ -1292,7 +1292,7 @@
   },
   {
     "name": "Axe Beak",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -1427,7 +1427,7 @@
   },
   {
     "name": "Azer Sentinel",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Elemental, Lawful Neutral",
@@ -1555,7 +1555,7 @@
   },
   {
     "name": "Balor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Fiend (Demon), Chaotic Evil",
@@ -1709,7 +1709,7 @@
   },
   {
     "name": "Bandit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -1858,7 +1858,7 @@
   },
   {
     "name": "Bandit Captain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -2018,7 +2018,7 @@
   },
   {
     "name": "Barbed Devil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend (Devil), Lawful Evil",
@@ -2202,7 +2202,7 @@
   },
   {
     "name": "Basilisk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Unaligned",
@@ -2337,7 +2337,7 @@
   },
   {
     "name": "Bearded Devil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend (Devil), Lawful Evil",
@@ -2490,7 +2490,7 @@
   },
   {
     "name": "Behir",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Monstrosity, Neutral Evil",
@@ -2655,7 +2655,7 @@
   },
   {
     "name": "Black Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Chromatic), Chaotic Evil",
@@ -2815,7 +2815,7 @@
   },
   {
     "name": "Young Black Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Chromatic), Chaotic Evil",
@@ -2975,7 +2975,7 @@
   },
   {
     "name": "Adult Black Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Chromatic), Chaotic Evil",
@@ -3135,7 +3135,7 @@
   },
   {
     "name": "Ancient Black Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Chromatic), Chaotic Evil",
@@ -3295,7 +3295,7 @@
   },
   {
     "name": "Black Pudding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Ooze, Unaligned",
@@ -3439,7 +3439,7 @@
   },
   {
     "name": "Blink Dog",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey, Lawful Good",
@@ -3585,7 +3585,7 @@
   },
   {
     "name": "Blue Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Chromatic), Lawful Evil",
@@ -3745,7 +3745,7 @@
   },
   {
     "name": "Young Blue Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Chromatic), Lawful Evil",
@@ -3905,7 +3905,7 @@
   },
   {
     "name": "Adult Blue Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Chromatic), Lawful Evil",
@@ -4065,7 +4065,7 @@
   },
   {
     "name": "Ancient Blue Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Chromatic), Lawful Evil",
@@ -4225,7 +4225,7 @@
   },
   {
     "name": "Bone Devil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Devil), Lawful Evil",
@@ -4394,7 +4394,7 @@
   },
   {
     "name": "Brass Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Metallic), Chaotic Good",
@@ -4554,7 +4554,7 @@
   },
   {
     "name": "Young Brass Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Metallic), Chaotic Good",
@@ -4719,7 +4719,7 @@
   },
   {
     "name": "Adult Brass Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Metallic), Chaotic Good",
@@ -4889,7 +4889,7 @@
   },
   {
     "name": "Ancient Brass Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Metallic), Chaotic Good",
@@ -5059,7 +5059,7 @@
   },
   {
     "name": "Bronze Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Metallic), Lawful Good",
@@ -5219,7 +5219,7 @@
   },
   {
     "name": "Young Bronze Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Metallic), Lawful Good",
@@ -5384,7 +5384,7 @@
   },
   {
     "name": "Adult Bronze Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Metallic), Lawful Good",
@@ -5549,7 +5549,7 @@
   },
   {
     "name": "Ancient Bronze Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Metallic), Lawful Good",
@@ -5714,7 +5714,7 @@
   },
   {
     "name": "Bugbear Stalker",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey (Goblinoid), Chaotic Evil",
@@ -5853,7 +5853,7 @@
   },
   {
     "name": "Bugbear Warrior",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey (Goblinoid), Chaotic Evil",
@@ -6003,7 +6003,7 @@
   },
   {
     "name": "Bulette",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -6149,7 +6149,7 @@
   },
   {
     "name": "Centaur Trooper",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fey, Neutral Good",
@@ -6299,7 +6299,7 @@
   },
   {
     "name": "Chain Devil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend (Devil), Lawful Evil",
@@ -6442,7 +6442,7 @@
   },
   {
     "name": "Chimera",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Chaotic Evil",
@@ -6608,7 +6608,7 @@
   },
   {
     "name": "Chuul",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Aberration, Chaotic Evil",
@@ -6758,7 +6758,7 @@
   },
   {
     "name": "Clay Golem",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Construct, Unaligned",
@@ -6901,7 +6901,7 @@
   },
   {
     "name": "Cloaker",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Aberration, Chaotic Neutral",
@@ -7061,7 +7061,7 @@
   },
   {
     "name": "Cloud Giant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Giant, Neutral",
@@ -7222,7 +7222,7 @@
   },
   {
     "name": "Cockatrice",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Monstrosity, Unaligned",
@@ -7366,7 +7366,7 @@
   },
   {
     "name": "Commoner",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -7505,7 +7505,7 @@
   },
   {
     "name": "Copper Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Metallic), Chaotic Good",
@@ -7665,7 +7665,7 @@
   },
   {
     "name": "Young Copper Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Metallic), Chaotic Good",
@@ -7830,7 +7830,7 @@
   },
   {
     "name": "Adult Copper Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Metallic), Chaotic Good",
@@ -7995,7 +7995,7 @@
   },
   {
     "name": "Ancient Copper Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Metallic), Chaotic Good",
@@ -8160,7 +8160,7 @@
   },
   {
     "name": "Couatl",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Celestial, Lawful Good",
@@ -8308,7 +8308,7 @@
   },
   {
     "name": "Swarm of Crawling Claws",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Swarm of Tiny Undead, Neutral Evil",
@@ -8456,7 +8456,7 @@
   },
   {
     "name": "Cultist",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -8606,7 +8606,7 @@
   },
   {
     "name": "Cultist Fanatic",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -8750,7 +8750,7 @@
   },
   {
     "name": "Darkmantle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Aberration, Unaligned",
@@ -8896,7 +8896,7 @@
   },
   {
     "name": "Death Dog",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Neutral Evil",
@@ -9046,7 +9046,7 @@
   },
   {
     "name": "Deva",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Celestial (Angel), Lawful Good",
@@ -9205,7 +9205,7 @@
   },
   {
     "name": "Djinni",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental (Genie), Neutral",
@@ -9338,7 +9338,7 @@
   },
   {
     "name": "Doppelganger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Neutral",
@@ -9477,7 +9477,7 @@
   },
   {
     "name": "Dragon Turtle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon, Neutral",
@@ -9631,7 +9631,7 @@
   },
   {
     "name": "Dretch",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Fiend (Demon), Chaotic Evil",
@@ -9774,7 +9774,7 @@
   },
   {
     "name": "Drider",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Chaotic Evil",
@@ -9935,7 +9935,7 @@
   },
   {
     "name": "Druid",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid (Druid), Neutral",
@@ -10100,7 +10100,7 @@
   },
   {
     "name": "Dryad",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey, Neutral",
@@ -10256,7 +10256,7 @@
   },
   {
     "name": "Earth Elemental",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental, Neutral",
@@ -10414,7 +10414,7 @@
   },
   {
     "name": "Efreeti",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental (Genie), Neutral",
@@ -10558,7 +10558,7 @@
   },
   {
     "name": "Erinyes",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend (Devil), Lawful Evil",
@@ -10706,7 +10706,7 @@
   },
   {
     "name": "Ettercap",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Neutral Evil",
@@ -10872,7 +10872,7 @@
   },
   {
     "name": "Ettin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Giant, Chaotic Evil",
@@ -11031,7 +11031,7 @@
   },
   {
     "name": "Fire Elemental",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental, Neutral",
@@ -11174,7 +11174,7 @@
   },
   {
     "name": "Fire Giant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Giant, Lawful Evil",
@@ -11324,7 +11324,7 @@
   },
   {
     "name": "Flesh Golem",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Construct, Neutral",
@@ -11463,7 +11463,7 @@
   },
   {
     "name": "Frost Giant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Giant, Neutral Evil",
@@ -11613,7 +11613,7 @@
   },
   {
     "name": "Shrieker Fungus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Plant, Unaligned",
@@ -11741,7 +11741,7 @@
   },
   {
     "name": "Violet Fungus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Plant, Unaligned",
@@ -11880,7 +11880,7 @@
   },
   {
     "name": "Gargoyle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Elemental, Chaotic Evil",
@@ -12030,7 +12030,7 @@
   },
   {
     "name": "Gelatinous Cube",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Ooze, Unaligned",
@@ -12169,7 +12169,7 @@
   },
   {
     "name": "Ghast",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Chaotic Evil",
@@ -12322,7 +12322,7 @@
   },
   {
     "name": "Ghost",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Neutral",
@@ -12459,7 +12459,7 @@
   },
   {
     "name": "Ghoul",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Chaotic Evil",
@@ -12608,7 +12608,7 @@
   },
   {
     "name": "Gibbering Mouther",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Aberration, Chaotic Neutral",
@@ -12749,7 +12749,7 @@
   },
   {
     "name": "Glabrezu",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Demon), Chaotic Evil",
@@ -12903,7 +12903,7 @@
   },
   {
     "name": "Gladiator",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -13042,7 +13042,7 @@
   },
   {
     "name": "Gnoll Warrior",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Chaotic Evil",
@@ -13177,7 +13177,7 @@
   },
   {
     "name": "Goblin Minion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Fey (Goblinoid), Chaotic Neutral",
@@ -13311,7 +13311,7 @@
   },
   {
     "name": "Goblin Warrior",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Fey (Goblinoid), Chaotic Neutral",
@@ -13456,7 +13456,7 @@
   },
   {
     "name": "Goblin Boss",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Fey (Goblinoid), Chaotic Neutral",
@@ -13601,7 +13601,7 @@
   },
   {
     "name": "Gold Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Metallic), Lawful Good",
@@ -13761,7 +13761,7 @@
   },
   {
     "name": "Young Gold Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Metallic), Lawful Good",
@@ -13931,7 +13931,7 @@
   },
   {
     "name": "Adult Gold Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Metallic), Lawful Good",
@@ -14101,7 +14101,7 @@
   },
   {
     "name": "Ancient Gold Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Metallic), Lawful Good",
@@ -14260,7 +14260,7 @@
   },
   {
     "name": "Gorgon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Construct, Unaligned",
@@ -14405,7 +14405,7 @@
   },
   {
     "name": "Gray Ooze",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Ooze, Unaligned",
@@ -14559,7 +14559,7 @@
   },
   {
     "name": "Green Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Chromatic), Lawful Evil",
@@ -14719,7 +14719,7 @@
   },
   {
     "name": "Young Green Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Chromatic), Lawful Evil",
@@ -14884,7 +14884,7 @@
   },
   {
     "name": "Adult Green Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Chromatic), Lawful Evil",
@@ -15054,7 +15054,7 @@
   },
   {
     "name": "Ancient Green Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Chromatic), Lawful Evil",
@@ -15224,7 +15224,7 @@
   },
   {
     "name": "Green Hag",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey, Neutral Evil",
@@ -15385,7 +15385,7 @@
   },
   {
     "name": "Grick",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Aberration, Unaligned",
@@ -15541,7 +15541,7 @@
   },
   {
     "name": "Griffon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -15684,7 +15684,7 @@
   },
   {
     "name": "Grimlock",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Aberration, Neutral Evil",
@@ -15840,7 +15840,7 @@
   },
   {
     "name": "Guardian Naga",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial, Lawful Good",
@@ -16005,7 +16005,7 @@
   },
   {
     "name": "Guard",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -16139,7 +16139,7 @@
   },
   {
     "name": "Guard Captain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -16289,7 +16289,7 @@
   },
   {
     "name": "Half-Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon, Neutral",
@@ -16444,7 +16444,7 @@
   },
   {
     "name": "Harpy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Chaotic Evil",
@@ -16584,7 +16584,7 @@
   },
   {
     "name": "Hell Hound",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Lawful Evil",
@@ -16729,7 +16729,7 @@
   },
   {
     "name": "Hezrou",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Demon), Chaotic Evil",
@@ -16872,7 +16872,7 @@
   },
   {
     "name": "Hill Giant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Giant, Chaotic Evil",
@@ -17023,7 +17023,7 @@
   },
   {
     "name": "Hippogriff",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -17169,7 +17169,7 @@
   },
   {
     "name": "Hobgoblin Warrior",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey (Goblinoid), Lawful Evil",
@@ -17308,7 +17308,7 @@
   },
   {
     "name": "Hobgoblin Captain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey (Goblinoid), Lawful Evil",
@@ -17457,7 +17457,7 @@
   },
   {
     "name": "Homunculus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Construct, Neutral",
@@ -17600,7 +17600,7 @@
   },
   {
     "name": "Horned Devil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Devil), Lawful Evil",
@@ -17758,7 +17758,7 @@
   },
   {
     "name": "Hydra",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Monstrosity, Unaligned",
@@ -17908,7 +17908,7 @@
   },
   {
     "name": "Ice Devil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Devil), Lawful Evil",
@@ -18063,7 +18063,7 @@
   },
   {
     "name": "Imp",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Fiend (Devil), Lawful Evil",
@@ -18227,7 +18227,7 @@
   },
   {
     "name": "Incubus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Neutral Evil",
@@ -18386,7 +18386,7 @@
   },
   {
     "name": "Invisible Stalker",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental, Neutral",
@@ -18575,7 +18575,7 @@
   },
   {
     "name": "Kraken",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Monstrosity (Titan), Chaotic Evil",
@@ -18730,7 +18730,7 @@
   },
   {
     "name": "Lamia",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend, Chaotic Evil",
@@ -18881,7 +18881,7 @@
   },
   {
     "name": "Lemure",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend (Devil), Lawful Evil",
@@ -19024,7 +19024,7 @@
   },
   {
     "name": "Lich",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead (Wizard), Neutral Evil",
@@ -19192,7 +19192,7 @@
   },
   {
     "name": "Mage",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid (Wizard), Neutral",
@@ -19336,7 +19336,7 @@
   },
   {
     "name": "Archmage",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid (Wizard), Neutral",
@@ -19484,7 +19484,7 @@
   },
   {
     "name": "Magmin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Elemental, Chaotic Neutral",
@@ -19623,7 +19623,7 @@
   },
   {
     "name": "Manticore",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Lawful Evil",
@@ -19763,7 +19763,7 @@
   },
   {
     "name": "Marilith",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Demon), Chaotic Evil",
@@ -19917,7 +19917,7 @@
   },
   {
     "name": "Medusa",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Lawful Evil",
@@ -20088,7 +20088,7 @@
   },
   {
     "name": "Dust Mephit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Elemental, Neutral Evil",
@@ -20247,7 +20247,7 @@
   },
   {
     "name": "Ice Mephit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Elemental, Neutral Evil",
@@ -20402,7 +20402,7 @@
   },
   {
     "name": "Magma Mephit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Elemental, Neutral Evil",
@@ -20556,7 +20556,7 @@
   },
   {
     "name": "Steam Mephit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Elemental, Neutral Evil",
@@ -20706,7 +20706,7 @@
   },
   {
     "name": "Merfolk Skirmisher",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Elemental, Neutral",
@@ -20835,7 +20835,7 @@
   },
   {
     "name": "Merrow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Chaotic Evil",
@@ -20985,7 +20985,7 @@
   },
   {
     "name": "Mimic",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Neutral",
@@ -21130,7 +21130,7 @@
   },
   {
     "name": "Minotaur of Baphomet",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Chaotic Evil",
@@ -21276,7 +21276,7 @@
   },
   {
     "name": "Mummy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Undead, Lawful Evil",
@@ -21419,7 +21419,7 @@
   },
   {
     "name": "Mummy Lord",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Undead (Cleric), Lawful Evil",
@@ -21588,7 +21588,7 @@
   },
   {
     "name": "Nalfeshnee",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Demon), Chaotic Evil",
@@ -21736,7 +21736,7 @@
   },
   {
     "name": "Night Hag",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Neutral Evil",
@@ -21900,7 +21900,7 @@
   },
   {
     "name": "Nightmare",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend, Neutral Evil",
@@ -22044,7 +22044,7 @@
   },
   {
     "name": "Noble",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -22199,7 +22199,7 @@
   },
   {
     "name": "Ochre Jelly",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Ooze, Unaligned",
@@ -22347,7 +22347,7 @@
   },
   {
     "name": "Ogre",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Giant, Chaotic Evil",
@@ -22486,7 +22486,7 @@
   },
   {
     "name": "Oni",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend, Lawful Evil",
@@ -22646,7 +22646,7 @@
   },
   {
     "name": "Otyugh",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Aberration, Neutral",
@@ -22791,7 +22791,7 @@
   },
   {
     "name": "Owlbear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -22943,7 +22943,7 @@
   },
   {
     "name": "Phase Spider",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Unaligned",
@@ -23089,7 +23089,7 @@
   },
   {
     "name": "Pirate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -23217,7 +23217,7 @@
   },
   {
     "name": "Pirate Captain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -23377,7 +23377,7 @@
   },
   {
     "name": "Pit Fiend",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Devil), Lawful Evil",
@@ -23556,7 +23556,7 @@
   },
   {
     "name": "Planetar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial (Angel), Lawful Good",
@@ -23699,7 +23699,7 @@
   },
   {
     "name": "Priest Acolyte",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid (Cleric), Neutral",
@@ -23849,7 +23849,7 @@
   },
   {
     "name": "Priest",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid (Cleric), Neutral",
@@ -24004,7 +24004,7 @@
   },
   {
     "name": "Pseudodragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Dragon, Neutral Good",
@@ -24155,7 +24155,7 @@
   },
   {
     "name": "Purple Worm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Monstrosity, Unaligned",
@@ -24305,7 +24305,7 @@
   },
   {
     "name": "Quasit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Fiend (Demon), Chaotic Evil",
@@ -24454,7 +24454,7 @@
   },
   {
     "name": "Rakshasa",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Lawful Evil",
@@ -24613,7 +24613,7 @@
   },
   {
     "name": "Red Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Chromatic), Chaotic Evil",
@@ -24773,7 +24773,7 @@
   },
   {
     "name": "Young Red Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Chromatic), Chaotic Evil",
@@ -24933,7 +24933,7 @@
   },
   {
     "name": "Adult Red Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Chromatic), Chaotic Evil",
@@ -25093,7 +25093,7 @@
   },
   {
     "name": "Ancient Red Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Chromatic), Chaotic Evil",
@@ -25253,7 +25253,7 @@
   },
   {
     "name": "Remorhaz",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Monstrosity, Unaligned",
@@ -25397,7 +25397,7 @@
   },
   {
     "name": "Roc",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Monstrosity, Unaligned",
@@ -25553,7 +25553,7 @@
   },
   {
     "name": "Roper",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Aberration, Neutral Evil",
@@ -25711,7 +25711,7 @@
   },
   {
     "name": "Rust Monster",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Monstrosity, Unaligned",
@@ -25846,7 +25846,7 @@
   },
   {
     "name": "Sahuagin Warrior",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Lawful Evil",
@@ -25996,7 +25996,7 @@
   },
   {
     "name": "Salamander",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental, Neutral Evil",
@@ -26133,7 +26133,7 @@
   },
   {
     "name": "Satyr",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey, Chaotic Neutral",
@@ -26284,7 +26284,7 @@
   },
   {
     "name": "Scout",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -26444,7 +26444,7 @@
   },
   {
     "name": "Sea Hag",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fey, Chaotic Evil",
@@ -26584,7 +26584,7 @@
   },
   {
     "name": "Shadow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Chaotic Evil",
@@ -26737,7 +26737,7 @@
   },
   {
     "name": "Shambling Mound",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Plant, Unaligned",
@@ -26880,7 +26880,7 @@
   },
   {
     "name": "Shield Guardian",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Construct, Unaligned",
@@ -27019,7 +27019,7 @@
   },
   {
     "name": "Silver Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Metallic), Lawful Good",
@@ -27174,7 +27174,7 @@
   },
   {
     "name": "Young Silver Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Metallic), Lawful Good",
@@ -27334,7 +27334,7 @@
   },
   {
     "name": "Adult Silver Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Metallic), Lawful Good",
@@ -27494,7 +27494,7 @@
   },
   {
     "name": "Ancient Silver Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Metallic), Lawful Good",
@@ -27654,7 +27654,7 @@
   },
   {
     "name": "Skeleton",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Lawful Evil",
@@ -27811,7 +27811,7 @@
   },
   {
     "name": "Warhorse Skeleton",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Undead, Lawful Evil",
@@ -27954,7 +27954,7 @@
   },
   {
     "name": "Minotaur Skeleton",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Undead, Lawful Evil",
@@ -28107,7 +28107,7 @@
   },
   {
     "name": "Solar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial (Angel), Lawful Good",
@@ -28246,7 +28246,7 @@
   },
   {
     "name": "Specter",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Chaotic Evil",
@@ -28394,7 +28394,7 @@
   },
   {
     "name": "Sphinx of Wonder",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Celestial, Lawful Good",
@@ -28554,7 +28554,7 @@
   },
   {
     "name": "Sphinx of Lore",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial, Lawful Neutral",
@@ -28723,7 +28723,7 @@
   },
   {
     "name": "Sphinx of Valor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial, Lawful Neutral",
@@ -28887,7 +28887,7 @@
   },
   {
     "name": "Spirit Naga",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend, Chaotic Evil",
@@ -29036,7 +29036,7 @@
   },
   {
     "name": "Sprite",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Fey, Neutral Good",
@@ -29196,7 +29196,7 @@
   },
   {
     "name": "Spy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -29381,7 +29381,7 @@
   },
   {
     "name": "Stirge",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Tiny Monstrosity, Unaligned",
@@ -29521,7 +29521,7 @@
   },
   {
     "name": "Stone Giant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Giant, Neutral",
@@ -29682,7 +29682,7 @@
   },
   {
     "name": "Stone Golem",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Construct, Unaligned",
@@ -29831,7 +29831,7 @@
   },
   {
     "name": "Storm Giant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Giant, Chaotic Good",
@@ -29994,7 +29994,7 @@
   },
   {
     "name": "Succubus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Fiend, Neutral Evil",
@@ -30164,7 +30164,7 @@
   },
   {
     "name": "Tarrasque",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Monstrosity (Titan), Unaligned",
@@ -30343,7 +30343,7 @@
   },
   {
     "name": "Tough",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -30492,7 +30492,7 @@
   },
   {
     "name": "Tough Boss",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -30641,7 +30641,7 @@
   },
   {
     "name": "Treant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Plant, Chaotic Good",
@@ -30784,7 +30784,7 @@
   },
   {
     "name": "Troll",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Giant, Chaotic Evil",
@@ -30925,7 +30925,7 @@
   },
   {
     "name": "Troll Limb",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Small Giant, Chaotic Evil",
@@ -31060,7 +31060,7 @@
   },
   {
     "name": "Unicorn",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Celestial, Lawful Good",
@@ -31209,7 +31209,7 @@
   },
   {
     "name": "Vampire Familiar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral Evil",
@@ -31366,7 +31366,7 @@
   },
   {
     "name": "Vampire Spawn",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Undead, Neutral Evil",
@@ -31513,7 +31513,7 @@
   },
   {
     "name": "Vampire",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Undead, Lawful Evil",
@@ -31668,7 +31668,7 @@
   },
   {
     "name": "Vrock",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fiend (Demon), Chaotic Evil",
@@ -31816,7 +31816,7 @@
   },
   {
     "name": "Warrior Veteran",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Humanoid, Neutral",
@@ -31976,7 +31976,7 @@
   },
   {
     "name": "Water Elemental",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Elemental, Neutral",
@@ -32124,7 +32124,7 @@
   },
   {
     "name": "Werebear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Monstrosity (Lycanthrope), Neutral Good",
@@ -32279,7 +32279,7 @@
   },
   {
     "name": "Wereboar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Monstrosity (Lycanthrope), Neutral Evil",
@@ -32434,7 +32434,7 @@
   },
   {
     "name": "Wererat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Monstrosity (Lycanthrope), Lawful Evil",
@@ -32599,7 +32599,7 @@
   },
   {
     "name": "Weretiger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Monstrosity (Lycanthrope), Neutral",
@@ -32769,7 +32769,7 @@
   },
   {
     "name": "Werewolf",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Monstrosity (Lycanthrope), Chaotic Evil",
@@ -32939,7 +32939,7 @@
   },
   {
     "name": "White Dragon Wyrmling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Dragon (Chromatic), Chaotic Evil",
@@ -33104,7 +33104,7 @@
   },
   {
     "name": "Young White Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon (Chromatic), Chaotic Evil",
@@ -33269,7 +33269,7 @@
   },
   {
     "name": "Adult White Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Huge Dragon (Chromatic), Chaotic Evil",
@@ -33434,7 +33434,7 @@
   },
   {
     "name": "Ancient White Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Gargantuan Dragon (Chromatic), Chaotic Evil",
@@ -33619,7 +33619,7 @@
   },
   {
     "name": "Winter Wolf",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Monstrosity, Neutral Evil",
@@ -33766,7 +33766,7 @@
   },
   {
     "name": "Worg",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Fey, Neutral Evil",
@@ -33907,7 +33907,7 @@
   },
   {
     "name": "Wraith",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium or Small Undead, Neutral Evil",
@@ -34055,7 +34055,7 @@
   },
   {
     "name": "Wyvern",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Large Dragon, Unaligned",
@@ -34211,7 +34211,7 @@
   },
   {
     "name": "Xorn",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Elemental, Neutral",
@@ -34376,7 +34376,7 @@
   },
   {
     "name": "Zombie",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "publisher": "Wizards of the Coast LLC",
     "source": "SRD 5.2.1",
     "short_description": "Medium Undead, Neutral Evil",

--- a/db/seeds/5th-edition/feats.json
+++ b/db/seeds/5th-edition/feats.json
@@ -2,7 +2,7 @@
   {
     "name": "Alert",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "Magic Initiate",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Savage Attacker",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Skilled",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -54,7 +54,7 @@
   {
     "name": "Ability Score Improvement",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -67,7 +67,7 @@
   {
     "name": "Grappler",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -80,7 +80,7 @@
   {
     "name": "Archery",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -93,7 +93,7 @@
   {
     "name": "Defense",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -106,7 +106,7 @@
   {
     "name": "Great Weapon Fighting",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -119,7 +119,7 @@
   {
     "name": "Two-Weapon Fighting",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -132,7 +132,7 @@
   {
     "name": "Boon of Combat Prowess",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -145,7 +145,7 @@
   {
     "name": "Boon of Dimensional Travel",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -158,7 +158,7 @@
   {
     "name": "Boon of Fate",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -171,7 +171,7 @@
   {
     "name": "Boon of Irresistible Offense",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -184,7 +184,7 @@
   {
     "name": "Boon of Spell Recall",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -197,7 +197,7 @@
   {
     "name": "Boon of the Night Spirit",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -210,7 +210,7 @@
   {
     "name": "Boon of Truesight",
     "rule_type": "Feat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/items.json
+++ b/db/seeds/5th-edition/items.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Club",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -11,7 +11,7 @@
   },
   {
     "name": "Dagger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -21,7 +21,7 @@
   },
   {
     "name": "Greatclub",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -31,7 +31,7 @@
   },
   {
     "name": "Handaxe",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   },
   {
     "name": "Javelin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -51,7 +51,7 @@
   },
   {
     "name": "Light Hammer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -61,7 +61,7 @@
   },
   {
     "name": "Mace",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -71,7 +71,7 @@
   },
   {
     "name": "Quarterstaff",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -81,7 +81,7 @@
   },
   {
     "name": "Sickle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -91,7 +91,7 @@
   },
   {
     "name": "Spear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -101,7 +101,7 @@
   },
   {
     "name": "Dart",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -111,7 +111,7 @@
   },
   {
     "name": "Light Crossbow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -121,7 +121,7 @@
   },
   {
     "name": "Shortbow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -131,7 +131,7 @@
   },
   {
     "name": "Sling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -141,7 +141,7 @@
   },
   {
     "name": "Battleaxe",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -151,7 +151,7 @@
   },
   {
     "name": "Flail",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -161,7 +161,7 @@
   },
   {
     "name": "Glaive",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -171,7 +171,7 @@
   },
   {
     "name": "Greataxe",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -181,7 +181,7 @@
   },
   {
     "name": "Greatsword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -191,7 +191,7 @@
   },
   {
     "name": "Halberd",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -201,7 +201,7 @@
   },
   {
     "name": "Lance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -211,7 +211,7 @@
   },
   {
     "name": "Longsword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -221,7 +221,7 @@
   },
   {
     "name": "Maul",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -231,7 +231,7 @@
   },
   {
     "name": "Morningstar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -241,7 +241,7 @@
   },
   {
     "name": "Pike",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -251,7 +251,7 @@
   },
   {
     "name": "Rapier",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -261,7 +261,7 @@
   },
   {
     "name": "Scimitar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -271,7 +271,7 @@
   },
   {
     "name": "Shortsword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -281,7 +281,7 @@
   },
   {
     "name": "Trident",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -291,7 +291,7 @@
   },
   {
     "name": "Warhammer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -301,7 +301,7 @@
   },
   {
     "name": "War Pick",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -311,7 +311,7 @@
   },
   {
     "name": "Whip",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -321,7 +321,7 @@
   },
   {
     "name": "Blowgun",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -331,7 +331,7 @@
   },
   {
     "name": "Hand Crossbow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -341,7 +341,7 @@
   },
   {
     "name": "Heavy Crossbow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -351,7 +351,7 @@
   },
   {
     "name": "Longbow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -361,7 +361,7 @@
   },
   {
     "name": "Musket",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -371,7 +371,7 @@
   },
   {
     "name": "Pistol",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -381,7 +381,7 @@
   },
   {
     "name": "Padded Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -391,7 +391,7 @@
   },
   {
     "name": "Leather Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -401,7 +401,7 @@
   },
   {
     "name": "Studded Leather Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -411,7 +411,7 @@
   },
   {
     "name": "Hide Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -421,7 +421,7 @@
   },
   {
     "name": "Chain Shirt",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -431,7 +431,7 @@
   },
   {
     "name": "Scale Mail",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -441,7 +441,7 @@
   },
   {
     "name": "Breastplate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -451,7 +451,7 @@
   },
   {
     "name": "Half Plate Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -461,7 +461,7 @@
   },
   {
     "name": "Ring Mail",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -471,7 +471,7 @@
   },
   {
     "name": "Chain Mail",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -481,7 +481,7 @@
   },
   {
     "name": "Splint Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -491,7 +491,7 @@
   },
   {
     "name": "Plate Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -501,7 +501,7 @@
   },
   {
     "name": "Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -511,7 +511,7 @@
   },
   {
     "name": "Alchemist's Supplies",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -521,7 +521,7 @@
   },
   {
     "name": "Brewer's Supplies",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -531,7 +531,7 @@
   },
   {
     "name": "Calligrapher's Supplies",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -541,7 +541,7 @@
   },
   {
     "name": "Carpenter's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -551,7 +551,7 @@
   },
   {
     "name": "Cartographer's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -561,7 +561,7 @@
   },
   {
     "name": "Cobbler's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -571,7 +571,7 @@
   },
   {
     "name": "Cook's Utensils",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -581,7 +581,7 @@
   },
   {
     "name": "Glassblower's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -591,7 +591,7 @@
   },
   {
     "name": "Jeweler's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -601,7 +601,7 @@
   },
   {
     "name": "Leatherworker's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -611,7 +611,7 @@
   },
   {
     "name": "Mason's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -621,7 +621,7 @@
   },
   {
     "name": "Painter's Supplies",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -631,7 +631,7 @@
   },
   {
     "name": "Potter's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -641,7 +641,7 @@
   },
   {
     "name": "Smith's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -651,7 +651,7 @@
   },
   {
     "name": "Tinker's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -661,7 +661,7 @@
   },
   {
     "name": "Weaver's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -671,7 +671,7 @@
   },
   {
     "name": "Woodcarver's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -681,7 +681,7 @@
   },
   {
     "name": "Disguise Kit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -691,7 +691,7 @@
   },
   {
     "name": "Forgery Kit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -701,7 +701,7 @@
   },
   {
     "name": "Gaming Set",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -711,7 +711,7 @@
   },
   {
     "name": "Herbalism Kit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -721,7 +721,7 @@
   },
   {
     "name": "Musical Instrument",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -731,7 +731,7 @@
   },
   {
     "name": "Navigator's Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -741,7 +741,7 @@
   },
   {
     "name": "Poisoner's Kit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -751,7 +751,7 @@
   },
   {
     "name": "Thieves' Tools",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Tool",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -761,7 +761,7 @@
   },
   {
     "name": "Acid",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -771,7 +771,7 @@
   },
   {
     "name": "Alchemist's Fire",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -781,7 +781,7 @@
   },
   {
     "name": "Antitoxin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -791,7 +791,7 @@
   },
   {
     "name": "Arcane Focus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -801,7 +801,7 @@
   },
   {
     "name": "Backpack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -811,7 +811,7 @@
   },
   {
     "name": "Ball Bearings",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -821,7 +821,7 @@
   },
   {
     "name": "Barrel",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -831,7 +831,7 @@
   },
   {
     "name": "Basket",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -841,7 +841,7 @@
   },
   {
     "name": "Bedroll",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -851,7 +851,7 @@
   },
   {
     "name": "Bell",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -861,7 +861,7 @@
   },
   {
     "name": "Blanket",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -871,7 +871,7 @@
   },
   {
     "name": "Block and Tackle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -881,7 +881,7 @@
   },
   {
     "name": "Book",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -891,7 +891,7 @@
   },
   {
     "name": "Bottle, Glass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -901,7 +901,7 @@
   },
   {
     "name": "Bucket",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -911,7 +911,7 @@
   },
   {
     "name": "Burglar's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -921,7 +921,7 @@
   },
   {
     "name": "Caltrops",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -931,7 +931,7 @@
   },
   {
     "name": "Candle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -941,7 +941,7 @@
   },
   {
     "name": "Case, Crossbow Bolt",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -951,7 +951,7 @@
   },
   {
     "name": "Case, Map or Scroll",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -961,7 +961,7 @@
   },
   {
     "name": "Chain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -971,7 +971,7 @@
   },
   {
     "name": "Chest",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -981,7 +981,7 @@
   },
   {
     "name": "Climber's Kit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -991,7 +991,7 @@
   },
   {
     "name": "Clothes, Fine",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1001,7 +1001,7 @@
   },
   {
     "name": "Clothes, Traveler's",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1011,7 +1011,7 @@
   },
   {
     "name": "Component Pouch",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1021,7 +1021,7 @@
   },
   {
     "name": "Costume",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1031,7 +1031,7 @@
   },
   {
     "name": "Crowbar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1041,7 +1041,7 @@
   },
   {
     "name": "Diplomat's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1051,7 +1051,7 @@
   },
   {
     "name": "Druidic Focus",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1061,7 +1061,7 @@
   },
   {
     "name": "Dungeoneer's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1071,7 +1071,7 @@
   },
   {
     "name": "Entertainer's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1081,7 +1081,7 @@
   },
   {
     "name": "Explorer's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1091,7 +1091,7 @@
   },
   {
     "name": "Flask",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1101,7 +1101,7 @@
   },
   {
     "name": "Grappling Hook",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1111,7 +1111,7 @@
   },
   {
     "name": "Healer's Kit",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1121,7 +1121,7 @@
   },
   {
     "name": "Holy Symbol",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1131,7 +1131,7 @@
   },
   {
     "name": "Holy Water",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1141,7 +1141,7 @@
   },
   {
     "name": "Hunting Trap",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1151,7 +1151,7 @@
   },
   {
     "name": "Ink",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1161,7 +1161,7 @@
   },
   {
     "name": "Ink Pen",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1171,7 +1171,7 @@
   },
   {
     "name": "Jug",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1181,7 +1181,7 @@
   },
   {
     "name": "Ladder",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1191,7 +1191,7 @@
   },
   {
     "name": "Lamp",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1201,7 +1201,7 @@
   },
   {
     "name": "Lantern, Bullseye",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1211,7 +1211,7 @@
   },
   {
     "name": "Lantern, Hooded",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1221,7 +1221,7 @@
   },
   {
     "name": "Lock",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1231,7 +1231,7 @@
   },
   {
     "name": "Magnifying Glass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1241,7 +1241,7 @@
   },
   {
     "name": "Manacles",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1251,7 +1251,7 @@
   },
   {
     "name": "Map",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1261,7 +1261,7 @@
   },
   {
     "name": "Mirror",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1271,7 +1271,7 @@
   },
   {
     "name": "Net",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1281,7 +1281,7 @@
   },
   {
     "name": "Oil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1291,7 +1291,7 @@
   },
   {
     "name": "Paper",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1301,7 +1301,7 @@
   },
   {
     "name": "Parchment",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1311,7 +1311,7 @@
   },
   {
     "name": "Perfume",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1321,7 +1321,7 @@
   },
   {
     "name": "Poison, Basic",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1331,7 +1331,7 @@
   },
   {
     "name": "Pole",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1341,7 +1341,7 @@
   },
   {
     "name": "Pot, Iron",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1351,7 +1351,7 @@
   },
   {
     "name": "Pouch",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1361,7 +1361,7 @@
   },
   {
     "name": "Priest's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1371,7 +1371,7 @@
   },
   {
     "name": "Quiver",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1381,7 +1381,7 @@
   },
   {
     "name": "Ram, Portable",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1391,7 +1391,7 @@
   },
   {
     "name": "Rations",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1401,7 +1401,7 @@
   },
   {
     "name": "Robe",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1411,7 +1411,7 @@
   },
   {
     "name": "Rope",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1421,7 +1421,7 @@
   },
   {
     "name": "Sack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1431,7 +1431,7 @@
   },
   {
     "name": "Scholar's Pack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1441,7 +1441,7 @@
   },
   {
     "name": "Shovel",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1451,7 +1451,7 @@
   },
   {
     "name": "Signal Whistle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1461,7 +1461,7 @@
   },
   {
     "name": "Spikes, Iron",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1471,7 +1471,7 @@
   },
   {
     "name": "Spyglass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1481,7 +1481,7 @@
   },
   {
     "name": "String",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1491,7 +1491,7 @@
   },
   {
     "name": "Tent",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1501,7 +1501,7 @@
   },
   {
     "name": "Tinderbox",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1511,7 +1511,7 @@
   },
   {
     "name": "Torch",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1521,7 +1521,7 @@
   },
   {
     "name": "Vial",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1531,7 +1531,7 @@
   },
   {
     "name": "Waterskin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1541,7 +1541,7 @@
   },
   {
     "name": "Arrows",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1551,7 +1551,7 @@
   },
   {
     "name": "Bolts",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1561,7 +1561,7 @@
   },
   {
     "name": "Bullets, Firearm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1571,7 +1571,7 @@
   },
   {
     "name": "Bullets, Sling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1581,7 +1581,7 @@
   },
   {
     "name": "Needles",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1591,7 +1591,7 @@
   },
   {
     "name": "Spell Scroll",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Adventuring Gear",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1601,7 +1601,7 @@
   },
   {
     "name": "Camel",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1611,7 +1611,7 @@
   },
   {
     "name": "Elephant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1621,7 +1621,7 @@
   },
   {
     "name": "Horse, Draft",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1631,7 +1631,7 @@
   },
   {
     "name": "Horse, Riding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1641,7 +1641,7 @@
   },
   {
     "name": "Mastiff",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1651,7 +1651,7 @@
   },
   {
     "name": "Mule",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1661,7 +1661,7 @@
   },
   {
     "name": "Pony",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1671,7 +1671,7 @@
   },
   {
     "name": "Warhorse",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Mount",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1681,7 +1681,7 @@
   },
   {
     "name": "Carriage",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1691,7 +1691,7 @@
   },
   {
     "name": "Cart",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1701,7 +1701,7 @@
   },
   {
     "name": "Chariot",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1711,7 +1711,7 @@
   },
   {
     "name": "Sled",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1721,7 +1721,7 @@
   },
   {
     "name": "Wagon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1731,7 +1731,7 @@
   },
   {
     "name": "Airship",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1741,7 +1741,7 @@
   },
   {
     "name": "Galley",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1751,7 +1751,7 @@
   },
   {
     "name": "Keelboat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1761,7 +1761,7 @@
   },
   {
     "name": "Longship",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1771,7 +1771,7 @@
   },
   {
     "name": "Rowboat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1781,7 +1781,7 @@
   },
   {
     "name": "Sailing Ship",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1791,7 +1791,7 @@
   },
   {
     "name": "Warship",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Vehicle",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1801,7 +1801,7 @@
   },
   {
     "name": "Adamantine Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1811,7 +1811,7 @@
   },
   {
     "name": "Ammunition, +1",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1821,7 +1821,7 @@
   },
   {
     "name": "Ammunition, +2",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1831,7 +1831,7 @@
   },
   {
     "name": "Ammunition, +3",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1841,7 +1841,7 @@
   },
   {
     "name": "Ammunition of Slaying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1851,7 +1851,7 @@
   },
   {
     "name": "Amulet of Health",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1861,7 +1861,7 @@
   },
   {
     "name": "Amulet of Proof against Detection and Location",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1871,7 +1871,7 @@
   },
   {
     "name": "Amulet of the Planes",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1881,7 +1881,7 @@
   },
   {
     "name": "Animated Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1891,7 +1891,7 @@
   },
   {
     "name": "Apparatus of the Crab",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1901,7 +1901,7 @@
   },
   {
     "name": "Armor, +1",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1911,7 +1911,7 @@
   },
   {
     "name": "Armor, +2",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1921,7 +1921,7 @@
   },
   {
     "name": "Armor, +3",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1931,7 +1931,7 @@
   },
   {
     "name": "Armor of Invulnerability",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1941,7 +1941,7 @@
   },
   {
     "name": "Armor of Resistance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1951,7 +1951,7 @@
   },
   {
     "name": "Armor of Vulnerability",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1961,7 +1961,7 @@
   },
   {
     "name": "Arrow-Catching Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1971,7 +1971,7 @@
   },
   {
     "name": "Bag of Beans",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1981,7 +1981,7 @@
   },
   {
     "name": "Bag of Devouring",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -1991,7 +1991,7 @@
   },
   {
     "name": "Bag of Holding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2001,7 +2001,7 @@
   },
   {
     "name": "Bag of Tricks",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2011,7 +2011,7 @@
   },
   {
     "name": "Bead of Force",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2021,7 +2021,7 @@
   },
   {
     "name": "Bead of Nourishment",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2031,7 +2031,7 @@
   },
   {
     "name": "Belt of Dwarvenkind",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2041,7 +2041,7 @@
   },
   {
     "name": "Belt of Giant Strength",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2051,7 +2051,7 @@
   },
   {
     "name": "Berserker Axe",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2061,7 +2061,7 @@
   },
   {
     "name": "Boots of Elvenkind",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2071,7 +2071,7 @@
   },
   {
     "name": "Boots of Levitation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2081,7 +2081,7 @@
   },
   {
     "name": "Boots of Speed",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2091,7 +2091,7 @@
   },
   {
     "name": "Boots of Striding and Springing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2101,7 +2101,7 @@
   },
   {
     "name": "Boots of the Winterlands",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2111,7 +2111,7 @@
   },
   {
     "name": "Bowl of Commanding Water Elementals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2121,7 +2121,7 @@
   },
   {
     "name": "Bracers of Archery",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2131,7 +2131,7 @@
   },
   {
     "name": "Bracers of Defense",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2141,7 +2141,7 @@
   },
   {
     "name": "Brazier of Commanding Fire Elementals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2151,7 +2151,7 @@
   },
   {
     "name": "Brooch of Shielding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2161,7 +2161,7 @@
   },
   {
     "name": "Broom of Flying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2171,7 +2171,7 @@
   },
   {
     "name": "Candle of Invocation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2181,7 +2181,7 @@
   },
   {
     "name": "Cape of the Mountebank",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2191,7 +2191,7 @@
   },
   {
     "name": "Carpet of Flying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2201,7 +2201,7 @@
   },
   {
     "name": "Censer of Controlling Air Elementals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2211,7 +2211,7 @@
   },
   {
     "name": "Chime of Opening",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2221,7 +2221,7 @@
   },
   {
     "name": "Circlet of Blasting",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2231,7 +2231,7 @@
   },
   {
     "name": "Cloak of Arachnida",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2241,7 +2241,7 @@
   },
   {
     "name": "Cloak of Displacement",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2251,7 +2251,7 @@
   },
   {
     "name": "Cloak of Elvenkind",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2261,7 +2261,7 @@
   },
   {
     "name": "Cloak of Invisibility",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2271,7 +2271,7 @@
   },
   {
     "name": "Cloak of Protection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2281,7 +2281,7 @@
   },
   {
     "name": "Cloak of the Bat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2291,7 +2291,7 @@
   },
   {
     "name": "Cloak of the Manta Ray",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2301,7 +2301,7 @@
   },
   {
     "name": "Crystal Ball",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2311,7 +2311,7 @@
   },
   {
     "name": "Crystal Ball of Mind Reading",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2321,7 +2321,7 @@
   },
   {
     "name": "Crystal Ball of Telepathy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2331,7 +2331,7 @@
   },
   {
     "name": "Crystal Ball of True Seeing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2341,7 +2341,7 @@
   },
   {
     "name": "Cube of Force",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2351,7 +2351,7 @@
   },
   {
     "name": "Cubic Gate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2361,7 +2361,7 @@
   },
   {
     "name": "Dagger of Venom",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2371,7 +2371,7 @@
   },
   {
     "name": "Dancing Sword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2381,7 +2381,7 @@
   },
   {
     "name": "Decanter of Endless Water",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2391,7 +2391,7 @@
   },
   {
     "name": "Deck of Illusions",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2401,7 +2401,7 @@
   },
   {
     "name": "Defender",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2411,7 +2411,7 @@
   },
   {
     "name": "Demon Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2421,7 +2421,7 @@
   },
   {
     "name": "Dimensional Shackles",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2431,7 +2431,7 @@
   },
   {
     "name": "Dragon Orb",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2441,7 +2441,7 @@
   },
   {
     "name": "Dragon Scale Mail",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2451,7 +2451,7 @@
   },
   {
     "name": "Dragon Slayer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2461,7 +2461,7 @@
   },
   {
     "name": "Dust of Disappearance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2471,7 +2471,7 @@
   },
   {
     "name": "Dust of Dryness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2481,7 +2481,7 @@
   },
   {
     "name": "Dust of Sneezing and Choking",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2491,7 +2491,7 @@
   },
   {
     "name": "Dwarven Plate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2501,7 +2501,7 @@
   },
   {
     "name": "Dwarven Thrower",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2511,7 +2511,7 @@
   },
   {
     "name": "Efficient Quiver",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2521,7 +2521,7 @@
   },
   {
     "name": "Efreeti Bottle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2531,7 +2531,7 @@
   },
   {
     "name": "Elemental Gem",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2541,7 +2541,7 @@
   },
   {
     "name": "Elixir of Health",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2551,7 +2551,7 @@
   },
   {
     "name": "Elven Chain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2561,7 +2561,7 @@
   },
   {
     "name": "Energy Bow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2571,7 +2571,7 @@
   },
   {
     "name": "Eversmoking Bottle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2581,7 +2581,7 @@
   },
   {
     "name": "Eyes of Charming",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2591,7 +2591,7 @@
   },
   {
     "name": "Eyes of Minute Seeing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2601,7 +2601,7 @@
   },
   {
     "name": "Eyes of the Eagle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2611,7 +2611,7 @@
   },
   {
     "name": "Feather Token",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2621,7 +2621,7 @@
   },
   {
     "name": "Figurine of Wondrous Power",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2631,7 +2631,7 @@
   },
   {
     "name": "Flame Tongue",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2641,7 +2641,7 @@
   },
   {
     "name": "Folding Boat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2651,7 +2651,7 @@
   },
   {
     "name": "Frost Brand",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2661,7 +2661,7 @@
   },
   {
     "name": "Gauntlets of Ogre Power",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2671,7 +2671,7 @@
   },
   {
     "name": "Gem of Brightness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2681,7 +2681,7 @@
   },
   {
     "name": "Gem of Seeing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2691,7 +2691,7 @@
   },
   {
     "name": "Giant Slayer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2701,7 +2701,7 @@
   },
   {
     "name": "Glamoured Studded Leather",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2711,7 +2711,7 @@
   },
   {
     "name": "Gloves of Missile Snaring",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2721,7 +2721,7 @@
   },
   {
     "name": "Gloves of Swimming and Climbing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2731,7 +2731,7 @@
   },
   {
     "name": "Gloves of Thievery",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2741,7 +2741,7 @@
   },
   {
     "name": "Goggles of Night",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2751,7 +2751,7 @@
   },
   {
     "name": "Hammer of Thunderbolts",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2761,7 +2761,7 @@
   },
   {
     "name": "Handy Haversack",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2771,7 +2771,7 @@
   },
   {
     "name": "Hat of Disguise",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2781,7 +2781,7 @@
   },
   {
     "name": "Hat of Many Spells",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2791,7 +2791,7 @@
   },
   {
     "name": "Headband of Intellect",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2801,7 +2801,7 @@
   },
   {
     "name": "Helm of Brilliance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2811,7 +2811,7 @@
   },
   {
     "name": "Helm of Comprehending Languages",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2821,7 +2821,7 @@
   },
   {
     "name": "Helm of Telepathy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2831,7 +2831,7 @@
   },
   {
     "name": "Helm of Teleportation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2841,7 +2841,7 @@
   },
   {
     "name": "Holy Avenger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2851,7 +2851,7 @@
   },
   {
     "name": "Horn of Blasting",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2861,7 +2861,7 @@
   },
   {
     "name": "Horn of Valhalla",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2871,7 +2871,7 @@
   },
   {
     "name": "Horseshoes of a Zephyr",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2881,7 +2881,7 @@
   },
   {
     "name": "Horseshoes of Speed",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2891,7 +2891,7 @@
   },
   {
     "name": "Immovable Rod",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2901,7 +2901,7 @@
   },
   {
     "name": "Instant Fortress",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2911,7 +2911,7 @@
   },
   {
     "name": "Ioun Stone",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2921,7 +2921,7 @@
   },
   {
     "name": "Iron Bands",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2931,7 +2931,7 @@
   },
   {
     "name": "Iron Flask",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2941,7 +2941,7 @@
   },
   {
     "name": "Javelin of Lightning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2951,7 +2951,7 @@
   },
   {
     "name": "Lantern of Revealing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2961,7 +2961,7 @@
   },
   {
     "name": "Luck Blade",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2971,7 +2971,7 @@
   },
   {
     "name": "Mace of Disruption",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2981,7 +2981,7 @@
   },
   {
     "name": "Mace of Smiting",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -2991,7 +2991,7 @@
   },
   {
     "name": "Mace of Terror",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3001,7 +3001,7 @@
   },
   {
     "name": "Mantle of Spell Resistance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3011,7 +3011,7 @@
   },
   {
     "name": "Manual of Bodily Health",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3021,7 +3021,7 @@
   },
   {
     "name": "Manual of Gainful Exercise",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3031,7 +3031,7 @@
   },
   {
     "name": "Manual of Golems",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3041,7 +3041,7 @@
   },
   {
     "name": "Manual of Quickness of Action",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3051,7 +3051,7 @@
   },
   {
     "name": "Marvelous Pigments",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3061,7 +3061,7 @@
   },
   {
     "name": "Medallion of Thoughts",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3071,7 +3071,7 @@
   },
   {
     "name": "Mirror of Life Trapping",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3081,7 +3081,7 @@
   },
   {
     "name": "Mithral Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3091,7 +3091,7 @@
   },
   {
     "name": "Mysterious Deck",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3101,7 +3101,7 @@
   },
   {
     "name": "Necklace of Adaptation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3111,7 +3111,7 @@
   },
   {
     "name": "Necklace of Fireballs",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3121,7 +3121,7 @@
   },
   {
     "name": "Necklace of Prayer Beads",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3131,7 +3131,7 @@
   },
   {
     "name": "Nine Lives Stealer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3141,7 +3141,7 @@
   },
   {
     "name": "Oathbow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3151,7 +3151,7 @@
   },
   {
     "name": "Oil of Etherealness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3161,7 +3161,7 @@
   },
   {
     "name": "Oil of Sharpness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3171,7 +3171,7 @@
   },
   {
     "name": "Oil of Slipperiness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3181,7 +3181,7 @@
   },
   {
     "name": "Pearl of Power",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3191,7 +3191,7 @@
   },
   {
     "name": "Periapt of Health",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3201,7 +3201,7 @@
   },
   {
     "name": "Periapt of Proof against Poison",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3211,7 +3211,7 @@
   },
   {
     "name": "Periapt of Wound Closure",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3221,7 +3221,7 @@
   },
   {
     "name": "Philter of Love",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3231,7 +3231,7 @@
   },
   {
     "name": "Pipes of Haunting",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3241,7 +3241,7 @@
   },
   {
     "name": "Pipes of the Sewers",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3251,7 +3251,7 @@
   },
   {
     "name": "Plate Armor of Etherealness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3261,7 +3261,7 @@
   },
   {
     "name": "Portable Hole",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3271,7 +3271,7 @@
   },
   {
     "name": "Potion of Animal Friendship",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3281,7 +3281,7 @@
   },
   {
     "name": "Potion of Clairvoyance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3291,7 +3291,7 @@
   },
   {
     "name": "Potion of Climbing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3301,7 +3301,7 @@
   },
   {
     "name": "Potion of Diminution",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3311,7 +3311,7 @@
   },
   {
     "name": "Potion of Flying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3321,7 +3321,7 @@
   },
   {
     "name": "Potion of Gaseous Form",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3331,7 +3331,7 @@
   },
   {
     "name": "Potion of Giant Strength",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3341,7 +3341,7 @@
   },
   {
     "name": "Potion of Growth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3351,7 +3351,7 @@
   },
   {
     "name": "Potion of Healing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3361,7 +3361,7 @@
   },
   {
     "name": "Potion of Greater Healing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3371,7 +3371,7 @@
   },
   {
     "name": "Potion of Superior Healing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3381,7 +3381,7 @@
   },
   {
     "name": "Potion of Supreme Healing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3391,7 +3391,7 @@
   },
   {
     "name": "Potion of Heroism",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3401,7 +3401,7 @@
   },
   {
     "name": "Potion of Invisibility",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3411,7 +3411,7 @@
   },
   {
     "name": "Potion of Invulnerability",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3421,7 +3421,7 @@
   },
   {
     "name": "Potion of Longevity",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3431,7 +3431,7 @@
   },
   {
     "name": "Potion of Mind Reading",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3441,7 +3441,7 @@
   },
   {
     "name": "Potion of Poison",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3451,7 +3451,7 @@
   },
   {
     "name": "Potion of Resistance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3461,7 +3461,7 @@
   },
   {
     "name": "Potion of Speed",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3471,7 +3471,7 @@
   },
   {
     "name": "Potion of Vitality",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3481,7 +3481,7 @@
   },
   {
     "name": "Potion of Water Breathing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Potion",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3491,7 +3491,7 @@
   },
   {
     "name": "Quarterstaff of the Acrobat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3501,7 +3501,7 @@
   },
   {
     "name": "Ring of Animal Influence",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3511,7 +3511,7 @@
   },
   {
     "name": "Ring of Djinni Summoning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3521,7 +3521,7 @@
   },
   {
     "name": "Ring of Elemental Command",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3531,7 +3531,7 @@
   },
   {
     "name": "Ring of Evasion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3541,7 +3541,7 @@
   },
   {
     "name": "Ring of Feather Falling",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3551,7 +3551,7 @@
   },
   {
     "name": "Ring of Free Action",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3561,7 +3561,7 @@
   },
   {
     "name": "Ring of Invisibility",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3571,7 +3571,7 @@
   },
   {
     "name": "Ring of Jumping",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3581,7 +3581,7 @@
   },
   {
     "name": "Ring of Mind Shielding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3591,7 +3591,7 @@
   },
   {
     "name": "Ring of Protection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3601,7 +3601,7 @@
   },
   {
     "name": "Ring of Regeneration",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3611,7 +3611,7 @@
   },
   {
     "name": "Ring of Resistance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3621,7 +3621,7 @@
   },
   {
     "name": "Ring of Shooting Stars",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3631,7 +3631,7 @@
   },
   {
     "name": "Ring of Spell Storing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3641,7 +3641,7 @@
   },
   {
     "name": "Ring of Spell Turning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3651,7 +3651,7 @@
   },
   {
     "name": "Ring of Swimming",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3661,7 +3661,7 @@
   },
   {
     "name": "Ring of Telekinesis",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3671,7 +3671,7 @@
   },
   {
     "name": "Ring of the Ram",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3681,7 +3681,7 @@
   },
   {
     "name": "Ring of Three Wishes",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3691,7 +3691,7 @@
   },
   {
     "name": "Ring of Warmth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3701,7 +3701,7 @@
   },
   {
     "name": "Ring of Water Walking",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3711,7 +3711,7 @@
   },
   {
     "name": "Ring of X-ray Vision",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Ring",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3721,7 +3721,7 @@
   },
   {
     "name": "Robe of Eyes",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3731,7 +3731,7 @@
   },
   {
     "name": "Robe of Scintillating Colors",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3741,7 +3741,7 @@
   },
   {
     "name": "Robe of Stars",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3751,7 +3751,7 @@
   },
   {
     "name": "Robe of the Archmagi",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3761,7 +3761,7 @@
   },
   {
     "name": "Robe of Useful Items",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3771,7 +3771,7 @@
   },
   {
     "name": "Rod of Absorption",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3781,7 +3781,7 @@
   },
   {
     "name": "Rod of Alertness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3791,7 +3791,7 @@
   },
   {
     "name": "Rod of Lordly Might",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3801,7 +3801,7 @@
   },
   {
     "name": "Rod of Resurrection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3811,7 +3811,7 @@
   },
   {
     "name": "Rod of Rulership",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3821,7 +3821,7 @@
   },
   {
     "name": "Rod of Security",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Rod",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3831,7 +3831,7 @@
   },
   {
     "name": "Rope of Climbing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3841,7 +3841,7 @@
   },
   {
     "name": "Rope of Entanglement",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3851,7 +3851,7 @@
   },
   {
     "name": "Scarab of Protection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3861,7 +3861,7 @@
   },
   {
     "name": "Scimitar of Speed",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3871,7 +3871,7 @@
   },
   {
     "name": "Sending Stones",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3881,7 +3881,7 @@
   },
   {
     "name": "Sentinel Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3891,7 +3891,7 @@
   },
   {
     "name": "Shield, +1",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3901,7 +3901,7 @@
   },
   {
     "name": "Shield, +2",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3911,7 +3911,7 @@
   },
   {
     "name": "Shield, +3",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3921,7 +3921,7 @@
   },
   {
     "name": "Shield of Missile Attraction",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3931,7 +3931,7 @@
   },
   {
     "name": "Shield of the Cavalier",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3941,7 +3941,7 @@
   },
   {
     "name": "Slippers of Spider Climbing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3951,7 +3951,7 @@
   },
   {
     "name": "Sovereign Glue",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3961,7 +3961,7 @@
   },
   {
     "name": "Spellguard Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Armor",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3971,7 +3971,7 @@
   },
   {
     "name": "Sphere of Annihilation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3981,7 +3981,7 @@
   },
   {
     "name": "Staff of Charming",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -3991,7 +3991,7 @@
   },
   {
     "name": "Staff of Fire",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4001,7 +4001,7 @@
   },
   {
     "name": "Staff of Frost",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4011,7 +4011,7 @@
   },
   {
     "name": "Staff of Healing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4021,7 +4021,7 @@
   },
   {
     "name": "Staff of Power",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4031,7 +4031,7 @@
   },
   {
     "name": "Staff of Striking",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4041,7 +4041,7 @@
   },
   {
     "name": "Staff of Swarming Insects",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4051,7 +4051,7 @@
   },
   {
     "name": "Staff of the Magi",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4061,7 +4061,7 @@
   },
   {
     "name": "Staff of the Python",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4071,7 +4071,7 @@
   },
   {
     "name": "Staff of the Woodlands",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4081,7 +4081,7 @@
   },
   {
     "name": "Staff of Thunder and Lightning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4091,7 +4091,7 @@
   },
   {
     "name": "Staff of Withering",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Staff",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4101,7 +4101,7 @@
   },
   {
     "name": "Stone of Controlling Earth Elementals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4111,7 +4111,7 @@
   },
   {
     "name": "Stone of Good Luck",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4121,7 +4121,7 @@
   },
   {
     "name": "Sun Blade",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4131,7 +4131,7 @@
   },
   {
     "name": "Sword of Life Stealing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4141,7 +4141,7 @@
   },
   {
     "name": "Sword of Sharpness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4151,7 +4151,7 @@
   },
   {
     "name": "Sword of Wounding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4161,7 +4161,7 @@
   },
   {
     "name": "Talisman of Pure Good",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4171,7 +4171,7 @@
   },
   {
     "name": "Talisman of the Sphere",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4181,7 +4181,7 @@
   },
   {
     "name": "Talisman of Ultimate Evil",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4191,7 +4191,7 @@
   },
   {
     "name": "Thunderous Greatclub",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4201,7 +4201,7 @@
   },
   {
     "name": "Tome of Clear Thought",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4211,7 +4211,7 @@
   },
   {
     "name": "Tome of Leadership and Influence",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4221,7 +4221,7 @@
   },
   {
     "name": "Tome of Understanding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4231,7 +4231,7 @@
   },
   {
     "name": "Trident of Fish Command",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4241,7 +4241,7 @@
   },
   {
     "name": "Universal Solvent",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4251,7 +4251,7 @@
   },
   {
     "name": "Vicious Weapon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4261,7 +4261,7 @@
   },
   {
     "name": "Vorpal Sword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4271,7 +4271,7 @@
   },
   {
     "name": "Wand of Binding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4281,7 +4281,7 @@
   },
   {
     "name": "Wand of Enemy Detection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4291,7 +4291,7 @@
   },
   {
     "name": "Wand of Fear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4301,7 +4301,7 @@
   },
   {
     "name": "Wand of Fireballs",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4311,7 +4311,7 @@
   },
   {
     "name": "Wand of Lightning Bolts",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4321,7 +4321,7 @@
   },
   {
     "name": "Wand of Magic Detection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4331,7 +4331,7 @@
   },
   {
     "name": "Wand of Magic Missiles",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4341,7 +4341,7 @@
   },
   {
     "name": "Wand of Paralysis",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4351,7 +4351,7 @@
   },
   {
     "name": "Wand of Polymorph",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4361,7 +4361,7 @@
   },
   {
     "name": "Wand of Secrets",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4371,7 +4371,7 @@
   },
   {
     "name": "Wand of the War Mage, +1",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4381,7 +4381,7 @@
   },
   {
     "name": "Wand of the War Mage, +2",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4391,7 +4391,7 @@
   },
   {
     "name": "Wand of the War Mage, +3",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4401,7 +4401,7 @@
   },
   {
     "name": "Wand of Web",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4411,7 +4411,7 @@
   },
   {
     "name": "Wand of Wonder",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wand",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4421,7 +4421,7 @@
   },
   {
     "name": "Weapon, +1",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4431,7 +4431,7 @@
   },
   {
     "name": "Weapon, +2",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4441,7 +4441,7 @@
   },
   {
     "name": "Weapon, +3",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4451,7 +4451,7 @@
   },
   {
     "name": "Weapon of Warning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Magic Weapon",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4461,7 +4461,7 @@
   },
   {
     "name": "Well of Many Worlds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4471,7 +4471,7 @@
   },
   {
     "name": "Wind Fan",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4481,7 +4481,7 @@
   },
   {
     "name": "Winged Boots",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -4491,7 +4491,7 @@
   },
   {
     "name": "Wings of Flying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "category": "Wondrous Item",
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/rule_references.json
+++ b/db/seeds/5th-edition/rule_references.json
@@ -2,7 +2,7 @@
   {
     "name": "Advantage and Disadvantage",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "Cover",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Concentration",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Critical Hit",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -54,7 +54,7 @@
   {
     "name": "Darkness",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -67,7 +67,7 @@
   {
     "name": "Darkvision",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -80,7 +80,7 @@
   {
     "name": "Difficult Terrain",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -93,7 +93,7 @@
   {
     "name": "Falling",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -106,7 +106,7 @@
   {
     "name": "Hiding",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -119,7 +119,7 @@
   {
     "name": "Long Rest",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -132,7 +132,7 @@
   {
     "name": "Short Rest",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -145,7 +145,7 @@
   {
     "name": "Damage Types",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -158,7 +158,7 @@
   {
     "name": "Resistance",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -171,7 +171,7 @@
   {
     "name": "Opportunity Attacks",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -184,7 +184,7 @@
   {
     "name": "Death Saving Throw",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -197,7 +197,7 @@
   {
     "name": "Grappling",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -210,7 +210,7 @@
   {
     "name": "Unarmed Strike",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -223,7 +223,7 @@
   {
     "name": "Heroic Inspiration",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -236,7 +236,7 @@
   {
     "name": "Passive Perception",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -249,7 +249,7 @@
   {
     "name": "Suffocation",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -262,7 +262,7 @@
   {
     "name": "Truesight",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -275,7 +275,7 @@
   {
     "name": "Telepathy",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -288,7 +288,7 @@
   {
     "name": "Tremorsense",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -301,7 +301,7 @@
   {
     "name": "Teleportation",
     "rule_type": "Rule Reference",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/species.json
+++ b/db/seeds/5th-edition/species.json
@@ -2,7 +2,7 @@
   {
     "name": "Dragonborn",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "Dwarf",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Elf",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Gnome",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -54,7 +54,7 @@
   {
     "name": "Goliath",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -67,7 +67,7 @@
   {
     "name": "Halfling",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -80,7 +80,7 @@
   {
     "name": "Human",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -93,7 +93,7 @@
   {
     "name": "Orc",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -106,7 +106,7 @@
   {
     "name": "Tiefling",
     "rule_type": "Species",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/5th-edition/spells.json
+++ b/db/seeds/5th-edition/spells.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Acid Arrow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (powdered rhubarb leaf)",
@@ -16,7 +16,7 @@
   },
   {
     "name": "Acid Splash",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -31,7 +31,7 @@
   },
   {
     "name": "Aid",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a strip of white cloth)",
@@ -46,7 +46,7 @@
   },
   {
     "name": "Alarm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (a bell and silver wire)",
@@ -61,7 +61,7 @@
   },
   {
     "name": "Alter Self",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -76,7 +76,7 @@
   },
   {
     "name": "Animal Friendship",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a morsel of food)",
@@ -91,7 +91,7 @@
   },
   {
     "name": "Animal Messenger",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a morsel of food)",
@@ -106,7 +106,7 @@
   },
   {
     "name": "Animal Shapes",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -121,7 +121,7 @@
   },
   {
     "name": "Animate Dead",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 minute",
     "components": "V, S, M (a drop of blood, a piece of flesh, and a pinch of bone dust)",
@@ -136,7 +136,7 @@
   },
   {
     "name": "Animate Objects",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -151,7 +151,7 @@
   },
   {
     "name": "Antilife Shell",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -166,7 +166,7 @@
   },
   {
     "name": "Antimagic Field",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (iron filings)",
@@ -181,7 +181,7 @@
   },
   {
     "name": "Antipathy/Sympathy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "1 hour",
     "components": "V, S, M (a mix of vinegar and honey)",
@@ -196,7 +196,7 @@
   },
   {
     "name": "Arcane Eye",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (a bit of bat fur)",
@@ -211,7 +211,7 @@
   },
   {
     "name": "Arcane Hand",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (an eggshell and a glove)",
@@ -226,7 +226,7 @@
   },
   {
     "name": "Arcane Lock",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (gold dust worth 25+ GP, which the spell consumes)",
@@ -241,7 +241,7 @@
   },
   {
     "name": "Arcane Sword",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a miniature sword worth 250+ GP)",
@@ -256,7 +256,7 @@
   },
   {
     "name": "Arcanist's Magic Aura",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a small square of silk)",
@@ -271,7 +271,7 @@
   },
   {
     "name": "Astral Projection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 hour",
     "components": "V, S, M (for each of the spell's targets, one jacinth worth 1,000+ GP and one silver bar worth 100+ GP, all of which the spell consumes)",
@@ -286,7 +286,7 @@
   },
   {
     "name": "Augury",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (specially marked sticks, bones, cards, or other divinatory tokens worth 25+ GP)",
@@ -301,7 +301,7 @@
   },
   {
     "name": "Aura of Life",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V",
@@ -316,7 +316,7 @@
   },
   {
     "name": "Awaken",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "8 hours",
     "components": "V, S, M (an agate worth 1,000+ GP, which the spell consumes)",
@@ -331,7 +331,7 @@
   },
   {
     "name": "Bane",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a drop of blood)",
@@ -346,7 +346,7 @@
   },
   {
     "name": "Banishment",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a pentacle)",
@@ -361,7 +361,7 @@
   },
   {
     "name": "Barkskin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S, M (a handful of bark)",
@@ -376,7 +376,7 @@
   },
   {
     "name": "Beacon of Hope",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -391,7 +391,7 @@
   },
   {
     "name": "Befuddlement",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a key ring with no keys)",
@@ -406,7 +406,7 @@
   },
   {
     "name": "Bestow Curse",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -421,7 +421,7 @@
   },
   {
     "name": "Black Tentacles",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a tentacle)",
@@ -436,7 +436,7 @@
   },
   {
     "name": "Blade Barrier",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -451,7 +451,7 @@
   },
   {
     "name": "Bless",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a Holy Symbol worth 5+ GP)",
@@ -466,7 +466,7 @@
   },
   {
     "name": "Blight",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -481,7 +481,7 @@
   },
   {
     "name": "Blindness/Deafness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V",
@@ -496,7 +496,7 @@
   },
   {
     "name": "Blink",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -511,7 +511,7 @@
   },
   {
     "name": "Blur",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V",
@@ -526,7 +526,7 @@
   },
   {
     "name": "Burning Hands",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -541,7 +541,7 @@
   },
   {
     "name": "Call Lightning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -556,7 +556,7 @@
   },
   {
     "name": "Calm Emotions",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -571,7 +571,7 @@
   },
   {
     "name": "Chain Lightning",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (three silver pins)",
@@ -586,7 +586,7 @@
   },
   {
     "name": "Charm Monster",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -601,7 +601,7 @@
   },
   {
     "name": "Charm Person",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -616,7 +616,7 @@
   },
   {
     "name": "Chill Touch",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -631,7 +631,7 @@
   },
   {
     "name": "Chromatic Orb",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a diamond worth 50+ GP)",
@@ -646,7 +646,7 @@
   },
   {
     "name": "Circle of Death",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S, M (the powder of a crushed black pearl worth 500+ GP)",
@@ -661,7 +661,7 @@
   },
   {
     "name": "Clairvoyance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "10 minutes",
     "components": "V, S, M (a focus worth 100+ GP, either a jeweled horn for hearing or a glass eye for seeing)",
@@ -676,7 +676,7 @@
   },
   {
     "name": "Clone",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 hour",
     "components": "V, S, M (a diamond worth 1,000+ GP, which the spell consumes, and a sealable vessel worth 2,000+ GP that is large enough to hold the creature being cloned)",
@@ -691,7 +691,7 @@
   },
   {
     "name": "Cloudkill",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -706,7 +706,7 @@
   },
   {
     "name": "Color Spray",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of colorful sand)",
@@ -721,7 +721,7 @@
   },
   {
     "name": "Command",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -736,7 +736,7 @@
   },
   {
     "name": "Commune",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (incense)",
@@ -751,7 +751,7 @@
   },
   {
     "name": "Commune with Nature",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute or Ritual",
     "components": "V, S",
@@ -766,7 +766,7 @@
   },
   {
     "name": "Comprehend Languages",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a pinch of soot and salt)",
@@ -781,7 +781,7 @@
   },
   {
     "name": "Compulsion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -796,7 +796,7 @@
   },
   {
     "name": "Cone of Cold",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a small crystal or glass cone)",
@@ -811,7 +811,7 @@
   },
   {
     "name": "Confusion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (three nut shells)",
@@ -826,7 +826,7 @@
   },
   {
     "name": "Conjure Animals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -841,7 +841,7 @@
   },
   {
     "name": "Conjure Celestial",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -856,7 +856,7 @@
   },
   {
     "name": "Conjure Elemental",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -871,7 +871,7 @@
   },
   {
     "name": "Conjure Fey",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -886,7 +886,7 @@
   },
   {
     "name": "Conjure Minor Elementals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -901,7 +901,7 @@
   },
   {
     "name": "Conjure Woodland Beings",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -916,7 +916,7 @@
   },
   {
     "name": "Contact Other Plane",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute or Ritual",
     "components": "V",
@@ -931,7 +931,7 @@
   },
   {
     "name": "Contagion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -946,7 +946,7 @@
   },
   {
     "name": "Contingency",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "10 minutes",
     "components": "V, S, M (a gem-encrusted statuette of yourself worth 1,500+ GP)",
@@ -961,7 +961,7 @@
   },
   {
     "name": "Continual Flame",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (ruby dust worth 50+ GP, which the spell consumes)",
@@ -976,7 +976,7 @@
   },
   {
     "name": "Control Water",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a mixture of water and dust)",
@@ -991,7 +991,7 @@
   },
   {
     "name": "Control Weather",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "10 minutes",
     "components": "V, S, M (burning incense)",
@@ -1006,7 +1006,7 @@
   },
   {
     "name": "Counterspell",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Reaction, which you take when you see a creature within 60 feet of yourself casting a spell with Verbal, Somatic, or Material components",
     "components": "S",
@@ -1021,7 +1021,7 @@
   },
   {
     "name": "Create Food and Water",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1036,7 +1036,7 @@
   },
   {
     "name": "Create or Destroy Water",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a mix of water and sand)",
@@ -1051,7 +1051,7 @@
   },
   {
     "name": "Create Undead",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 minute",
     "components": "V, S, M (one 150+ GP black onyx stone for each corpse)",
@@ -1066,7 +1066,7 @@
   },
   {
     "name": "Creation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "1 minute",
     "components": "V, S, M (a paintbrush)",
@@ -1081,7 +1081,7 @@
   },
   {
     "name": "Cure Wounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1096,7 +1096,7 @@
   },
   {
     "name": "Dancing Lights",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a bit of phosphorus)",
@@ -1111,7 +1111,7 @@
   },
   {
     "name": "Darkness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, M (bat fur and a piece of coal)",
@@ -1126,7 +1126,7 @@
   },
   {
     "name": "Darkvision",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a dried carrot)",
@@ -1141,7 +1141,7 @@
   },
   {
     "name": "Daylight",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -1156,7 +1156,7 @@
   },
   {
     "name": "Death Ward",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1171,7 +1171,7 @@
   },
   {
     "name": "Delayed Blast Fireball",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a ball of bat guano and sulfur)",
@@ -1186,7 +1186,7 @@
   },
   {
     "name": "Demiplane",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "S",
@@ -1201,7 +1201,7 @@
   },
   {
     "name": "Detect Evil and Good",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S",
@@ -1216,7 +1216,7 @@
   },
   {
     "name": "Detect Magic",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S",
@@ -1231,7 +1231,7 @@
   },
   {
     "name": "Detect Poison and Disease",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a yew leaf)",
@@ -1246,7 +1246,7 @@
   },
   {
     "name": "Detect Thoughts",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (1 Copper Piece)",
@@ -1261,7 +1261,7 @@
   },
   {
     "name": "Dimension Door",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V",
@@ -1276,7 +1276,7 @@
   },
   {
     "name": "Disguise Self",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S",
@@ -1291,7 +1291,7 @@
   },
   {
     "name": "Disintegrate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a lodestone and dust)",
@@ -1306,7 +1306,7 @@
   },
   {
     "name": "Dispel Evil and Good",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (powdered silver and iron)",
@@ -1321,7 +1321,7 @@
   },
   {
     "name": "Dispel Magic",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1336,7 +1336,7 @@
   },
   {
     "name": "Dissonant Whispers",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -1351,7 +1351,7 @@
   },
   {
     "name": "Divination",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (incense worth 25+ GP, which the spell consumes)",
@@ -1366,7 +1366,7 @@
   },
   {
     "name": "Divine Favor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S",
@@ -1381,7 +1381,7 @@
   },
   {
     "name": "Divine Smite",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Bonus Action, which you take immediately after hitting a target with a Melee weapon or an Unarmed Strike",
     "components": "V",
@@ -1396,7 +1396,7 @@
   },
   {
     "name": "Divine Word",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Bonus Action",
     "components": "V",
@@ -1411,7 +1411,7 @@
   },
   {
     "name": "Dominate Beast",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -1426,7 +1426,7 @@
   },
   {
     "name": "Dominate Monster",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -1441,7 +1441,7 @@
   },
   {
     "name": "Dominate Person",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -1456,7 +1456,7 @@
   },
   {
     "name": "Dragon's Breath",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S, M (a hot pepper)",
@@ -1471,7 +1471,7 @@
   },
   {
     "name": "Dream",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "1 minute",
     "components": "V, S, M (a handful of sand)",
@@ -1486,7 +1486,7 @@
   },
   {
     "name": "Druidcraft",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -1501,7 +1501,7 @@
   },
   {
     "name": "Earthquake",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a fractured rock)",
@@ -1516,7 +1516,7 @@
   },
   {
     "name": "Eldritch Blast",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -1531,7 +1531,7 @@
   },
   {
     "name": "Elementalism",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -1546,7 +1546,7 @@
   },
   {
     "name": "Enhance Ability",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (fur or a feather)",
@@ -1561,7 +1561,7 @@
   },
   {
     "name": "Enlarge/Reduce",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of powdered iron)",
@@ -1576,7 +1576,7 @@
   },
   {
     "name": "Ensnaring Strike",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Bonus Action, which you take immediately after hitting a creature with a weapon",
     "components": "V",
@@ -1591,7 +1591,7 @@
   },
   {
     "name": "Entangle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1606,7 +1606,7 @@
   },
   {
     "name": "Enthrall",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -1621,7 +1621,7 @@
   },
   {
     "name": "Etherealness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1636,7 +1636,7 @@
   },
   {
     "name": "Expeditious Retreat",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S",
@@ -1651,7 +1651,7 @@
   },
   {
     "name": "Eyebite",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -1666,7 +1666,7 @@
   },
   {
     "name": "Fabricate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "10 minutes",
     "components": "V, S",
@@ -1681,7 +1681,7 @@
   },
   {
     "name": "Faerie Fire",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V",
@@ -1696,7 +1696,7 @@
   },
   {
     "name": "Faithful Hound",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a silver whistle)",
@@ -1711,7 +1711,7 @@
   },
   {
     "name": "False Life",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S, M (a drop of alcohol)",
@@ -1726,7 +1726,7 @@
   },
   {
     "name": "Fear",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a white feather)",
@@ -1741,7 +1741,7 @@
   },
   {
     "name": "Feather Fall",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Reaction, which you take when you or a creature you can see within 60 feet of you falls",
     "components": "V, M (a small feather or piece of down)",
@@ -1756,7 +1756,7 @@
   },
   {
     "name": "Find Familiar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "1 hour or Ritual",
     "components": "V, S, M (burning incense worth 10+ GP, which the spell consumes)",
@@ -1771,7 +1771,7 @@
   },
   {
     "name": "Find Steed",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1786,7 +1786,7 @@
   },
   {
     "name": "Find the Path",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute",
     "components": "V, S, M (a set of divination tools—such as cards or runes—worth 100+ GP)",
@@ -1801,7 +1801,7 @@
   },
   {
     "name": "Find Traps",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S",
@@ -1816,7 +1816,7 @@
   },
   {
     "name": "Finger of Death",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -1831,7 +1831,7 @@
   },
   {
     "name": "Fireball",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a ball of bat guano and sulfur)",
@@ -1846,7 +1846,7 @@
   },
   {
     "name": "Fire Bolt",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -1861,7 +1861,7 @@
   },
   {
     "name": "Fire Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a bit of phosphorus or a firefly)",
@@ -1876,7 +1876,7 @@
   },
   {
     "name": "Fire Storm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -1891,7 +1891,7 @@
   },
   {
     "name": "Flame Blade",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Bonus Action",
     "components": "V, S, M (a sumac leaf)",
@@ -1906,7 +1906,7 @@
   },
   {
     "name": "Flame Strike",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of sulfur)",
@@ -1921,7 +1921,7 @@
   },
   {
     "name": "Flaming Sphere",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a ball of wax)",
@@ -1936,7 +1936,7 @@
   },
   {
     "name": "Flesh to Stone",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a cockatrice feather)",
@@ -1951,7 +1951,7 @@
   },
   {
     "name": "Floating Disk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a drop of mercury)",
@@ -1966,7 +1966,7 @@
   },
   {
     "name": "Fly",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a feather)",
@@ -1981,7 +1981,7 @@
   },
   {
     "name": "Fog Cloud",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -1996,7 +1996,7 @@
   },
   {
     "name": "Forbiddance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "10 minutes or Ritual",
     "components": "V, S, M (ruby dust worth 1,000+ GP)",
@@ -2011,7 +2011,7 @@
   },
   {
     "name": "Forcecage",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (ruby dust worth 1,500+ GP, which the spell consumes)",
@@ -2026,7 +2026,7 @@
   },
   {
     "name": "Foresight",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute",
     "components": "V, S, M (a hummingbird feather)",
@@ -2041,7 +2041,7 @@
   },
   {
     "name": "Freedom of Movement",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a leather strap)",
@@ -2056,7 +2056,7 @@
   },
   {
     "name": "Freezing Sphere",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a miniature crystal sphere)",
@@ -2071,7 +2071,7 @@
   },
   {
     "name": "Gaseous Form",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a bit of gauze)",
@@ -2086,7 +2086,7 @@
   },
   {
     "name": "Gate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a diamond worth 5,000+ GP)",
@@ -2101,7 +2101,7 @@
   },
   {
     "name": "Geas",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "1 minute",
     "components": "V",
@@ -2116,7 +2116,7 @@
   },
   {
     "name": "Gentle Repose",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (2 Copper Pieces, which the spell consumes)",
@@ -2131,7 +2131,7 @@
   },
   {
     "name": "Giant Insect",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -2146,7 +2146,7 @@
   },
   {
     "name": "Glibness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -2161,7 +2161,7 @@
   },
   {
     "name": "Globe of Invulnerability",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a glass bead)",
@@ -2176,7 +2176,7 @@
   },
   {
     "name": "Glyph of Warding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 hour",
     "components": "V, S, M (powdered diamond worth 200+ GP, which the spell consumes)",
@@ -2191,7 +2191,7 @@
   },
   {
     "name": "Goodberry",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a sprig of mistletoe)",
@@ -2206,7 +2206,7 @@
   },
   {
     "name": "Grease",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a bit of pork rind or butter)",
@@ -2221,7 +2221,7 @@
   },
   {
     "name": "Greater Invisibility",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S",
@@ -2236,7 +2236,7 @@
   },
   {
     "name": "Greater Restoration",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (diamond dust worth 100+ GP, which the spell consumes)",
@@ -2251,7 +2251,7 @@
   },
   {
     "name": "Guardian of Faith",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V",
@@ -2266,7 +2266,7 @@
   },
   {
     "name": "Guards and Wards",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 hour",
     "components": "V, S, M (a silver rod worth 10+ GP)",
@@ -2281,7 +2281,7 @@
   },
   {
     "name": "Guidance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S",
@@ -2296,7 +2296,7 @@
   },
   {
     "name": "Guiding Bolt",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -2311,7 +2311,7 @@
   },
   {
     "name": "Gust of Wind",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a legume seed)",
@@ -2326,7 +2326,7 @@
   },
   {
     "name": "Hallow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "24 hours",
     "components": "V, S, M (incense worth 1,000+ GP, which the spell consumes)",
@@ -2341,7 +2341,7 @@
   },
   {
     "name": "Hallucinatory Terrain",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "10 minutes",
     "components": "V, S, M (a mushroom)",
@@ -2356,7 +2356,7 @@
   },
   {
     "name": "Harm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -2371,7 +2371,7 @@
   },
   {
     "name": "Haste",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a shaving of licorice root)",
@@ -2386,7 +2386,7 @@
   },
   {
     "name": "Heal",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -2401,7 +2401,7 @@
   },
   {
     "name": "Healing Word",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Bonus Action",
     "components": "V",
@@ -2416,7 +2416,7 @@
   },
   {
     "name": "Heat Metal",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a piece of iron and a flame)",
@@ -2431,7 +2431,7 @@
   },
   {
     "name": "Hellish Rebuke",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Reaction, which you take in response to taking damage from a creature that you can see within 60 feet of yourself",
     "components": "V, S",
@@ -2446,7 +2446,7 @@
   },
   {
     "name": "Heroes' Feast",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "10 minutes",
     "components": "V, S, M (a gem-encrusted bowl worth 1,000+ GP, which the spell consumes)",
@@ -2461,7 +2461,7 @@
   },
   {
     "name": "Heroism",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -2476,7 +2476,7 @@
   },
   {
     "name": "Hex",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Bonus Action",
     "components": "V, S, M (the petrified eye of a newt)",
@@ -2491,7 +2491,7 @@
   },
   {
     "name": "Hideous Laughter",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a tart and a feather)",
@@ -2506,7 +2506,7 @@
   },
   {
     "name": "Hold Monster",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a straight piece of iron)",
@@ -2521,7 +2521,7 @@
   },
   {
     "name": "Hold Person",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a straight piece of iron)",
@@ -2536,7 +2536,7 @@
   },
   {
     "name": "Holy Aura",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a reliquary worth 1,000+ GP)",
@@ -2551,7 +2551,7 @@
   },
   {
     "name": "Hunter's Mark",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Bonus Action",
     "components": "V",
@@ -2566,7 +2566,7 @@
   },
   {
     "name": "Hypnotic Pattern",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "S, M (a pinch of confetti)",
@@ -2581,7 +2581,7 @@
   },
   {
     "name": "Ice Knife",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "S, M (a drop of water or a piece of ice)",
@@ -2596,7 +2596,7 @@
   },
   {
     "name": "Ice Storm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a mitten)",
@@ -2611,7 +2611,7 @@
   },
   {
     "name": "Identify",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (a pearl worth 100+ GP)",
@@ -2626,7 +2626,7 @@
   },
   {
     "name": "Illusory Script",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "1 minute or Ritual",
     "components": "S, M (ink worth 10+ GP, which the spell consumes)",
@@ -2641,7 +2641,7 @@
   },
   {
     "name": "Imprisonment",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 minute",
     "components": "V, S, M (a statuette of the target worth 5,000+ GP)",
@@ -2656,7 +2656,7 @@
   },
   {
     "name": "Incendiary Cloud",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -2671,7 +2671,7 @@
   },
   {
     "name": "Inflict Wounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -2686,7 +2686,7 @@
   },
   {
     "name": "Insect Plague",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a locust)",
@@ -2701,7 +2701,7 @@
   },
   {
     "name": "Instant Summons",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (a sapphire worth 1,000+ GP)",
@@ -2716,7 +2716,7 @@
   },
   {
     "name": "Invisibility",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (an eyelash in gum arabic)",
@@ -2731,7 +2731,7 @@
   },
   {
     "name": "Irresistible Dance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -2746,7 +2746,7 @@
   },
   {
     "name": "Jump",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S, M (a grasshopper's hind leg)",
@@ -2761,7 +2761,7 @@
   },
   {
     "name": "Knock",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V",
@@ -2776,7 +2776,7 @@
   },
   {
     "name": "Legend Lore",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "10 minutes",
     "components": "V, S, M (incense worth 250+ GP, which the spell consumes, and four ivory strips worth 50+ GP each)",
@@ -2791,7 +2791,7 @@
   },
   {
     "name": "Lesser Restoration",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Bonus Action",
     "components": "V, S",
@@ -2806,7 +2806,7 @@
   },
   {
     "name": "Levitate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a metal spring)",
@@ -2821,7 +2821,7 @@
   },
   {
     "name": "Light",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, M (a firefly or phosphorescent moss)",
@@ -2836,7 +2836,7 @@
   },
   {
     "name": "Lightning Bolt",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a bit of fur and a crystal rod)",
@@ -2851,7 +2851,7 @@
   },
   {
     "name": "Locate Animals or Plants",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (fur from a bloodhound)",
@@ -2866,7 +2866,7 @@
   },
   {
     "name": "Locate Creature",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (fur from a bloodhound)",
@@ -2881,7 +2881,7 @@
   },
   {
     "name": "Locate Object",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (a forked twig)",
@@ -2896,7 +2896,7 @@
   },
   {
     "name": "Longstrider",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of dirt)",
@@ -2911,7 +2911,7 @@
   },
   {
     "name": "Mage Armor",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a piece of cured leather)",
@@ -2926,7 +2926,7 @@
   },
   {
     "name": "Mage Hand",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -2941,7 +2941,7 @@
   },
   {
     "name": "Magic Circle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 minute",
     "components": "V, S, M (salt and powdered silver worth 100+ GP, which the spell consumes)",
@@ -2956,7 +2956,7 @@
   },
   {
     "name": "Magic Jar",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 minute",
     "components": "V, S, M (a gem, crystal, or reliquary worth 500+ GP)",
@@ -2971,7 +2971,7 @@
   },
   {
     "name": "Magic Missile",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -2986,7 +2986,7 @@
   },
   {
     "name": "Magic Mouth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (jade dust worth 10+ GP, which the spell consumes)",
@@ -3001,7 +3001,7 @@
   },
   {
     "name": "Magic Weapon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S",
@@ -3016,7 +3016,7 @@
   },
   {
     "name": "Magnificent Mansion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "1 minute",
     "components": "V, S, M (a miniature door worth 15+ GP)",
@@ -3031,7 +3031,7 @@
   },
   {
     "name": "Major Image",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a bit of fleece)",
@@ -3046,7 +3046,7 @@
   },
   {
     "name": "Mass Cure Wounds",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3061,7 +3061,7 @@
   },
   {
     "name": "Mass Heal",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3076,7 +3076,7 @@
   },
   {
     "name": "Mass Healing Word",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Bonus Action",
     "components": "V",
@@ -3091,7 +3091,7 @@
   },
   {
     "name": "Mass Suggestion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, M (a snake's tongue)",
@@ -3106,7 +3106,7 @@
   },
   {
     "name": "Maze",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3121,7 +3121,7 @@
   },
   {
     "name": "Meld into Stone",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action or Ritual",
     "components": "V, S",
@@ -3136,7 +3136,7 @@
   },
   {
     "name": "Mending",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "1 minute",
     "components": "V, S, M (two lodestones)",
@@ -3151,7 +3151,7 @@
   },
   {
     "name": "Message",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "S, M (a copper wire)",
@@ -3166,7 +3166,7 @@
   },
   {
     "name": "Meteor Swarm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -3181,7 +3181,7 @@
   },
   {
     "name": "Mind Blank",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3196,7 +3196,7 @@
   },
   {
     "name": "Mind Spike",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "S",
@@ -3211,7 +3211,7 @@
   },
   {
     "name": "Minor Illusion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "S, M (a bit of fleece)",
@@ -3226,7 +3226,7 @@
   },
   {
     "name": "Mirage Arcane",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "10 minutes",
     "components": "V, S",
@@ -3241,7 +3241,7 @@
   },
   {
     "name": "Mirror Image",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S",
@@ -3256,7 +3256,7 @@
   },
   {
     "name": "Mislead",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "S",
@@ -3271,7 +3271,7 @@
   },
   {
     "name": "Misty Step",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Bonus Action",
     "components": "V",
@@ -3286,7 +3286,7 @@
   },
   {
     "name": "Modify Memory",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",
@@ -3301,7 +3301,7 @@
   },
   {
     "name": "Moonbeam",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a moonseed leaf)",
@@ -3316,7 +3316,7 @@
   },
   {
     "name": "Move Earth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a miniature shovel)",
@@ -3331,7 +3331,7 @@
   },
   {
     "name": "Nondetection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of diamond dust worth 25+ GP, which the spell consumes)",
@@ -3346,7 +3346,7 @@
   },
   {
     "name": "Passwall",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of sesame seeds)",
@@ -3361,7 +3361,7 @@
   },
   {
     "name": "Pass without Trace",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (ashes from burned mistletoe)",
@@ -3376,7 +3376,7 @@
   },
   {
     "name": "Phantasmal Force",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a bit of fleece)",
@@ -3391,7 +3391,7 @@
   },
   {
     "name": "Phantasmal Killer",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S",
@@ -3406,7 +3406,7 @@
   },
   {
     "name": "Phantom Steed",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "1 minute or Ritual",
     "components": "V, S",
@@ -3421,7 +3421,7 @@
   },
   {
     "name": "Planar Ally",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "10 minutes",
     "components": "V, S",
@@ -3436,7 +3436,7 @@
   },
   {
     "name": "Planar Binding",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 hour",
     "components": "V, S, M (a jewel worth 1,000+ GP, which the spell consumes)",
@@ -3451,7 +3451,7 @@
   },
   {
     "name": "Plane Shift",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a forked, metal rod worth 250+ GP and attuned to a plane of existence)",
@@ -3466,7 +3466,7 @@
   },
   {
     "name": "Plant Growth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action (Overgrowth) or 8 hours (Enrichment)",
     "components": "V, S",
@@ -3481,7 +3481,7 @@
   },
   {
     "name": "Poison Spray",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -3496,7 +3496,7 @@
   },
   {
     "name": "Polymorph",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a caterpillar cocoon)",
@@ -3511,7 +3511,7 @@
   },
   {
     "name": "Power Word Heal",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -3526,7 +3526,7 @@
   },
   {
     "name": "Power Word Kill",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -3541,7 +3541,7 @@
   },
   {
     "name": "Power Word Stun",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -3556,7 +3556,7 @@
   },
   {
     "name": "Prayer of Healing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "10 minutes",
     "components": "V",
@@ -3571,7 +3571,7 @@
   },
   {
     "name": "Prestidigitation",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -3586,7 +3586,7 @@
   },
   {
     "name": "Prismatic Spray",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -3601,7 +3601,7 @@
   },
   {
     "name": "Prismatic Wall",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3616,7 +3616,7 @@
   },
   {
     "name": "Private Sanctum",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "10 minutes",
     "components": "V, S, M (a thin sheet of lead)",
@@ -3631,7 +3631,7 @@
   },
   {
     "name": "Produce Flame",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Bonus Action",
     "components": "V, S",
@@ -3646,7 +3646,7 @@
   },
   {
     "name": "Programmed Illusion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (jade dust worth 25+ GP)",
@@ -3661,7 +3661,7 @@
   },
   {
     "name": "Project Image",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a statuette of yourself worth 5+ GP)",
@@ -3676,7 +3676,7 @@
   },
   {
     "name": "Protection from Energy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3691,7 +3691,7 @@
   },
   {
     "name": "Protection from Evil and Good",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a flask of Holy Water worth 25+ GP, which the spell consumes)",
@@ -3706,7 +3706,7 @@
   },
   {
     "name": "Protection from Poison",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3721,7 +3721,7 @@
   },
   {
     "name": "Purify Food and Drink",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action or Ritual",
     "components": "V, S",
@@ -3736,7 +3736,7 @@
   },
   {
     "name": "Raise Dead",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 hour",
     "components": "V, S, M (a diamond worth 500+ GP, which the spell consumes)",
@@ -3751,7 +3751,7 @@
   },
   {
     "name": "Ray of Enfeeblement",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -3766,7 +3766,7 @@
   },
   {
     "name": "Ray of Frost",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -3781,7 +3781,7 @@
   },
   {
     "name": "Regenerate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "1 minute",
     "components": "V, S, M (a prayer wheel)",
@@ -3796,7 +3796,7 @@
   },
   {
     "name": "Ray of Sickness",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -3811,7 +3811,7 @@
   },
   {
     "name": "Reincarnate",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 hour",
     "components": "V, S, M (rare oils worth 1,000+ GP, which the spell consumes)",
@@ -3826,7 +3826,7 @@
   },
   {
     "name": "Remove Curse",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3841,7 +3841,7 @@
   },
   {
     "name": "Resilient Sphere",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a glass sphere)",
@@ -3856,7 +3856,7 @@
   },
   {
     "name": "Resistance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -3871,7 +3871,7 @@
   },
   {
     "name": "Resurrection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 hour",
     "components": "V, S, M (a diamond worth 1,000+ GP, which the spell consumes)",
@@ -3886,7 +3886,7 @@
   },
   {
     "name": "Reverse Gravity",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a lodestone and iron filings)",
@@ -3901,7 +3901,7 @@
   },
   {
     "name": "Revivify",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S, M (a diamond worth 300+ GP, which the spell consumes)",
@@ -3916,7 +3916,7 @@
   },
   {
     "name": "Rope Trick",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a segment of rope)",
@@ -3931,7 +3931,7 @@
   },
   {
     "name": "Sacred Flame",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -3946,7 +3946,7 @@
   },
   {
     "name": "Sanctuary",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Bonus Action",
     "components": "V, S, M (a shard of glass from a mirror)",
@@ -3961,7 +3961,7 @@
   },
   {
     "name": "Scorching Ray",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -3976,7 +3976,7 @@
   },
   {
     "name": "Scrying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "10 minutes",
     "components": "V, S, M (a focus worth 1,000+ GP, such as a crystal ball, mirror, or water-filled font)",
@@ -3991,7 +3991,7 @@
   },
   {
     "name": "Searing Smite",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Bonus Action, which you take immediately after hitting a target with a Melee weapon or an Unarmed Strike",
     "components": "V",
@@ -4006,7 +4006,7 @@
   },
   {
     "name": "Secret Chest",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a chest, 3 feet by 2 feet by 2 feet, constructed from rare materials worth 5,000+ GP, and a Tiny replica of the chest made from the same materials worth 50+ GP)",
@@ -4021,7 +4021,7 @@
   },
   {
     "name": "See Invisibility",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of talc)",
@@ -4036,7 +4036,7 @@
   },
   {
     "name": "Seeming",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S",
@@ -4051,7 +4051,7 @@
   },
   {
     "name": "Sending",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (a copper wire)",
@@ -4066,7 +4066,7 @@
   },
   {
     "name": "Sequester",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (gem dust worth 5,000+ GP, which the spell consumes)",
@@ -4081,7 +4081,7 @@
   },
   {
     "name": "Shapechange",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a jade circlet worth 1,500+ GP)",
@@ -4096,7 +4096,7 @@
   },
   {
     "name": "Shatter",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a chip of mica)",
@@ -4111,7 +4111,7 @@
   },
   {
     "name": "Shield",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Reaction, which you take when you are hit by an attack roll or targeted by the Magic Missile spell",
     "components": "V, S",
@@ -4126,7 +4126,7 @@
   },
   {
     "name": "Shield of Faith",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Bonus Action",
     "components": "V, S, M (a prayer scroll)",
@@ -4141,7 +4141,7 @@
   },
   {
     "name": "Shillelagh",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action",
     "components": "V, S, M (mistletoe)",
@@ -4156,7 +4156,7 @@
   },
   {
     "name": "Shining Smite",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Bonus Action, which you take immediately after hitting a creature with a Melee weapon or an Unarmed Strike",
     "components": "V",
@@ -4171,7 +4171,7 @@
   },
   {
     "name": "Shocking Grasp",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -4186,7 +4186,7 @@
   },
   {
     "name": "Silence",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action or Ritual",
     "components": "V, S",
@@ -4201,7 +4201,7 @@
   },
   {
     "name": "Silent Image",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S, M (a bit of fleece)",
@@ -4216,7 +4216,7 @@
   },
   {
     "name": "Simulacrum",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "12 hours",
     "components": "V, S, M (powdered ruby worth 1,500+ GP, which the spell consumes)",
@@ -4231,7 +4231,7 @@
   },
   {
     "name": "Sleep",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S, M (a pinch of sand or rose petals)",
@@ -4246,7 +4246,7 @@
   },
   {
     "name": "Sleet Storm",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a miniature umbrella)",
@@ -4261,7 +4261,7 @@
   },
   {
     "name": "Slow",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a drop of molasses)",
@@ -4276,7 +4276,7 @@
   },
   {
     "name": "Sorcerous Burst",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -4291,7 +4291,7 @@
   },
   {
     "name": "Spare the Dying",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -4306,7 +4306,7 @@
   },
   {
     "name": "Speak with Animals",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S",
@@ -4321,7 +4321,7 @@
   },
   {
     "name": "Speak with Dead",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S, M (burning incense)",
@@ -4336,7 +4336,7 @@
   },
   {
     "name": "Speak with Plants",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -4351,7 +4351,7 @@
   },
   {
     "name": "Spider Climb",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a drop of bitumen and a spider)",
@@ -4366,7 +4366,7 @@
   },
   {
     "name": "Spike Growth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (seven thorns)",
@@ -4381,7 +4381,7 @@
   },
   {
     "name": "Spirit Guardians",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a prayer scroll)",
@@ -4396,7 +4396,7 @@
   },
   {
     "name": "Spiritual Weapon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Bonus Action",
     "components": "V, S",
@@ -4411,7 +4411,7 @@
   },
   {
     "name": "Starry Wisp",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -4426,7 +4426,7 @@
   },
   {
     "name": "Stinking Cloud",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a rotten egg)",
@@ -4441,7 +4441,7 @@
   },
   {
     "name": "Stone Shape",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (soft clay)",
@@ -4456,7 +4456,7 @@
   },
   {
     "name": "Stoneskin",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (diamond dust worth 100+ GP, which the spell consumes)",
@@ -4471,7 +4471,7 @@
   },
   {
     "name": "Storm of Vengeance",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -4486,7 +4486,7 @@
   },
   {
     "name": "Suggestion",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, M (a drop of honey)",
@@ -4501,7 +4501,7 @@
   },
   {
     "name": "Summon Dragon",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (an object with the image of a dragon engraved on it worth 500+ GP)",
@@ -4516,7 +4516,7 @@
   },
   {
     "name": "Sunbeam",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a magnifying glass)",
@@ -4531,7 +4531,7 @@
   },
   {
     "name": "Sunburst",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a piece of sunstone)",
@@ -4546,7 +4546,7 @@
   },
   {
     "name": "Symbol",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "1 minute",
     "components": "V, S, M (powdered diamond worth 1,000+ GP, which the spell consumes)",
@@ -4561,7 +4561,7 @@
   },
   {
     "name": "Telekinesis",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S",
@@ -4576,7 +4576,7 @@
   },
   {
     "name": "Telepathic Bond",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (two eggs)",
@@ -4591,7 +4591,7 @@
   },
   {
     "name": "Teleport",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V",
@@ -4606,7 +4606,7 @@
   },
   {
     "name": "Teleportation Circle",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "1 minute",
     "components": "V, M (rare inks worth 50+ GP, which the spell consumes)",
@@ -4621,7 +4621,7 @@
   },
   {
     "name": "Thaumaturgy",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V",
@@ -4636,7 +4636,7 @@
   },
   {
     "name": "Thunderwave",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S",
@@ -4651,7 +4651,7 @@
   },
   {
     "name": "Time Stop",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V",
@@ -4666,7 +4666,7 @@
   },
   {
     "name": "Tiny Hut",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "1 minute or Ritual",
     "components": "V, S, M (a crystal bead)",
@@ -4681,7 +4681,7 @@
   },
   {
     "name": "Tongues",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, M (a miniature ziggurat)",
@@ -4696,7 +4696,7 @@
   },
   {
     "name": "Transport via Plants",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -4711,7 +4711,7 @@
   },
   {
     "name": "Tree Stride",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S",
@@ -4726,7 +4726,7 @@
   },
   {
     "name": "True Polymorph",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action",
     "components": "V, S, M (a drop of mercury, a dollop of gum arabic, and a wisp of smoke)",
@@ -4741,7 +4741,7 @@
   },
   {
     "name": "True Resurrection",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "1 hour",
     "components": "V, S, M (diamonds worth 25,000+ GP, which the spell consumes)",
@@ -4756,7 +4756,7 @@
   },
   {
     "name": "True Seeing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "V, S, M (mushroom powder worth 25+ GP, which the spell consumes)",
@@ -4771,7 +4771,7 @@
   },
   {
     "name": "True Strike",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Divination",
     "casting_time": "Action",
     "components": "S, M (a weapon with which you have proficiency and that is worth 1+ CP)",
@@ -4786,7 +4786,7 @@
   },
   {
     "name": "Tsunami",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "1 minute",
     "components": "V, S",
@@ -4801,7 +4801,7 @@
   },
   {
     "name": "Unseen Servant",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a bit of string and of wood)",
@@ -4816,7 +4816,7 @@
   },
   {
     "name": "Vampiric Touch",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Necromancy",
     "casting_time": "Action",
     "components": "V, S",
@@ -4831,7 +4831,7 @@
   },
   {
     "name": "Vicious Mockery",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V",
@@ -4846,7 +4846,7 @@
   },
   {
     "name": "Vitriolic Sphere",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a drop of bile)",
@@ -4861,7 +4861,7 @@
   },
   {
     "name": "Wall of Fire",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a piece of charcoal)",
@@ -4876,7 +4876,7 @@
   },
   {
     "name": "Wall of Force",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a shard of glass)",
@@ -4891,7 +4891,7 @@
   },
   {
     "name": "Wall of Ice",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a piece of quartz)",
@@ -4906,7 +4906,7 @@
   },
   {
     "name": "Wall of Stone",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a cube of granite)",
@@ -4921,7 +4921,7 @@
   },
   {
     "name": "Wall of Thorns",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a handful of thorns)",
@@ -4936,7 +4936,7 @@
   },
   {
     "name": "Warding Bond",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Abjuration",
     "casting_time": "Action",
     "components": "V, S, M (a pair of platinum rings worth 50+ GP each, which you and the target must wear for the duration)",
@@ -4951,7 +4951,7 @@
   },
   {
     "name": "Water Breathing",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a short reed)",
@@ -4966,7 +4966,7 @@
   },
   {
     "name": "Water Walk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "Action or Ritual",
     "components": "V, S, M (a piece of cork)",
@@ -4981,7 +4981,7 @@
   },
   {
     "name": "Web",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V, S, M (a bit of spiderweb)",
@@ -4996,7 +4996,7 @@
   },
   {
     "name": "Weird",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Illusion",
     "casting_time": "Action",
     "components": "V, S",
@@ -5011,7 +5011,7 @@
   },
   {
     "name": "Wind Walk",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Transmutation",
     "casting_time": "1 minute",
     "components": "V, S, M (a candle)",
@@ -5026,7 +5026,7 @@
   },
   {
     "name": "Wind Wall",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Evocation",
     "casting_time": "Action",
     "components": "V, S, M (a fan and a feather)",
@@ -5041,7 +5041,7 @@
   },
   {
     "name": "Wish",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V",
@@ -5056,7 +5056,7 @@
   },
   {
     "name": "Word of Recall",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Conjuration",
     "casting_time": "Action",
     "components": "V",
@@ -5071,7 +5071,7 @@
   },
   {
     "name": "Zone of Truth",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "school": "Enchantment",
     "casting_time": "Action",
     "components": "V, S",

--- a/db/seeds/5th-edition/subclasses.json
+++ b/db/seeds/5th-edition/subclasses.json
@@ -2,7 +2,7 @@
   {
     "name": "Path of the Berserker",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -15,7 +15,7 @@
   {
     "name": "College of Lore",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -28,7 +28,7 @@
   {
     "name": "Life Domain",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -41,7 +41,7 @@
   {
     "name": "Circle of the Land",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -54,7 +54,7 @@
   {
     "name": "Champion",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -67,7 +67,7 @@
   {
     "name": "Warrior of the Open Hand",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -80,7 +80,7 @@
   {
     "name": "Oath of Devotion",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -93,7 +93,7 @@
   {
     "name": "Hunter",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -106,7 +106,7 @@
   {
     "name": "Thief",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -119,7 +119,7 @@
   {
     "name": "Draconic Sorcery",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -132,7 +132,7 @@
   {
     "name": "Fiend Patron",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",
@@ -145,7 +145,7 @@
   {
     "name": "Evoker",
     "rule_type": "Subclass",
-    "core_rules": "5th Edition",
+    "core_rules": "dnd5e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Wizards of the Coast LLC",

--- a/db/seeds/draw-steel/abilities.json
+++ b/db/seeds/draw-steel/abilities.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Arrest (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -18,7 +18,7 @@
   },
   {
     "name": "Back Blasphemer!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -35,7 +35,7 @@
   },
   {
     "name": "Behold a Shield of Faith! (3 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -52,7 +52,7 @@
   },
   {
     "name": "Behold the Face of Justice! (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -69,7 +69,7 @@
   },
   {
     "name": "Censored (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -86,7 +86,7 @@
   },
   {
     "name": "Driving Assault (3 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -103,7 +103,7 @@
   },
   {
     "name": "Every Step... Death!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -120,7 +120,7 @@
   },
   {
     "name": "Faithful Friend",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -137,7 +137,7 @@
   },
   {
     "name": "Grave Speech",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -154,7 +154,7 @@
   },
   {
     "name": "Halt Miscreant!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -171,7 +171,7 @@
   },
   {
     "name": "Hands of the Maker",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -188,7 +188,7 @@
   },
   {
     "name": "Judgment",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -205,7 +205,7 @@
   },
   {
     "name": "My Life for Yours",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -222,7 +222,7 @@
   },
   {
     "name": "Purifying Fire (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -239,7 +239,7 @@
   },
   {
     "name": "Repent! (3 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -256,7 +256,7 @@
   },
   {
     "name": "The Gods Punish and Defend (3 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -273,7 +273,7 @@
   },
   {
     "name": "Your Allies Cannot Save You!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -290,7 +290,7 @@
   },
   {
     "name": "Blessing of the Faithful (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -307,7 +307,7 @@
   },
   {
     "name": "It Is Justice You Fear (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -324,7 +324,7 @@
   },
   {
     "name": "Prescient Grace (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -341,7 +341,7 @@
   },
   {
     "name": "Revelator (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -358,7 +358,7 @@
   },
   {
     "name": "Sentenced (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -375,7 +375,7 @@
   },
   {
     "name": "With My Blessing (5 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -392,7 +392,7 @@
   },
   {
     "name": "Edict of Disruptive Isolation (7 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -409,7 +409,7 @@
   },
   {
     "name": "Edict of Perfect Order (7 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -426,7 +426,7 @@
   },
   {
     "name": "Edict of Purifying Pacifism (7 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -443,7 +443,7 @@
   },
   {
     "name": "Edict of Stillness (7 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -460,7 +460,7 @@
   },
   {
     "name": "Blessing of Secrets",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -477,7 +477,7 @@
   },
   {
     "name": "Gods Grant Thee Strength (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -494,7 +494,7 @@
   },
   {
     "name": "Orison of Victory (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -511,7 +511,7 @@
   },
   {
     "name": "Righteous Judgment (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -528,7 +528,7 @@
   },
   {
     "name": "Shield of the Righteous (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -545,7 +545,7 @@
   },
   {
     "name": "Begone! (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -562,7 +562,7 @@
   },
   {
     "name": "Burden of Evil (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -579,7 +579,7 @@
   },
   {
     "name": "Congregation (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -596,7 +596,7 @@
   },
   {
     "name": "Edict of Peace (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -613,7 +613,7 @@
   },
   {
     "name": "Intercede (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -630,7 +630,7 @@
   },
   {
     "name": "Pain of Your Own Making (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -647,7 +647,7 @@
   },
   {
     "name": "Guided to Your Side",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -664,7 +664,7 @@
   },
   {
     "name": "Trinity of Trickery (9 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -681,7 +681,7 @@
   },
   {
     "name": "Excommunication (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -698,7 +698,7 @@
   },
   {
     "name": "Hand of the Gods (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -715,7 +715,7 @@
   },
   {
     "name": "Pillar of Holy Fire (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -732,7 +732,7 @@
   },
   {
     "name": "Your Allies Turn on You! (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -749,7 +749,7 @@
   },
   {
     "name": "Apostate (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -766,7 +766,7 @@
   },
   {
     "name": "Banish (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -783,7 +783,7 @@
   },
   {
     "name": "Blessing and a Curse (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -800,7 +800,7 @@
   },
   {
     "name": "Edict of Unyielding Resolve (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -817,7 +817,7 @@
   },
   {
     "name": "Fulfill Your Destiny (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -834,7 +834,7 @@
   },
   {
     "name": "Terror Manifest (11 Wrath)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -851,7 +851,7 @@
   },
   {
     "name": "Charge",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -868,7 +868,7 @@
   },
   {
     "name": "Defend",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -885,7 +885,7 @@
   },
   {
     "name": "Free Strike",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -902,7 +902,7 @@
   },
   {
     "name": "Heal",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -919,7 +919,7 @@
   },
   {
     "name": "Aid Attack",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -936,7 +936,7 @@
   },
   {
     "name": "Catch Breath",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -953,7 +953,7 @@
   },
   {
     "name": "Escape Grab",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -970,7 +970,7 @@
   },
   {
     "name": "Grab",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -987,7 +987,7 @@
   },
   {
     "name": "Hide",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1004,7 +1004,7 @@
   },
   {
     "name": "Knockback",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1021,7 +1021,7 @@
   },
   {
     "name": "Make or Assist a Test",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1038,7 +1038,7 @@
   },
   {
     "name": "Search for Hidden Creatures",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1055,7 +1055,7 @@
   },
   {
     "name": "Stand Up",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1072,7 +1072,7 @@
   },
   {
     "name": "Use Consumable",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1089,7 +1089,7 @@
   },
   {
     "name": "Advance",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1106,7 +1106,7 @@
   },
   {
     "name": "Disengage",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1123,7 +1123,7 @@
   },
   {
     "name": "Ride",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1140,7 +1140,7 @@
   },
   {
     "name": "Blessed Light",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1157,7 +1157,7 @@
   },
   {
     "name": "Call the Thunder Down (3 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1174,7 +1174,7 @@
   },
   {
     "name": "Corruption's Curse (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1191,7 +1191,7 @@
   },
   {
     "name": "Curse of Terror (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1208,7 +1208,7 @@
   },
   {
     "name": "Drain",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1225,7 +1225,7 @@
   },
   {
     "name": "Faith Is Our Armor (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1242,7 +1242,7 @@
   },
   {
     "name": "Faithful Friend",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1259,7 +1259,7 @@
   },
   {
     "name": "Font of Wrath (3 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1276,7 +1276,7 @@
   },
   {
     "name": "Grave Speech",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1293,7 +1293,7 @@
   },
   {
     "name": "Hands of the Maker",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1310,7 +1310,7 @@
   },
   {
     "name": "Healing Grace",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1327,7 +1327,7 @@
   },
   {
     "name": "Holy Lash",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1344,7 +1344,7 @@
   },
   {
     "name": "Judgment's Hammer (3 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1361,7 +1361,7 @@
   },
   {
     "name": "Lightfall",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1378,7 +1378,7 @@
   },
   {
     "name": "Ray of Wrath",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1395,7 +1395,7 @@
   },
   {
     "name": "Sacrificial Offer",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1412,7 +1412,7 @@
   },
   {
     "name": "Sermon of Grace (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1429,7 +1429,7 @@
   },
   {
     "name": "Staggering Curse",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1446,7 +1446,7 @@
   },
   {
     "name": "Violence Will Not Aid Thee (3 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1463,7 +1463,7 @@
   },
   {
     "name": "Warrior's Prayer",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1480,7 +1480,7 @@
   },
   {
     "name": "Wither",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1497,7 +1497,7 @@
   },
   {
     "name": "Word of Guidance",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1514,7 +1514,7 @@
   },
   {
     "name": "Word of Judgment",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1531,7 +1531,7 @@
   },
   {
     "name": "Blessing of Fate and Destiny (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1548,7 +1548,7 @@
   },
   {
     "name": "Blessing of Insight (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1565,7 +1565,7 @@
   },
   {
     "name": "Divine Comedy (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1582,7 +1582,7 @@
   },
   {
     "name": "Morning Light (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1599,7 +1599,7 @@
   },
   {
     "name": "Nature Judges Thee (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1616,7 +1616,7 @@
   },
   {
     "name": "Our Hearts Your Strength (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1633,7 +1633,7 @@
   },
   {
     "name": "Reap (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1650,7 +1650,7 @@
   },
   {
     "name": "Sacred Bond (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1667,7 +1667,7 @@
   },
   {
     "name": "Saint's Tempest (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1684,7 +1684,7 @@
   },
   {
     "name": "Statue of Power (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1701,7 +1701,7 @@
   },
   {
     "name": "The Gods Command You Obey (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1718,7 +1718,7 @@
   },
   {
     "name": "Wellspring of Grace (5 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1735,7 +1735,7 @@
   },
   {
     "name": "Fear of the Gods (7 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1752,7 +1752,7 @@
   },
   {
     "name": "Saint's Raiment (7 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1769,7 +1769,7 @@
   },
   {
     "name": "Soul Siphon (7 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1786,7 +1786,7 @@
   },
   {
     "name": "Words of Wrath and Grace (7 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1803,7 +1803,7 @@
   },
   {
     "name": "Beacon of Grace (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1820,7 +1820,7 @@
   },
   {
     "name": "Blessing of Secrets",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1837,7 +1837,7 @@
   },
   {
     "name": "Penance (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1854,7 +1854,7 @@
   },
   {
     "name": "Sanctuary (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1871,7 +1871,7 @@
   },
   {
     "name": "Vessel of Retribution (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1888,7 +1888,7 @@
   },
   {
     "name": "Beacon of Grace (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1905,7 +1905,7 @@
   },
   {
     "name": "Penance (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1922,7 +1922,7 @@
   },
   {
     "name": "Sanctuary (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1939,7 +1939,7 @@
   },
   {
     "name": "Vessel of Retribution (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1956,7 +1956,7 @@
   },
   {
     "name": "Aura of Souls (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1973,7 +1973,7 @@
   },
   {
     "name": "Blade of the Heavens (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1990,7 +1990,7 @@
   },
   {
     "name": "Blessing of the Midday Sun (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2007,7 +2007,7 @@
   },
   {
     "name": "Cuirass of the Gods (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2024,7 +2024,7 @@
   },
   {
     "name": "Gods' Machine (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2041,7 +2041,7 @@
   },
   {
     "name": "Invocation of Mystery (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2058,7 +2058,7 @@
   },
   {
     "name": "Invocation of Undoing (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2075,7 +2075,7 @@
   },
   {
     "name": "Lauded by God (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2092,7 +2092,7 @@
   },
   {
     "name": "Lightning Lord (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2109,7 +2109,7 @@
   },
   {
     "name": "Revitalizing Grace (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2126,7 +2126,7 @@
   },
   {
     "name": "Spirit Stampede (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2143,7 +2143,7 @@
   },
   {
     "name": "Your Story Ends Here (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2160,7 +2160,7 @@
   },
   {
     "name": "Arise! (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2177,7 +2177,7 @@
   },
   {
     "name": "Blessing of Steel (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2194,7 +2194,7 @@
   },
   {
     "name": "Blessing of the Blade (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2211,7 +2211,7 @@
   },
   {
     "name": "Drag the Unworthy (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2228,7 +2228,7 @@
   },
   {
     "name": "Guided to Your Side",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2245,7 +2245,7 @@
   },
   {
     "name": "Trinity of Trickery (9 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2262,7 +2262,7 @@
   },
   {
     "name": "Arise! (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2279,7 +2279,7 @@
   },
   {
     "name": "Blessing of Steel (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2296,7 +2296,7 @@
   },
   {
     "name": "Blessing of the Blade (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2313,7 +2313,7 @@
   },
   {
     "name": "Drag the Unworthy (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2330,7 +2330,7 @@
   },
   {
     "name": "Alacrity of the Heart (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2347,7 +2347,7 @@
   },
   {
     "name": "Bend Fate (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2364,7 +2364,7 @@
   },
   {
     "name": "Blessing of the Fortress (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2381,7 +2381,7 @@
   },
   {
     "name": "Divine Dragon (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2398,7 +2398,7 @@
   },
   {
     "name": "Godstorm (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2415,7 +2415,7 @@
   },
   {
     "name": "Night Falls (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2432,7 +2432,7 @@
   },
   {
     "name": "Radiance of Grace (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2449,7 +2449,7 @@
   },
   {
     "name": "Righteous Phalanx (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2466,7 +2466,7 @@
   },
   {
     "name": "Solar Flare (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2483,7 +2483,7 @@
   },
   {
     "name": "Thorn Cage (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2500,7 +2500,7 @@
   },
   {
     "name": "Word of Final Redemption (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2517,7 +2517,7 @@
   },
   {
     "name": "Word of Weakening (11 Piety)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2534,7 +2534,7 @@
   },
   {
     "name": "Afflict a Bountiful Decay",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2551,7 +2551,7 @@
   },
   {
     "name": "Behold the Mystery (3 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2568,7 +2568,7 @@
   },
   {
     "name": "Bifurcated Incineration",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2585,7 +2585,7 @@
   },
   {
     "name": "Breath of Dawn Remembered",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2602,7 +2602,7 @@
   },
   {
     "name": "Conflagration (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2619,7 +2619,7 @@
   },
   {
     "name": "Explosive Assistance",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2636,7 +2636,7 @@
   },
   {
     "name": "Grasp of Beyond",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2653,7 +2653,7 @@
   },
   {
     "name": "Hurl Element",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2670,7 +2670,7 @@
   },
   {
     "name": "Instantaneous Excavation (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2687,7 +2687,7 @@
   },
   {
     "name": "Invigorating Growth (3 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2704,7 +2704,7 @@
   },
   {
     "name": "Meteoric Introduction",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2721,7 +2721,7 @@
   },
   {
     "name": "Motivate Earth",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2738,7 +2738,7 @@
   },
   {
     "name": "No More Than a Breeze (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2755,7 +2755,7 @@
   },
   {
     "name": "Practical Magic",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2772,7 +2772,7 @@
   },
   {
     "name": "Ray of Agonizing Self-Reflection",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2789,7 +2789,7 @@
   },
   {
     "name": "Return to Formlessness",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2806,7 +2806,7 @@
   },
   {
     "name": "Ripples in the Earth (3 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2823,7 +2823,7 @@
   },
   {
     "name": "Shared Void Sense",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2840,7 +2840,7 @@
   },
   {
     "name": "Skin Like Castle Walls",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2857,7 +2857,7 @@
   },
   {
     "name": "Subtle Relocation",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2874,7 +2874,7 @@
   },
   {
     "name": "Test of Rain (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2891,7 +2891,7 @@
   },
   {
     "name": "The Flesh, a Crucible (3 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2908,7 +2908,7 @@
   },
   {
     "name": "The Green Within, the Green Without",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2925,7 +2925,7 @@
   },
   {
     "name": "Unquiet Ground",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2942,7 +2942,7 @@
   },
   {
     "name": "Viscous Fire",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2959,7 +2959,7 @@
   },
   {
     "name": "O Flower Aid, O Earth Defend (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2976,7 +2976,7 @@
   },
   {
     "name": "Subvert the Green Within (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -2993,7 +2993,7 @@
   },
   {
     "name": "There Is No Space Between",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3010,7 +3010,7 @@
   },
   {
     "name": "Translated Through Flame (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3027,7 +3027,7 @@
   },
   {
     "name": "Volcano's Embrace (5 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3044,7 +3044,7 @@
   },
   {
     "name": "Earth Accepts Me",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3061,7 +3061,7 @@
   },
   {
     "name": "Erase (7 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3078,7 +3078,7 @@
   },
   {
     "name": "Maw of Earth (7 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3095,7 +3095,7 @@
   },
   {
     "name": "Remember Growth and Sun and Rain",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3112,7 +3112,7 @@
   },
   {
     "name": "Swarm of Spirits (7 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3129,7 +3129,7 @@
   },
   {
     "name": "Wall of Fire (7 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3146,7 +3146,7 @@
   },
   {
     "name": "Heart of the Wode (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3163,7 +3163,7 @@
   },
   {
     "name": "Muse of Fire (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3180,7 +3180,7 @@
   },
   {
     "name": "Return to Oblivion (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3197,7 +3197,7 @@
   },
   {
     "name": "Summon Source of Earth",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3214,7 +3214,7 @@
   },
   {
     "name": "World Torn Asunder (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3231,7 +3231,7 @@
   },
   {
     "name": "Combustion Deferred (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3248,7 +3248,7 @@
   },
   {
     "name": "Heart of the Wode (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3265,7 +3265,7 @@
   },
   {
     "name": "Luminous Champion Aloft (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3282,7 +3282,7 @@
   },
   {
     "name": "Magma Titan (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3299,7 +3299,7 @@
   },
   {
     "name": "Meteor (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3316,7 +3316,7 @@
   },
   {
     "name": "Muse of Fire (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3333,7 +3333,7 @@
   },
   {
     "name": "Return to Oblivion (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3350,7 +3350,7 @@
   },
   {
     "name": "Storm of Sands (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3367,7 +3367,7 @@
   },
   {
     "name": "Subverted Perception of Space (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3384,7 +3384,7 @@
   },
   {
     "name": "Summon Source of Earth",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3401,7 +3401,7 @@
   },
   {
     "name": "The Wode Remembers and Returns (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3418,7 +3418,7 @@
   },
   {
     "name": "Web of All That's Come Before (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3435,7 +3435,7 @@
   },
   {
     "name": "World Torn Asunder (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3452,7 +3452,7 @@
   },
   {
     "name": "Luminous Champion Aloft (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3469,7 +3469,7 @@
   },
   {
     "name": "Magma Titan (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3486,7 +3486,7 @@
   },
   {
     "name": "Meteor (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3503,7 +3503,7 @@
   },
   {
     "name": "The Wode Remembers and Returns (9 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3520,7 +3520,7 @@
   },
   {
     "name": "Earth Rejects You (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3537,7 +3537,7 @@
   },
   {
     "name": "Heart of the Wode (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3554,7 +3554,7 @@
   },
   {
     "name": "Muse of Fire (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3571,7 +3571,7 @@
   },
   {
     "name": "Prism (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3588,7 +3588,7 @@
   },
   {
     "name": "Return to Oblivion (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3605,7 +3605,7 @@
   },
   {
     "name": "Summon Source of Earth",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3622,7 +3622,7 @@
   },
   {
     "name": "The Green Defends Its Servants (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3639,7 +3639,7 @@
   },
   {
     "name": "Unquenchable Fire (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3656,7 +3656,7 @@
   },
   {
     "name": "World Torn Asunder (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3673,7 +3673,7 @@
   },
   {
     "name": "Earth Rejects You (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3690,7 +3690,7 @@
   },
   {
     "name": "Prism (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3707,7 +3707,7 @@
   },
   {
     "name": "The Green Defends Its Servants (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3724,7 +3724,7 @@
   },
   {
     "name": "Unquenchable Fire (11 Essence)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3741,7 +3741,7 @@
   },
   {
     "name": "Back! (3 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3758,7 +3758,7 @@
   },
   {
     "name": "Blood for Blood! (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3775,7 +3775,7 @@
   },
   {
     "name": "Brutal Slam",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3792,7 +3792,7 @@
   },
   {
     "name": "Furious Change",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3809,7 +3809,7 @@
   },
   {
     "name": "Hit and Run",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3826,7 +3826,7 @@
   },
   {
     "name": "Impaled!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3843,7 +3843,7 @@
   },
   {
     "name": "Lines of Force",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3860,7 +3860,7 @@
   },
   {
     "name": "Make Peace With Your God! (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3877,7 +3877,7 @@
   },
   {
     "name": "Out of the Way! (3 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3894,7 +3894,7 @@
   },
   {
     "name": "Thunder Roar (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3911,7 +3911,7 @@
   },
   {
     "name": "Tide of Death (3 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3928,7 +3928,7 @@
   },
   {
     "name": "To the Death!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3945,7 +3945,7 @@
   },
   {
     "name": "To the Uttermost End (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3962,7 +3962,7 @@
   },
   {
     "name": "Unearthly Reflexes",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3979,7 +3979,7 @@
   },
   {
     "name": "Your Entrails Are Your Extrails! (3 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -3996,7 +3996,7 @@
   },
   {
     "name": "Apex Predator (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4013,7 +4013,7 @@
   },
   {
     "name": "Death... Death! (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4030,7 +4030,7 @@
   },
   {
     "name": "Phalanx-Breaker (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4047,7 +4047,7 @@
   },
   {
     "name": "Special Delivery (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4064,7 +4064,7 @@
   },
   {
     "name": "Visceral Roar (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4081,7 +4081,7 @@
   },
   {
     "name": "Wrecking Ball (5 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4098,7 +4098,7 @@
   },
   {
     "name": "Demon Unleashed (7 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4115,7 +4115,7 @@
   },
   {
     "name": "Face the Storm! (7 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4132,7 +4132,7 @@
   },
   {
     "name": "Steelbreaker (7 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4149,7 +4149,7 @@
   },
   {
     "name": "You Are Already Dead (7 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4166,7 +4166,7 @@
   },
   {
     "name": "Debilitating Strike (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4183,7 +4183,7 @@
   },
   {
     "name": "My Turn! (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4200,7 +4200,7 @@
   },
   {
     "name": "Rebounding Storm (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4217,7 +4217,7 @@
   },
   {
     "name": "To Stone! (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4234,7 +4234,7 @@
   },
   {
     "name": "Avalanche Impact (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4251,7 +4251,7 @@
   },
   {
     "name": "Death Strike (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4268,7 +4268,7 @@
   },
   {
     "name": "Force of Storms (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4285,7 +4285,7 @@
   },
   {
     "name": "Pounce (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4302,7 +4302,7 @@
   },
   {
     "name": "Riders on the Storm (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4319,7 +4319,7 @@
   },
   {
     "name": "Seek and Destroy (9 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4336,7 +4336,7 @@
   },
   {
     "name": "Elemental Ferocity (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4353,7 +4353,7 @@
   },
   {
     "name": "Overkill (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4370,7 +4370,7 @@
   },
   {
     "name": "Primordial Rage (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4387,7 +4387,7 @@
   },
   {
     "name": "Relentless Death (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4404,7 +4404,7 @@
   },
   {
     "name": "Death Comes for You All! (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4421,7 +4421,7 @@
   },
   {
     "name": "Death Rattle (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4438,7 +4438,7 @@
   },
   {
     "name": "Deluge (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4455,7 +4455,7 @@
   },
   {
     "name": "Primordial Bane (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4472,7 +4472,7 @@
   },
   {
     "name": "Primordial Vortex (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4489,7 +4489,7 @@
   },
   {
     "name": "Shower of Blood (11 Ferocity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4506,7 +4506,7 @@
   },
   {
     "name": "Exploding Arrow",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4523,7 +4523,7 @@
   },
   {
     "name": "Unmooring",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4540,7 +4540,7 @@
   },
   {
     "name": "Fade",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4557,7 +4557,7 @@
   },
   {
     "name": "Double Strike",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4574,7 +4574,7 @@
   },
   {
     "name": "Forward Thrust, Backward Smash",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4591,7 +4591,7 @@
   },
   {
     "name": "Battle Grace",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4608,7 +4608,7 @@
   },
   {
     "name": "Pain for Pain",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4625,7 +4625,7 @@
   },
   {
     "name": "Devastating Rush",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4642,7 +4642,7 @@
   },
   {
     "name": "Let's Dance",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4659,7 +4659,7 @@
   },
   {
     "name": "Raider's Awe",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4676,7 +4676,7 @@
   },
   {
     "name": "Hamstring Shot",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4693,7 +4693,7 @@
   },
   {
     "name": "Two Shot",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4710,7 +4710,7 @@
   },
   {
     "name": "Net and Stab",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4727,7 +4727,7 @@
   },
   {
     "name": "Protective Attack",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4744,7 +4744,7 @@
   },
   {
     "name": "Patient Shot",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4761,7 +4761,7 @@
   },
   {
     "name": "Leaping Lightning",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4778,7 +4778,7 @@
   },
   {
     "name": "Where I Want You",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4795,7 +4795,7 @@
   },
   {
     "name": "Fancy Footwork",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4812,7 +4812,7 @@
   },
   {
     "name": "Shield Bash",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4829,7 +4829,7 @@
   },
   {
     "name": "Weakening Brand",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4846,7 +4846,7 @@
   },
   {
     "name": "Extension of My Arm",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4863,7 +4863,7 @@
   },
   {
     "name": "A Squad Unto Myself (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4880,7 +4880,7 @@
   },
   {
     "name": "Arcane Disruptor (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4897,7 +4897,7 @@
   },
   {
     "name": "Chronal Spike (3 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4914,7 +4914,7 @@
   },
   {
     "name": "Dance of Blows",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4931,7 +4931,7 @@
   },
   {
     "name": "Faster Than the Eye",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4948,7 +4948,7 @@
   },
   {
     "name": "Impart Force (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4965,7 +4965,7 @@
   },
   {
     "name": "Inertial Shield",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4982,7 +4982,7 @@
   },
   {
     "name": "Inertial Step",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -4999,7 +4999,7 @@
   },
   {
     "name": "Joint Lock",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5016,7 +5016,7 @@
   },
   {
     "name": "Kinetic Strike",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5033,7 +5033,7 @@
   },
   {
     "name": "Magnetic Strike",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5050,7 +5050,7 @@
   },
   {
     "name": "Null Field",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5067,7 +5067,7 @@
   },
   {
     "name": "Phase Inversion Strike",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5084,7 +5084,7 @@
   },
   {
     "name": "Phase Strike (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5101,7 +5101,7 @@
   },
   {
     "name": "Pressure Points",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5118,7 +5118,7 @@
   },
   {
     "name": "Psychic Pulse (3 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5135,7 +5135,7 @@
   },
   {
     "name": "Relentless Nemesis (3 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5152,7 +5152,7 @@
   },
   {
     "name": "Stunning Blow (3 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5169,7 +5169,7 @@
   },
   {
     "name": "Blur (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5186,7 +5186,7 @@
   },
   {
     "name": "Entropic Field (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5203,7 +5203,7 @@
   },
   {
     "name": "Force Redirected (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5220,7 +5220,7 @@
   },
   {
     "name": "Gravitic Strike (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5237,7 +5237,7 @@
   },
   {
     "name": "Heat Sink (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5254,7 +5254,7 @@
   },
   {
     "name": "Kinetic Shield (5 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5271,7 +5271,7 @@
   },
   {
     "name": "Absorption Field (7 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5288,7 +5288,7 @@
   },
   {
     "name": "Molecular Rearrangement Field (7 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5305,7 +5305,7 @@
   },
   {
     "name": "Stabilizing Field (7 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5322,7 +5322,7 @@
   },
   {
     "name": "Synapse Field (7 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5339,7 +5339,7 @@
   },
   {
     "name": "Anticipating Strike (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5356,7 +5356,7 @@
   },
   {
     "name": "Iron Grip (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5373,7 +5373,7 @@
   },
   {
     "name": "Phase Leap (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5390,7 +5390,7 @@
   },
   {
     "name": "Synaptic Reset (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5407,7 +5407,7 @@
   },
   {
     "name": "Gravitic Charge (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5424,7 +5424,7 @@
   },
   {
     "name": "Ice Pillars (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5441,7 +5441,7 @@
   },
   {
     "name": "Interphase (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5458,7 +5458,7 @@
   },
   {
     "name": "Iron Body (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5475,7 +5475,7 @@
   },
   {
     "name": "Phase Step (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5492,7 +5492,7 @@
   },
   {
     "name": "Wall of Ice (9 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5509,7 +5509,7 @@
   },
   {
     "name": "Arcane Purge (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5526,7 +5526,7 @@
   },
   {
     "name": "Phase Hurl (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5543,7 +5543,7 @@
   },
   {
     "name": "Scalar Assault (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5560,7 +5560,7 @@
   },
   {
     "name": "Synaptic Anchor (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5577,7 +5577,7 @@
   },
   {
     "name": "Absolute Zero (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5594,7 +5594,7 @@
   },
   {
     "name": "Arrestor Cycle (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5611,7 +5611,7 @@
   },
   {
     "name": "Heat Drain (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5628,7 +5628,7 @@
   },
   {
     "name": "Inertial Absorption (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5645,7 +5645,7 @@
   },
   {
     "name": "Realitas (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5662,7 +5662,7 @@
   },
   {
     "name": "Time Loop (11 Discipline)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5679,7 +5679,7 @@
   },
   {
     "name": "Black Ash Teleport",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5696,7 +5696,7 @@
   },
   {
     "name": "Clever Trick (1 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5713,7 +5713,7 @@
   },
   {
     "name": "Coat the Blade",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5730,7 +5730,7 @@
   },
   {
     "name": "Coup de Grace (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5747,7 +5747,7 @@
   },
   {
     "name": "Defensive Roll",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5764,7 +5764,7 @@
   },
   {
     "name": "Disorienting Strike (3 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5781,7 +5781,7 @@
   },
   {
     "name": "Eviscerate (3 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5798,7 +5798,7 @@
   },
   {
     "name": "Gasping in Pain",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5815,7 +5815,7 @@
   },
   {
     "name": "Get In Get Out (3 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5832,7 +5832,7 @@
   },
   {
     "name": "Hesitation Is Weakness (1 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5849,7 +5849,7 @@
   },
   {
     "name": "I Work Better Alone",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5866,7 +5866,7 @@
   },
   {
     "name": "I'm No Threat",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5883,7 +5883,7 @@
   },
   {
     "name": "In All This Confusion",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5900,7 +5900,7 @@
   },
   {
     "name": "One Hundred Throats (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5917,7 +5917,7 @@
   },
   {
     "name": "Setup (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5934,7 +5934,7 @@
   },
   {
     "name": "Shadowstrike (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5951,7 +5951,7 @@
   },
   {
     "name": "Teamwork Has Its Place",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5968,7 +5968,7 @@
   },
   {
     "name": "Two Throats at Once (3 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -5985,7 +5985,7 @@
   },
   {
     "name": "You Were Watching the Wrong One",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6002,7 +6002,7 @@
   },
   {
     "name": "In a Puff of Ash (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6019,7 +6019,7 @@
   },
   {
     "name": "Machinations of Sound (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6036,7 +6036,7 @@
   },
   {
     "name": "So Gullible (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6053,7 +6053,7 @@
   },
   {
     "name": "Sticky Bomb (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6070,7 +6070,7 @@
   },
   {
     "name": "Stink Bomb (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6087,7 +6087,7 @@
   },
   {
     "name": "Too Slow (5 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6104,7 +6104,7 @@
   },
   {
     "name": "Careful Observation",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6121,7 +6121,7 @@
   },
   {
     "name": "Dancer (7 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6138,7 +6138,7 @@
   },
   {
     "name": "Misdirecting Strike (7 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6155,7 +6155,7 @@
   },
   {
     "name": "Pinning Shot (7 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6172,7 +6172,7 @@
   },
   {
     "name": "Staggering Blow (7 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6189,7 +6189,7 @@
   },
   {
     "name": "Night Watch",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6206,7 +6206,7 @@
   },
   {
     "name": "Blackout (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6223,7 +6223,7 @@
   },
   {
     "name": "Into the Shadows (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6240,7 +6240,7 @@
   },
   {
     "name": "Shadowfall (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6257,7 +6257,7 @@
   },
   {
     "name": "You Talk Too Much (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6274,7 +6274,7 @@
   },
   {
     "name": "Black Ash Eruption (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6291,7 +6291,7 @@
   },
   {
     "name": "Cinderstorm (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6308,7 +6308,7 @@
   },
   {
     "name": "Look! (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6325,7 +6325,7 @@
   },
   {
     "name": "One Vial Makes You Better (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6342,7 +6342,7 @@
   },
   {
     "name": "One Vial Makes You Faster (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6359,7 +6359,7 @@
   },
   {
     "name": "Puppet Strings (9 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6376,7 +6376,7 @@
   },
   {
     "name": "Assassinate (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6393,7 +6393,7 @@
   },
   {
     "name": "Shadowgrasp (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6410,7 +6410,7 @@
   },
   {
     "name": "Speed of Shadows (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6427,7 +6427,7 @@
   },
   {
     "name": "They Always Line Up (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6444,7 +6444,7 @@
   },
   {
     "name": "Time Bomb",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6461,7 +6461,7 @@
   },
   {
     "name": "Cacophony of Cinders (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6478,7 +6478,7 @@
   },
   {
     "name": "Chain Reaction (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6495,7 +6495,7 @@
   },
   {
     "name": "Demon Door (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6512,7 +6512,7 @@
   },
   {
     "name": "I Am You (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6529,7 +6529,7 @@
   },
   {
     "name": "It Was Me All Along (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6546,7 +6546,7 @@
   },
   {
     "name": "To the Stars (11 Insight)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6563,7 +6563,7 @@
   },
   {
     "name": "Advanced Tactics",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6580,7 +6580,7 @@
   },
   {
     "name": "Battle Cry (3 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6597,7 +6597,7 @@
   },
   {
     "name": "Concussive Strike (3 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6614,7 +6614,7 @@
   },
   {
     "name": "Hammer and Anvil (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6631,7 +6631,7 @@
   },
   {
     "name": "Inspiring Strike (3 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6648,7 +6648,7 @@
   },
   {
     "name": "Mark",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6665,7 +6665,7 @@
   },
   {
     "name": "Mind Game (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6682,7 +6682,7 @@
   },
   {
     "name": "Now! (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6699,7 +6699,7 @@
   },
   {
     "name": "Overwatch",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6716,7 +6716,7 @@
   },
   {
     "name": "Parry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6733,7 +6733,7 @@
   },
   {
     "name": "Squad! Forward! (3 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6750,7 +6750,7 @@
   },
   {
     "name": "\"Strike Now!\"",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6767,7 +6767,7 @@
   },
   {
     "name": "This Is What We Planned For (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6784,7 +6784,7 @@
   },
   {
     "name": "Fog of War (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6801,7 +6801,7 @@
   },
   {
     "name": "I've Got Your Back (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6818,7 +6818,7 @@
   },
   {
     "name": "No Dying on My Watch (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6835,7 +6835,7 @@
   },
   {
     "name": "Squad! On Me! (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6852,7 +6852,7 @@
   },
   {
     "name": "Targets of Opportunity (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6869,7 +6869,7 @@
   },
   {
     "name": "Try Me Instead (5 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6886,7 +6886,7 @@
   },
   {
     "name": "Frontal Assault (7 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6903,7 +6903,7 @@
   },
   {
     "name": "Hit 'Em Hard! (7 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6920,7 +6920,7 @@
   },
   {
     "name": "Rout (7 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6937,7 +6937,7 @@
   },
   {
     "name": "Stay Strong and Focus! (7 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6954,7 +6954,7 @@
   },
   {
     "name": "Squad! Gear Check! (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6971,7 +6971,7 @@
   },
   {
     "name": "Squad! Remember Your Training! (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -6988,7 +6988,7 @@
   },
   {
     "name": "Win This Day! (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7005,7 +7005,7 @@
   },
   {
     "name": "You've Still Got Something Left (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7022,7 +7022,7 @@
   },
   {
     "name": "Battle Plan (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7039,7 +7039,7 @@
   },
   {
     "name": "Coordinated Execution (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7056,7 +7056,7 @@
   },
   {
     "name": "Hustle! (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7073,7 +7073,7 @@
   },
   {
     "name": "Instant Retaliation (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7090,7 +7090,7 @@
   },
   {
     "name": "Panic in Their Lines (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7107,7 +7107,7 @@
   },
   {
     "name": "To Me Squad! (9 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7124,7 +7124,7 @@
   },
   {
     "name": "Finish Them! (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7141,7 +7141,7 @@
   },
   {
     "name": "Floodgates Open (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7158,7 +7158,7 @@
   },
   {
     "name": "Go Now and Speed Well (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7175,7 +7175,7 @@
   },
   {
     "name": "I'll Open and You'll Close (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7192,7 +7192,7 @@
   },
   {
     "name": "Blot Out the Sun! (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7209,7 +7209,7 @@
   },
   {
     "name": "Counterstrategy (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7226,7 +7226,7 @@
   },
   {
     "name": "No Escape (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7243,7 +7243,7 @@
   },
   {
     "name": "Squad! Hit and Run! (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7260,7 +7260,7 @@
   },
   {
     "name": "That One Is Mine! (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7277,7 +7277,7 @@
   },
   {
     "name": "Their Lack of Focus Is Their Undoing (11 Focus)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7294,7 +7294,7 @@
   },
   {
     "name": "Accelerate",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7311,7 +7311,7 @@
   },
   {
     "name": "Again",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7328,7 +7328,7 @@
   },
   {
     "name": "Awe (3 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7345,7 +7345,7 @@
   },
   {
     "name": "Choke (3 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7362,7 +7362,7 @@
   },
   {
     "name": "Entropic Bolt",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7379,7 +7379,7 @@
   },
   {
     "name": "Feedback Loop",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7396,7 +7396,7 @@
   },
   {
     "name": "Flashback (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7413,7 +7413,7 @@
   },
   {
     "name": "Hoarfrost",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7430,7 +7430,7 @@
   },
   {
     "name": "Incinerate",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7447,7 +7447,7 @@
   },
   {
     "name": "Inertia Soak (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7464,7 +7464,7 @@
   },
   {
     "name": "Iron (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7481,7 +7481,7 @@
   },
   {
     "name": "Kinetic Grip",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7498,7 +7498,7 @@
   },
   {
     "name": "Kinetic Pulse",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7515,7 +7515,7 @@
   },
   {
     "name": "Materialize",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7532,7 +7532,7 @@
   },
   {
     "name": "Mind Spike",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7549,7 +7549,7 @@
   },
   {
     "name": "Minor Telekinesis",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7566,7 +7566,7 @@
   },
   {
     "name": "Optic Blast",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7583,7 +7583,7 @@
   },
   {
     "name": "Perfect Clarity (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7600,7 +7600,7 @@
   },
   {
     "name": "Precognition (3 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7617,7 +7617,7 @@
   },
   {
     "name": "Remote Assistance",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7634,7 +7634,7 @@
   },
   {
     "name": "Repel",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7651,7 +7651,7 @@
   },
   {
     "name": "Smolder (3 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7668,7 +7668,7 @@
   },
   {
     "name": "Spirit Sword",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7685,7 +7685,7 @@
   },
   {
     "name": "Applied Chronometrics (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7702,7 +7702,7 @@
   },
   {
     "name": "Gravitic Burst (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7719,7 +7719,7 @@
   },
   {
     "name": "Levity and Gravity (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7736,7 +7736,7 @@
   },
   {
     "name": "Overwhelm (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7753,7 +7753,7 @@
   },
   {
     "name": "Slow (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7770,7 +7770,7 @@
   },
   {
     "name": "Synaptic Override (5 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7787,7 +7787,7 @@
   },
   {
     "name": "Fling Through Time (7 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7804,7 +7804,7 @@
   },
   {
     "name": "Force Orbs (7 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7821,7 +7821,7 @@
   },
   {
     "name": "Reflector Field (7 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7838,7 +7838,7 @@
   },
   {
     "name": "Soul Burn (7 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7855,7 +7855,7 @@
   },
   {
     "name": "Exothermic Shield (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7872,7 +7872,7 @@
   },
   {
     "name": "Hypersonic (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7889,7 +7889,7 @@
   },
   {
     "name": "Mind Snare (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7906,7 +7906,7 @@
   },
   {
     "name": "Soulbound (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7923,7 +7923,7 @@
   },
   {
     "name": "Fate (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7940,7 +7940,7 @@
   },
   {
     "name": "Gravitic Well (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7957,7 +7957,7 @@
   },
   {
     "name": "Greater Kinetic Grip (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7974,7 +7974,7 @@
   },
   {
     "name": "Stasis Field (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -7991,7 +7991,7 @@
   },
   {
     "name": "Synaptic Conditioning (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8008,7 +8008,7 @@
   },
   {
     "name": "Synaptic Dissipation (9 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8025,7 +8025,7 @@
   },
   {
     "name": "Doubt (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8042,7 +8042,7 @@
   },
   {
     "name": "Levitation Field",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8059,7 +8059,7 @@
   },
   {
     "name": "Mindwipe (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8076,7 +8076,7 @@
   },
   {
     "name": "Rejuvenate (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8093,7 +8093,7 @@
   },
   {
     "name": "Stasis Shield (3 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8110,7 +8110,7 @@
   },
   {
     "name": "Steel (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8127,7 +8127,7 @@
   },
   {
     "name": "Acceleration Field (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8144,7 +8144,7 @@
   },
   {
     "name": "Borrow From the Future (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8161,7 +8161,7 @@
   },
   {
     "name": "Fulcrum (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8178,7 +8178,7 @@
   },
   {
     "name": "Gravitic Nova (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8195,7 +8195,7 @@
   },
   {
     "name": "Resonant Mind Spike (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8212,7 +8212,7 @@
   },
   {
     "name": "Synaptic Terror (11 Clarity)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8229,7 +8229,7 @@
   },
   {
     "name": "Acrobatics",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8246,7 +8246,7 @@
   },
   {
     "name": "Artful Flourish",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8263,7 +8263,7 @@
   },
   {
     "name": "\"Ballad of the Beast\"",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8280,7 +8280,7 @@
   },
   {
     "name": "Blocking",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8297,7 +8297,7 @@
   },
   {
     "name": "Choreography",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8314,7 +8314,7 @@
   },
   {
     "name": "Cutting Sarcasm",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8331,7 +8331,7 @@
   },
   {
     "name": "Dramatic Monologue",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8348,7 +8348,7 @@
   },
   {
     "name": "Dramatic Reversal (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8365,7 +8365,7 @@
   },
   {
     "name": "Fake Your Death (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8382,7 +8382,7 @@
   },
   {
     "name": "Flip the Script (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8399,7 +8399,7 @@
   },
   {
     "name": "Harmonize (3 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8416,7 +8416,7 @@
   },
   {
     "name": "Harsh Critic (3 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8433,7 +8433,7 @@
   },
   {
     "name": "Hypnotic Overtones (3 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8450,7 +8450,7 @@
   },
   {
     "name": "Instigator",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8467,7 +8467,7 @@
   },
   {
     "name": "Method Acting (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8484,7 +8484,7 @@
   },
   {
     "name": "Power Chord",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8501,7 +8501,7 @@
   },
   {
     "name": "Quick Rewrite (3 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8518,7 +8518,7 @@
   },
   {
     "name": "Revitalizing Limerick",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8535,7 +8535,7 @@
   },
   {
     "name": "Riposte",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8552,7 +8552,7 @@
   },
   {
     "name": "Star Power (1 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8569,7 +8569,7 @@
   },
   {
     "name": "\"Thunder Mother\"",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8586,7 +8586,7 @@
   },
   {
     "name": "Turnabout Is Fair Play",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8603,7 +8603,7 @@
   },
   {
     "name": "Upstage (3 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8620,7 +8620,7 @@
   },
   {
     "name": "Witty Banter",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8637,7 +8637,7 @@
   },
   {
     "name": "Classic Chandelier Stunt (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8654,7 +8654,7 @@
   },
   {
     "name": "En Garde! (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8671,7 +8671,7 @@
   },
   {
     "name": "Encore (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8688,7 +8688,7 @@
   },
   {
     "name": "Guest Star (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8705,7 +8705,7 @@
   },
   {
     "name": "Tough Crowd (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8722,7 +8722,7 @@
   },
   {
     "name": "Twist at the End (5 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8739,7 +8739,7 @@
   },
   {
     "name": "Extensive Rewrites (7 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8756,7 +8756,7 @@
   },
   {
     "name": "\"Fire Up the Night\"",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8773,7 +8773,7 @@
   },
   {
     "name": "Infernal Gavotte (7 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8790,7 +8790,7 @@
   },
   {
     "name": "\"Never-Ending Hero\"",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8807,7 +8807,7 @@
   },
   {
     "name": "Star Solo (7 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8824,7 +8824,7 @@
   },
   {
     "name": "We Meet at Last (7 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8841,7 +8841,7 @@
   },
   {
     "name": "Action Hero (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8858,7 +8858,7 @@
   },
   {
     "name": "Continuity Error (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8875,7 +8875,7 @@
   },
   {
     "name": "Love Song (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8892,7 +8892,7 @@
   },
   {
     "name": "Patter Song (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8909,7 +8909,7 @@
   },
   {
     "name": "Take Two!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8926,7 +8926,7 @@
   },
   {
     "name": "We Can't Be Upstaged!",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8943,7 +8943,7 @@
   },
   {
     "name": "Blood on the Stage (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8960,7 +8960,7 @@
   },
   {
     "name": "Feedback (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8977,7 +8977,7 @@
   },
   {
     "name": "Fight Choreography (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -8994,7 +8994,7 @@
   },
   {
     "name": "Here's How Your Story Ends (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9011,7 +9011,7 @@
   },
   {
     "name": "Legendary Drum Fill (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9028,7 +9028,7 @@
   },
   {
     "name": "Spotlight",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9045,7 +9045,7 @@
   },
   {
     "name": "You're All My Understudies (9 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9062,7 +9062,7 @@
   },
   {
     "name": "Dramatic Reveal (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9079,7 +9079,7 @@
   },
   {
     "name": "Moonlight Sonata",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9096,7 +9096,7 @@
   },
   {
     "name": "Power Ballad (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9113,7 +9113,7 @@
   },
   {
     "name": "Radical Fantasia",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9130,7 +9130,7 @@
   },
   {
     "name": "Saved in the Edit (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9147,7 +9147,7 @@
   },
   {
     "name": "The Show Must Go On (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9164,7 +9164,7 @@
   },
   {
     "name": "Epic (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9181,7 +9181,7 @@
   },
   {
     "name": "Expert Fencer (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9198,7 +9198,7 @@
   },
   {
     "name": "Jam Session (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9215,7 +9215,7 @@
   },
   {
     "name": "Melt Their Faces (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9232,7 +9232,7 @@
   },
   {
     "name": "Renegotiated Contract (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -9249,7 +9249,7 @@
   },
   {
     "name": "Rising Tension (11 Drama)",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/draw-steel/ancestries.json
+++ b/db/seeds/draw-steel/ancestries.json
@@ -2,7 +2,7 @@
   {
     "name": "Devil",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -15,7 +15,7 @@
   {
     "name": "Dragon Knight",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -28,7 +28,7 @@
   {
     "name": "Dwarf",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -41,7 +41,7 @@
   {
     "name": "Hakaan",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -54,7 +54,7 @@
   {
     "name": "High Elf",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -67,7 +67,7 @@
   {
     "name": "Human",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -80,7 +80,7 @@
   {
     "name": "Memonek",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -93,7 +93,7 @@
   {
     "name": "Orc",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -106,7 +106,7 @@
   {
     "name": "Polder",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -119,7 +119,7 @@
   {
     "name": "Revenant",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -132,7 +132,7 @@
   {
     "name": "Time Raider",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -145,7 +145,7 @@
   {
     "name": "Wode Elf",
     "rule_type": "Ancestry",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/draw-steel/careers.json
+++ b/db/seeds/draw-steel/careers.json
@@ -2,7 +2,7 @@
   {
     "name": "Agent",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -15,7 +15,7 @@
   {
     "name": "Aristocrat",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -28,7 +28,7 @@
   {
     "name": "Artisan",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -41,7 +41,7 @@
   {
     "name": "Beggar",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -54,7 +54,7 @@
   {
     "name": "Criminal",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -67,7 +67,7 @@
   {
     "name": "Disciple",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -80,7 +80,7 @@
   {
     "name": "Explorer",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -93,7 +93,7 @@
   {
     "name": "Farmer",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -106,7 +106,7 @@
   {
     "name": "Gladiator",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -119,7 +119,7 @@
   {
     "name": "Laborer",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -132,7 +132,7 @@
   {
     "name": "Mage's Apprentice",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -145,7 +145,7 @@
   {
     "name": "Performer",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -158,7 +158,7 @@
   {
     "name": "Politician",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -171,7 +171,7 @@
   {
     "name": "Sage",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -184,7 +184,7 @@
   {
     "name": "Sailor",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -197,7 +197,7 @@
   {
     "name": "Soldier",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -210,7 +210,7 @@
   {
     "name": "Warden",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -223,7 +223,7 @@
   {
     "name": "Watch Officer",
     "rule_type": "Career",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/draw-steel/classes.json
+++ b/db/seeds/draw-steel/classes.json
@@ -2,7 +2,7 @@
   {
     "name": "Censor",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -15,7 +15,7 @@
   {
     "name": "Conduit",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -28,7 +28,7 @@
   {
     "name": "Elementalist",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -41,7 +41,7 @@
   {
     "name": "Fury",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -54,7 +54,7 @@
   {
     "name": "Null",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -67,7 +67,7 @@
   {
     "name": "Shadow",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -80,7 +80,7 @@
   {
     "name": "Tactician",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -93,7 +93,7 @@
   {
     "name": "Talent",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -106,7 +106,7 @@
   {
     "name": "Troubadour",
     "rule_type": "Class",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/draw-steel/complications.json
+++ b/db/seeds/draw-steel/complications.json
@@ -2,7 +2,7 @@
   {
     "name": "Advanced Studies",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -15,7 +15,7 @@
   {
     "name": "Amnesia",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -28,7 +28,7 @@
   {
     "name": "Animal Form",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -41,7 +41,7 @@
   {
     "name": "Antihero",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -54,7 +54,7 @@
   {
     "name": "Artifact Bonded",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -67,7 +67,7 @@
   {
     "name": "Bereaved",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -80,7 +80,7 @@
   {
     "name": "Betrothed",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -93,7 +93,7 @@
   {
     "name": "Chaos Touched",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -106,7 +106,7 @@
   {
     "name": "Chosen One",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -119,7 +119,7 @@
   {
     "name": "Consuming Interest",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -132,7 +132,7 @@
   {
     "name": "Corrupted Mentor",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -145,7 +145,7 @@
   {
     "name": "Coward",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -158,7 +158,7 @@
   {
     "name": "Crash Landed",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -171,7 +171,7 @@
   {
     "name": "Cult Victim",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -184,7 +184,7 @@
   {
     "name": "Curse of Caution",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -197,7 +197,7 @@
   {
     "name": "Curse of Immortality",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -210,7 +210,7 @@
   {
     "name": "Curse of Misfortune",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -223,7 +223,7 @@
   {
     "name": "Curse of Poverty",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -236,7 +236,7 @@
   {
     "name": "Curse of Punishment",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -249,7 +249,7 @@
   {
     "name": "Curse of Stone",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -262,7 +262,7 @@
   {
     "name": "Cursed Weapon",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -275,7 +275,7 @@
   {
     "name": "Disgraced",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -288,7 +288,7 @@
   {
     "name": "Dragon Dreams",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -301,7 +301,7 @@
   {
     "name": "Elemental Inside",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -314,7 +314,7 @@
   {
     "name": "Evanesceria",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -327,7 +327,7 @@
   {
     "name": "Exile",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -340,7 +340,7 @@
   {
     "name": "Fallen Immortal",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -353,7 +353,7 @@
   {
     "name": "Famous Relative",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -366,7 +366,7 @@
   {
     "name": "Feytouched",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -379,7 +379,7 @@
   {
     "name": "Fiery Ideal",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -392,7 +392,7 @@
   {
     "name": "Fire and Chaos",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -405,7 +405,7 @@
   {
     "name": "Following in the Footsteps",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -418,7 +418,7 @@
   {
     "name": "Forbidden Romance",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -431,7 +431,7 @@
   {
     "name": "Frostheart",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -444,7 +444,7 @@
   {
     "name": "Getting Too Old for This",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -457,7 +457,7 @@
   {
     "name": "Gnoll-Mauled",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -470,7 +470,7 @@
   {
     "name": "Greening",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -483,7 +483,7 @@
   {
     "name": "Grifter",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -496,7 +496,7 @@
   {
     "name": "Grounded",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -509,7 +509,7 @@
   {
     "name": "Guilty Conscience",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -522,7 +522,7 @@
   {
     "name": "Hawk Rider",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -535,7 +535,7 @@
   {
     "name": "Host Body",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -548,7 +548,7 @@
   {
     "name": "Hunted",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -561,7 +561,7 @@
   {
     "name": "Hunter",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -574,7 +574,7 @@
   {
     "name": "Indebted",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -587,7 +587,7 @@
   {
     "name": "Infernal Contract... But, Like, Bad",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -600,7 +600,7 @@
   {
     "name": "Infernal Contract",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -613,7 +613,7 @@
   {
     "name": "Ivory Tower",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -626,7 +626,7 @@
   {
     "name": "Lifebonded",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -639,7 +639,7 @@
   {
     "name": "Lightning Soul",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -652,7 +652,7 @@
   {
     "name": "Loner",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -665,7 +665,7 @@
   {
     "name": "Lost Your Head",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -678,7 +678,7 @@
   {
     "name": "Lost in Time",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -691,7 +691,7 @@
   {
     "name": "Lucky",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -704,7 +704,7 @@
   {
     "name": "Master Chef",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -717,7 +717,7 @@
   {
     "name": "Meddling Butler",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -730,7 +730,7 @@
   {
     "name": "Medium",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -743,7 +743,7 @@
   {
     "name": "Medusa Blood",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -756,7 +756,7 @@
   {
     "name": "Misunderstood",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -769,7 +769,7 @@
   {
     "name": "Mundane",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -782,7 +782,7 @@
   {
     "name": "Outlaw",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -795,7 +795,7 @@
   {
     "name": "Pirate",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -808,7 +808,7 @@
   {
     "name": "Preacher",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -821,7 +821,7 @@
   {
     "name": "Primordial Sickness",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -834,7 +834,7 @@
   {
     "name": "Prisoner of the Synlirii",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -847,7 +847,7 @@
   {
     "name": "Promising Apprentice",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -860,7 +860,7 @@
   {
     "name": "Psychic Eruption",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -873,7 +873,7 @@
   {
     "name": "Raised by Beasts",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -886,7 +886,7 @@
   {
     "name": "Refugee",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -899,7 +899,7 @@
   {
     "name": "Rival",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -912,7 +912,7 @@
   {
     "name": "Rogue Talent",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -925,7 +925,7 @@
   {
     "name": "Runaway",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -938,7 +938,7 @@
   {
     "name": "Searching for a Cure",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -951,7 +951,7 @@
   {
     "name": "Secret Identity",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -964,7 +964,7 @@
   {
     "name": "Secret Twin",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -977,7 +977,7 @@
   {
     "name": "Self-Taught",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -990,7 +990,7 @@
   {
     "name": "Sewer Folk",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1003,7 +1003,7 @@
   {
     "name": "Shadow Born",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1016,7 +1016,7 @@
   {
     "name": "Shared Spirit",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1029,7 +1029,7 @@
   {
     "name": "Shattered Legacy",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1042,7 +1042,7 @@
   {
     "name": "Shipwrecked",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1055,7 +1055,7 @@
   {
     "name": "Sibling's Shield",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1068,7 +1068,7 @@
   {
     "name": "Silent Sentinel",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1081,7 +1081,7 @@
   {
     "name": "Slight Case of Lycanthropy",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1094,7 +1094,7 @@
   {
     "name": "Stolen Face",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1107,7 +1107,7 @@
   {
     "name": "Strange Inheritance",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1120,7 +1120,7 @@
   {
     "name": "Stripped of Rank",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1133,7 +1133,7 @@
   {
     "name": "Thrill Seeker",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1146,7 +1146,7 @@
   {
     "name": "Vampire Scion",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1159,7 +1159,7 @@
   {
     "name": "Voice in Your Head",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1172,7 +1172,7 @@
   {
     "name": "Vow of Duty",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1185,7 +1185,7 @@
   {
     "name": "Vow of Honesty",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1198,7 +1198,7 @@
   {
     "name": "Waking Dreams",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1211,7 +1211,7 @@
   {
     "name": "War Dog Collar",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1224,7 +1224,7 @@
   {
     "name": "War of Assassins",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1237,7 +1237,7 @@
   {
     "name": "Ward",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1250,7 +1250,7 @@
   {
     "name": "Waterborn",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1263,7 +1263,7 @@
   {
     "name": "Wodewalker",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1276,7 +1276,7 @@
   {
     "name": "Wrathful Spirit",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -1289,7 +1289,7 @@
   {
     "name": "Wrongly Imprisoned",
     "rule_type": "Complication",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/draw-steel/conditions.json
+++ b/db/seeds/draw-steel/conditions.json
@@ -2,7 +2,7 @@
   {
     "name": "Bleeding",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -15,7 +15,7 @@
   {
     "name": "Dazed",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -28,7 +28,7 @@
   {
     "name": "Frightened",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -41,7 +41,7 @@
   {
     "name": "Grabbed",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -54,7 +54,7 @@
   {
     "name": "Prone",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -67,7 +67,7 @@
   {
     "name": "Restrained",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -80,7 +80,7 @@
   {
     "name": "Slowed",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -93,7 +93,7 @@
   {
     "name": "Taunted",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -106,7 +106,7 @@
   {
     "name": "Weakened",
     "rule_type": "Condition",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/draw-steel/kits.json
+++ b/db/seeds/draw-steel/kits.json
@@ -2,7 +2,7 @@
   {
     "name": "Arcane Archer",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -15,7 +15,7 @@
   {
     "name": "Battlemind",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -28,7 +28,7 @@
   {
     "name": "Cloak and Dagger",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -41,7 +41,7 @@
   {
     "name": "Dual Wielder",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -54,7 +54,7 @@
   {
     "name": "Guisarmier",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -67,7 +67,7 @@
   {
     "name": "Martial Artist",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -80,7 +80,7 @@
   {
     "name": "Mountain",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -93,7 +93,7 @@
   {
     "name": "Panther",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -106,7 +106,7 @@
   {
     "name": "Pugilist",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -119,7 +119,7 @@
   {
     "name": "Raider",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -132,7 +132,7 @@
   {
     "name": "Ranger",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -145,7 +145,7 @@
   {
     "name": "Rapid-Fire",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -158,7 +158,7 @@
   {
     "name": "Retiarius",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -171,7 +171,7 @@
   {
     "name": "Shining Armor",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -184,7 +184,7 @@
   {
     "name": "Sniper",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -197,7 +197,7 @@
   {
     "name": "Spellsword",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -210,7 +210,7 @@
   {
     "name": "Stick and Robe",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -223,7 +223,7 @@
   {
     "name": "Swashbuckler",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -236,7 +236,7 @@
   {
     "name": "Sword and Board",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -249,7 +249,7 @@
   {
     "name": "Warrior Priest",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",
@@ -262,7 +262,7 @@
   {
     "name": "Whirlwind",
     "rule_type": "Kit",
-    "core_rules": "Draw Steel",
+    "core_rules": "drawSteel",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "MCDM Productions",

--- a/db/seeds/pf2e/ancestries.json
+++ b/db/seeds/pf2e/ancestries.json
@@ -2,7 +2,7 @@
   {
     "name": "Athamaru",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23,7 +23,7 @@
   {
     "name": "Automaton",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42,7 +42,7 @@
   {
     "name": "Awakened Animal",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -61,7 +61,7 @@
   {
     "name": "Catfolk",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -80,7 +80,7 @@
   {
     "name": "Centaur",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -101,7 +101,7 @@
   {
     "name": "Dragonet",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -118,7 +118,7 @@
   {
     "name": "Dwarf",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -137,7 +137,7 @@
   {
     "name": "Elf",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -156,7 +156,7 @@
   {
     "name": "Gnome",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -175,7 +175,7 @@
   {
     "name": "Goblin",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -194,7 +194,7 @@
   {
     "name": "Halfling",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -213,7 +213,7 @@
   {
     "name": "Hobgoblin",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -232,7 +232,7 @@
   {
     "name": "Human",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -251,7 +251,7 @@
   {
     "name": "Jotunborn",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -272,7 +272,7 @@
   {
     "name": "Kholo",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -291,7 +291,7 @@
   {
     "name": "Kobold",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -310,7 +310,7 @@
   {
     "name": "Leshy",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -329,7 +329,7 @@
   {
     "name": "Lizardfolk",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -348,7 +348,7 @@
   {
     "name": "Merfolk",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -369,7 +369,7 @@
   {
     "name": "Minotaur",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -390,7 +390,7 @@
   {
     "name": "Orc",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -409,7 +409,7 @@
   {
     "name": "Ratfolk",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -428,7 +428,7 @@
   {
     "name": "Samsaran",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -447,7 +447,7 @@
   {
     "name": "Sarangay",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -466,7 +466,7 @@
   {
     "name": "Surki",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -485,7 +485,7 @@
   {
     "name": "Tanuki",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -504,7 +504,7 @@
   {
     "name": "Tengu",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -523,7 +523,7 @@
   {
     "name": "Tripkee",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -542,7 +542,7 @@
   {
     "name": "Wayang",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -563,7 +563,7 @@
   {
     "name": "Yaksha",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -582,7 +582,7 @@
   {
     "name": "Yaoguai",
     "rule_type": "Ancestry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/ancestry-feats.json
+++ b/db/seeds/pf2e/ancestry-feats.json
@@ -2,7 +2,7 @@
   {
     "name": "Athamaru Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19,7 +19,7 @@
   {
     "name": "Athamaru Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36,7 +36,7 @@
   {
     "name": "Community-Minded",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -53,7 +53,7 @@
   {
     "name": "Coral Symbiotes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -70,7 +70,7 @@
   {
     "name": "Elver Pet",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -87,7 +87,7 @@
   {
     "name": "Emit Defensive Odor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -108,7 +108,7 @@
   {
     "name": "Ocean Wariness",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -125,7 +125,7 @@
   {
     "name": "Pheromonal Message",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -144,7 +144,7 @@
   {
     "name": "Attuned Electroreceptors",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -162,7 +162,7 @@
   {
     "name": "Coral Reserve",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -180,7 +180,7 @@
   {
     "name": "Rapid Pheromone Recovery",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -198,7 +198,7 @@
   {
     "name": "Swift Eel Mount",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -216,7 +216,7 @@
   {
     "name": "Coral Lifeline",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -236,7 +236,7 @@
   {
     "name": "Moray Ambush",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -254,7 +254,7 @@
   {
     "name": "Offensive Odor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -272,7 +272,7 @@
   {
     "name": "Coral Growth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -290,7 +290,7 @@
   {
     "name": "Growing Eel Friend",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -308,7 +308,7 @@
   {
     "name": "Noxious Odor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -328,7 +328,7 @@
   {
     "name": "Riptide Mount",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -346,7 +346,7 @@
   {
     "name": "Skilled Swimmer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -364,7 +364,7 @@
   {
     "name": "Coral Detoxification",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -382,7 +382,7 @@
   {
     "name": "Emissary Assistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -400,7 +400,7 @@
   {
     "name": "Moray Eel Mount",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -418,7 +418,7 @@
   {
     "name": "Persistent Odor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -436,7 +436,7 @@
   {
     "name": "Arcane Communication",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -453,7 +453,7 @@
   {
     "name": "Arcane Eye",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -471,7 +471,7 @@
   {
     "name": "Automaton Armament",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -488,7 +488,7 @@
   {
     "name": "Automaton Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -505,7 +505,7 @@
   {
     "name": "Energy Beam",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -522,7 +522,7 @@
   {
     "name": "Reinforced Chassis",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -539,7 +539,7 @@
   {
     "name": "Arcane Locomotion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -557,7 +557,7 @@
   {
     "name": "Astral Blink",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -575,7 +575,7 @@
   {
     "name": "Core Rejuvenation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -593,7 +593,7 @@
   {
     "name": "Enlarged Chassis",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -611,7 +611,7 @@
   {
     "name": "Axial Recall",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -629,7 +629,7 @@
   {
     "name": "Core Cannon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -651,7 +651,7 @@
   {
     "name": "Greater Augmentation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -669,7 +669,7 @@
   {
     "name": "Arcane Safeguards",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -687,7 +687,7 @@
   {
     "name": "Integrated Armament",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -705,7 +705,7 @@
   {
     "name": "Magical Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -723,7 +723,7 @@
   {
     "name": "Arcane Camouflage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -741,7 +741,7 @@
   {
     "name": "Arcane Propulsion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -761,7 +761,7 @@
   {
     "name": "Arcane Slam",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -779,7 +779,7 @@
   {
     "name": "Core Attunement",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -797,7 +797,7 @@
   {
     "name": "Lesser Augmentation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -815,7 +815,7 @@
   {
     "name": "Rain of Bolts",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -833,7 +833,7 @@
   {
     "name": "Awakened Animal Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -850,7 +850,7 @@
   {
     "name": "Awakened Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -867,7 +867,7 @@
   {
     "name": "Fascinated by Society",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -884,7 +884,7 @@
   {
     "name": "Land Legs",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -902,7 +902,7 @@
   {
     "name": "Learn by Watching",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -919,7 +919,7 @@
   {
     "name": "Natural Senses",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -936,7 +936,7 @@
   {
     "name": "Sea Legs",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -954,7 +954,7 @@
   {
     "name": "Take Flight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -972,7 +972,7 @@
   {
     "name": "Tooth and Claw",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -989,7 +989,7 @@
   {
     "name": "You're So Cute!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1006,7 +1006,7 @@
   {
     "name": "Awaken Others",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1024,7 +1024,7 @@
   {
     "name": "Digger",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1042,7 +1042,7 @@
   {
     "name": "Sharpened Senses",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1060,7 +1060,7 @@
   {
     "name": "Awakened Stride",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1078,7 +1078,7 @@
   {
     "name": "Fearsome Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1098,7 +1098,7 @@
   {
     "name": "True Senses",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1116,7 +1116,7 @@
   {
     "name": "Fierce Grasp",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1134,7 +1134,7 @@
   {
     "name": "Late Awakener",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1152,7 +1152,7 @@
   {
     "name": "Natural Ambassador",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1170,7 +1170,7 @@
   {
     "name": "Scurry!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1188,7 +1188,7 @@
   {
     "name": "Strong of Wing",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1206,7 +1206,7 @@
   {
     "name": "Urban Jungle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1224,7 +1224,7 @@
   {
     "name": "Wild Stride",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1242,7 +1242,7 @@
   {
     "name": "Animal Summoner",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1260,7 +1260,7 @@
   {
     "name": "Full Flight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1278,7 +1278,7 @@
   {
     "name": "Cat Nap",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1299,7 +1299,7 @@
   {
     "name": "Catfolk Dance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1316,7 +1316,7 @@
   {
     "name": "Catfolk Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1333,7 +1333,7 @@
   {
     "name": "Catfolk Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1350,7 +1350,7 @@
   {
     "name": "Cat's Luck",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1369,7 +1369,7 @@
   {
     "name": "Saber Teeth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1386,7 +1386,7 @@
   {
     "name": "Well-Met Traveler",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1403,7 +1403,7 @@
   {
     "name": "Black Cat Curse",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1425,7 +1425,7 @@
   {
     "name": "Caterwaul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1451,7 +1451,7 @@
   {
     "name": "Elude Trouble",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1469,7 +1469,7 @@
   {
     "name": "Reliable Luck",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1487,7 +1487,7 @@
   {
     "name": "Ten Lives",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1505,7 +1505,7 @@
   {
     "name": "Climbing Claws",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1523,7 +1523,7 @@
   {
     "name": "Graceful Guidance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1541,7 +1541,7 @@
   {
     "name": "Light Paws",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1559,7 +1559,7 @@
   {
     "name": "Lucky Break",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1577,7 +1577,7 @@
   {
     "name": "Pride Hunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1595,7 +1595,7 @@
   {
     "name": "Springing Leaper",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1613,7 +1613,7 @@
   {
     "name": "Well-Groomed",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1631,7 +1631,7 @@
   {
     "name": "Aggravating Scratch",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1651,7 +1651,7 @@
   {
     "name": "Evade Doom",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1669,7 +1669,7 @@
   {
     "name": "Luck of the Clowder",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1687,7 +1687,7 @@
   {
     "name": "Predator's Growl",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1705,7 +1705,7 @@
   {
     "name": "Silent Step",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1725,7 +1725,7 @@
   {
     "name": "Wary Skulker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1743,7 +1743,7 @@
   {
     "name": "Centaur Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1760,7 +1760,7 @@
   {
     "name": "Centaur Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1777,7 +1777,7 @@
   {
     "name": "Practiced Brawn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1794,7 +1794,7 @@
   {
     "name": "Skilled Herbalist",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1811,7 +1811,7 @@
   {
     "name": "Steelhoof",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1829,7 +1829,7 @@
   {
     "name": "Camouflage Coat",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1847,7 +1847,7 @@
   {
     "name": "Incredible Sprint",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1865,7 +1865,7 @@
   {
     "name": "Miraculous Medic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1883,7 +1883,7 @@
   {
     "name": "Trample (Centaur)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1901,7 +1901,7 @@
   {
     "name": "Merge with the Source",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1919,7 +1919,7 @@
   {
     "name": "Starshot Arrow",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1939,7 +1939,7 @@
   {
     "name": "Accommodating Mount",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1957,7 +1957,7 @@
   {
     "name": "Distant Archer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1975,7 +1975,7 @@
   {
     "name": "Proud Mentor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1993,7 +1993,7 @@
   {
     "name": "Speaker in Training",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2011,7 +2011,7 @@
   {
     "name": "Fierce Competitor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2031,7 +2031,7 @@
   {
     "name": "Herbal Forager",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2049,7 +2049,7 @@
   {
     "name": "Mentor of Legends",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2067,7 +2067,7 @@
   {
     "name": "Ride On",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2085,7 +2085,7 @@
   {
     "name": "Speaker's Defense",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2103,7 +2103,7 @@
   {
     "name": "Stubborn Defiance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2121,7 +2121,7 @@
   {
     "name": "Covet Hoard",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2138,7 +2138,7 @@
   {
     "name": "Dragonet Breath",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2155,7 +2155,7 @@
   {
     "name": "Dragonet Resistances",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2172,7 +2172,7 @@
   {
     "name": "Mighty Dragonet",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2189,7 +2189,7 @@
   {
     "name": "My Claws are Daggers",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2206,7 +2206,7 @@
   {
     "name": "Scales of Steel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2223,7 +2223,7 @@
   {
     "name": "Take Wing",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2240,7 +2240,7 @@
   {
     "name": "Form a Flock",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2260,7 +2260,7 @@
   {
     "name": "Luring Chomp",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2282,7 +2282,7 @@
   {
     "name": "Dazzling Dragonet Disappearance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2300,7 +2300,7 @@
   {
     "name": "Dragonet Immunities",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2318,7 +2318,7 @@
   {
     "name": "Ascended Dragonet Heritage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2336,7 +2336,7 @@
   {
     "name": "Inhale, Exhale!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2356,7 +2356,7 @@
   {
     "name": "Jealous Grip",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2374,7 +2374,7 @@
   {
     "name": "Zip! Zoom!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2392,7 +2392,7 @@
   {
     "name": "Bond Companion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2410,7 +2410,7 @@
   {
     "name": "Ferocious Will",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2428,7 +2428,7 @@
   {
     "name": "Into the Sky",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2446,7 +2446,7 @@
   {
     "name": "Adaptive Vision",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2463,7 +2463,7 @@
   {
     "name": "Clan Pistol",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2480,7 +2480,7 @@
   {
     "name": "Dongun Education",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2497,7 +2497,7 @@
   {
     "name": "Dwarven Doughtiness",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2514,7 +2514,7 @@
   {
     "name": "Dwarven Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2531,7 +2531,7 @@
   {
     "name": "Dwarven Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2548,7 +2548,7 @@
   {
     "name": "Explosive Savant",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2565,7 +2565,7 @@
   {
     "name": "Fire Savvy",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2582,7 +2582,7 @@
   {
     "name": "Mountain Strategy",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2599,7 +2599,7 @@
   {
     "name": "Rock Runner",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2616,7 +2616,7 @@
   {
     "name": "Stonemason's Eye",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2633,7 +2633,7 @@
   {
     "name": "Unburdened Iron",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2650,7 +2650,7 @@
   {
     "name": "Crafter's Instinct",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2670,7 +2670,7 @@
   {
     "name": "Explosive Expert",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2688,7 +2688,7 @@
   {
     "name": "March the Mines",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2706,7 +2706,7 @@
   {
     "name": "Scrutinizing Gaze",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2724,7 +2724,7 @@
   {
     "name": "Telluric Power",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2742,7 +2742,7 @@
   {
     "name": "Forge-Blessed Shot",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2762,7 +2762,7 @@
   {
     "name": "Stonegate",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2780,7 +2780,7 @@
   {
     "name": "Stonewall",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2802,7 +2802,7 @@
   {
     "name": "Blast Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2820,7 +2820,7 @@
   {
     "name": "Boulder Roll",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2838,7 +2838,7 @@
   {
     "name": "Defy the Darkness",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2856,7 +2856,7 @@
   {
     "name": "Dwarven Reinforcement",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2874,7 +2874,7 @@
   {
     "name": "Spark Fist",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2896,7 +2896,7 @@
   {
     "name": "Demolitionist",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2914,7 +2914,7 @@
   {
     "name": "Echoes in Stone",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2934,7 +2934,7 @@
   {
     "name": "Mountain's Stoutness",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2952,7 +2952,7 @@
   {
     "name": "Smoke Sight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2970,7 +2970,7 @@
   {
     "name": "Stone Bones",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2988,7 +2988,7 @@
   {
     "name": "Stonewalker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3006,7 +3006,7 @@
   {
     "name": "Ancestral Longevity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3024,7 +3024,7 @@
   {
     "name": "Elven Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3041,7 +3041,7 @@
   {
     "name": "Elven Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3058,7 +3058,7 @@
   {
     "name": "Forlorn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3075,7 +3075,7 @@
   {
     "name": "Free Heart",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3092,7 +3092,7 @@
   {
     "name": "Nimble Elf",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3109,7 +3109,7 @@
   {
     "name": "Otherworldly Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3126,7 +3126,7 @@
   {
     "name": "Political Acumen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3144,7 +3144,7 @@
   {
     "name": "Traditional Ways",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3161,7 +3161,7 @@
   {
     "name": "Unwavering Mien",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3178,7 +3178,7 @@
   {
     "name": "Anchoring Arrow",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3198,7 +3198,7 @@
   {
     "name": "Avenge Ally",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3218,7 +3218,7 @@
   {
     "name": "Cold Iron Stomach",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3236,7 +3236,7 @@
   {
     "name": "Treehealer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3260,7 +3260,7 @@
   {
     "name": "Universal Longevity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3278,7 +3278,7 @@
   {
     "name": "Demon Slayer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3300,7 +3300,7 @@
   {
     "name": "Magic Rider",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3318,7 +3318,7 @@
   {
     "name": "Ageless Patience",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3336,7 +3336,7 @@
   {
     "name": "Ancestral Suspicion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3354,7 +3354,7 @@
   {
     "name": "Elven Persistence",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3374,7 +3374,7 @@
   {
     "name": "Martial Experience",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3392,7 +3392,7 @@
   {
     "name": "Shame the Sin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3410,7 +3410,7 @@
   {
     "name": "Swamp Stealth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3428,7 +3428,7 @@
   {
     "name": "Demon Hunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3446,7 +3446,7 @@
   {
     "name": "Elf Step",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3464,7 +3464,7 @@
   {
     "name": "Expert Longevity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3482,7 +3482,7 @@
   {
     "name": "Otherworldly Acumen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3500,7 +3500,7 @@
   {
     "name": "Political Virtuoso",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3518,7 +3518,7 @@
   {
     "name": "Tree Climber (Elf)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3536,7 +3536,7 @@
   {
     "name": "Animal Accomplice",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3553,7 +3553,7 @@
   {
     "name": "Animal Elocutionist",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3570,7 +3570,7 @@
   {
     "name": "Fey Fellowship",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3587,7 +3587,7 @@
   {
     "name": "First World Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3604,7 +3604,7 @@
   {
     "name": "Fisheye",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3622,7 +3622,7 @@
   {
     "name": "Gnome Obsession",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3639,7 +3639,7 @@
   {
     "name": "Gnome Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3656,7 +3656,7 @@
   {
     "name": "Illusion Sense",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3673,7 +3673,7 @@
   {
     "name": "Razzle-Dazzle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3690,7 +3690,7 @@
   {
     "name": "Arboreal Conversationalist",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3708,7 +3708,7 @@
   {
     "name": "Instinctive Obfuscation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3730,7 +3730,7 @@
   {
     "name": "Kijimuna Whistle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3748,7 +3748,7 @@
   {
     "name": "Homeward Bound",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3766,7 +3766,7 @@
   {
     "name": "Briny Beverage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3784,7 +3784,7 @@
   {
     "name": "Energized Font",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3802,7 +3802,7 @@
   {
     "name": "Project Persona",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3828,7 +3828,7 @@
   {
     "name": "Cautious Curiosity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3846,7 +3846,7 @@
   {
     "name": "First World Adept",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3864,7 +3864,7 @@
   {
     "name": "Life Leap",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3886,7 +3886,7 @@
   {
     "name": "Scarlet Strands",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3904,7 +3904,7 @@
   {
     "name": "Vivacious Conduit",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3922,7 +3922,7 @@
   {
     "name": "Burn It!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3939,7 +3939,7 @@
   {
     "name": "City Scavenger",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3956,7 +3956,7 @@
   {
     "name": "Dokkaebi Fire",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3974,7 +3974,7 @@
   {
     "name": "Goblin Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3991,7 +3991,7 @@
   {
     "name": "Goblin Scuttle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4008,7 +4008,7 @@
   {
     "name": "Goblin Song",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4025,7 +4025,7 @@
   {
     "name": "Goblin Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4042,7 +4042,7 @@
   {
     "name": "Junk Tinker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4059,7 +4059,7 @@
   {
     "name": "Phantom Visage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4083,7 +4083,7 @@
   {
     "name": "Rough Rider",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4100,7 +4100,7 @@
   {
     "name": "Tangle of Limbs",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4118,7 +4118,7 @@
   {
     "name": "Very Sneaky",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4135,7 +4135,7 @@
   {
     "name": "Flames of Vision",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4153,7 +4153,7 @@
   {
     "name": "Very, Very Sneaky",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4171,7 +4171,7 @@
   {
     "name": "Perfected Gamtu",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4191,7 +4191,7 @@
   {
     "name": "Reckless Abandon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4211,7 +4211,7 @@
   {
     "name": "Glorious Gamtu",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4231,7 +4231,7 @@
   {
     "name": "Kneecap",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4249,7 +4249,7 @@
   {
     "name": "Loud Singer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4267,7 +4267,7 @@
   {
     "name": "Phantom Resemblance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4285,7 +4285,7 @@
   {
     "name": "Vandal",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4303,7 +4303,7 @@
   {
     "name": "Cave Climber",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4321,7 +4321,7 @@
   {
     "name": "Cling",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4339,7 +4339,7 @@
   {
     "name": "Goblin Club",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4359,7 +4359,7 @@
   {
     "name": "Skittering Scuttle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4377,7 +4377,7 @@
   {
     "name": "Whispers in the Night",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4395,7 +4395,7 @@
   {
     "name": "Distracting Shadows",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4412,7 +4412,7 @@
   {
     "name": "Folksy Patter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4429,7 +4429,7 @@
   {
     "name": "Halfling Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4446,7 +4446,7 @@
   {
     "name": "Halfling Luck",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4465,7 +4465,7 @@
   {
     "name": "Halfling Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4482,7 +4482,7 @@
   {
     "name": "Prairie Rider",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4499,7 +4499,7 @@
   {
     "name": "Sure Feet",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4516,7 +4516,7 @@
   {
     "name": "Titan Slinger",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4533,7 +4533,7 @@
   {
     "name": "Unfettered Halfling",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4550,7 +4550,7 @@
   {
     "name": "Watchful Halfling",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4567,7 +4567,7 @@
   {
     "name": "Ceaseless Shadows",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4585,7 +4585,7 @@
   {
     "name": "Toppling Dance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4603,7 +4603,7 @@
   {
     "name": "Shadow Self",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4621,7 +4621,7 @@
   {
     "name": "Cultural Adaptability",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4639,7 +4639,7 @@
   {
     "name": "Step Lively",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4657,7 +4657,7 @@
   {
     "name": "Dance Underfoot",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4675,7 +4675,7 @@
   {
     "name": "Guiding Luck",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4693,7 +4693,7 @@
   {
     "name": "Irrepressible (Halfling)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4711,7 +4711,7 @@
   {
     "name": "Unhampered Passage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4729,7 +4729,7 @@
   {
     "name": "Alchemical Scholar",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4746,7 +4746,7 @@
   {
     "name": "Cantorian Reinforcement",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4763,7 +4763,7 @@
   {
     "name": "Hobgoblin Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4780,7 +4780,7 @@
   {
     "name": "Hobgoblin Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4797,7 +4797,7 @@
   {
     "name": "Leech-Clip",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4814,7 +4814,7 @@
   {
     "name": "Remorseless Lash",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4831,7 +4831,7 @@
   {
     "name": "Sneaky",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4848,7 +4848,7 @@
   {
     "name": "Stone Face",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4865,7 +4865,7 @@
   {
     "name": "Vigorous Health",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4882,7 +4882,7 @@
   {
     "name": "Can't Fall Here",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4904,7 +4904,7 @@
   {
     "name": "War Conditioning",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4922,7 +4922,7 @@
   {
     "name": "Cantorian Restoration",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4944,7 +4944,7 @@
   {
     "name": "Rallying Cry",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4964,7 +4964,7 @@
   {
     "name": "Agonizing Rebuke",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4982,7 +4982,7 @@
   {
     "name": "Expert Drill Sergeant",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5000,7 +5000,7 @@
   {
     "name": "Recognize Ambush",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5018,7 +5018,7 @@
   {
     "name": "Runtsage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5036,7 +5036,7 @@
   {
     "name": "Cantorian Rejuvenation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5058,7 +5058,7 @@
   {
     "name": "Fell Rider",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5076,7 +5076,7 @@
   {
     "name": "Pride in Arms",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5096,7 +5096,7 @@
   {
     "name": "Squad Tactics",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5114,7 +5114,7 @@
   {
     "name": "Adapted Cantrip",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5132,7 +5132,7 @@
   {
     "name": "Cooperative Nature",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5149,7 +5149,7 @@
   {
     "name": "General Training",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5166,7 +5166,7 @@
   {
     "name": "Haughty Obstinacy",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5183,7 +5183,7 @@
   {
     "name": "Natural Ambition",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5200,7 +5200,7 @@
   {
     "name": "Natural Skill",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5217,7 +5217,7 @@
   {
     "name": "Unconventional Weaponry",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5234,7 +5234,7 @@
   {
     "name": "Advanced General Training",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5252,7 +5252,7 @@
   {
     "name": "Bounce Back",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5270,7 +5270,7 @@
   {
     "name": "Stubborn Persistence",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5288,7 +5288,7 @@
   {
     "name": "Heroic Presence",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5310,7 +5310,7 @@
   {
     "name": "Adaptive Adept",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5328,7 +5328,7 @@
   {
     "name": "Clever Improviser",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5346,7 +5346,7 @@
   {
     "name": "Sense Allies",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5364,7 +5364,7 @@
   {
     "name": "Cooperative Soul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5382,7 +5382,7 @@
   {
     "name": "Group Aid",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5400,7 +5400,7 @@
   {
     "name": "Hardy Traveler",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5418,7 +5418,7 @@
   {
     "name": "Incredible Improvisation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5436,7 +5436,7 @@
   {
     "name": "Multitalented",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5454,7 +5454,7 @@
   {
     "name": "Caretaker's Intuition",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5471,7 +5471,7 @@
   {
     "name": "Caretaker's Restoration",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5488,7 +5488,7 @@
   {
     "name": "Jotunborn Grappler",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5505,7 +5505,7 @@
   {
     "name": "Jotunborn Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5522,7 +5522,7 @@
   {
     "name": "Jotunborn Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5539,7 +5539,7 @@
   {
     "name": "Jotun's Eyes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5557,7 +5557,7 @@
   {
     "name": "Plane-Stepping Dash",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5578,7 +5578,7 @@
   {
     "name": "Iivlar's Boundary Break",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5596,7 +5596,7 @@
   {
     "name": "Jotun's Restoration",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5614,7 +5614,7 @@
   {
     "name": "Plane Hop",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5634,7 +5634,7 @@
   {
     "name": "Smoothing Stomp",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5656,7 +5656,7 @@
   {
     "name": "Jotun's Heart",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5674,7 +5674,7 @@
   {
     "name": "Jotun's Transposition",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5692,7 +5692,7 @@
   {
     "name": "Planar Traveler",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5710,7 +5710,7 @@
   {
     "name": "Call the First Tools",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5734,7 +5734,7 @@
   {
     "name": "Jotun's Battle Stance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5754,7 +5754,7 @@
   {
     "name": "Jotun's Grasp",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5772,7 +5772,7 @@
   {
     "name": "Planar Resilience",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5790,7 +5790,7 @@
   {
     "name": "Pounding Leap",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5808,7 +5808,7 @@
   {
     "name": "Build the First Walls",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5834,7 +5834,7 @@
   {
     "name": "Iivlar's Deflection",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5852,7 +5852,7 @@
   {
     "name": "Jotun's Boost",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5872,7 +5872,7 @@
   {
     "name": "Plane Step",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5898,7 +5898,7 @@
   {
     "name": "Ask the Bones",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5915,7 +5915,7 @@
   {
     "name": "Crunch",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5932,7 +5932,7 @@
   {
     "name": "Hyena Familiar",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5949,7 +5949,7 @@
   {
     "name": "Kholo Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5966,7 +5966,7 @@
   {
     "name": "Kholo Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5983,7 +5983,7 @@
   {
     "name": "Pack Hunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6000,7 +6000,7 @@
   {
     "name": "Sensitive Nose",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6017,7 +6017,7 @@
   {
     "name": "Ancestor's Rage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6035,7 +6035,7 @@
   {
     "name": "Bonekeeper's Bane",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6053,7 +6053,7 @@
   {
     "name": "First to Strike, First to Fall",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6071,7 +6071,7 @@
   {
     "name": "Impaling Bone",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6089,7 +6089,7 @@
   {
     "name": "Legendary Laugh",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6107,7 +6107,7 @@
   {
     "name": "Absorb Strength",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6125,7 +6125,7 @@
   {
     "name": "Affliction Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6143,7 +6143,7 @@
   {
     "name": "Distant Cackle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6161,7 +6161,7 @@
   {
     "name": "Left-Hand Blood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6179,7 +6179,7 @@
   {
     "name": "Pack Stalker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6197,7 +6197,7 @@
   {
     "name": "Rabid Sprint",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6217,7 +6217,7 @@
   {
     "name": "Right-Hand Blood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6235,7 +6235,7 @@
   {
     "name": "Ambush Hunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6253,7 +6253,7 @@
   {
     "name": "Breath Like Honey",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6271,7 +6271,7 @@
   {
     "name": "Grandmother's Wisdom",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6289,7 +6289,7 @@
   {
     "name": "Laughing Kholo",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6307,7 +6307,7 @@
   {
     "name": "Seven Changes Performance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6325,7 +6325,7 @@
   {
     "name": "Larger than Life",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6343,7 +6343,7 @@
   {
     "name": "Fox Possession",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6361,7 +6361,7 @@
   {
     "name": "Rekindled Light",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6383,7 +6383,7 @@
   {
     "name": "Vulpine Scamper",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6401,7 +6401,7 @@
   {
     "name": "Fox Arson",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6421,7 +6421,7 @@
   {
     "name": "Many Guises (Kitsune)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6439,7 +6439,7 @@
   {
     "name": "Benefactor's Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6457,7 +6457,7 @@
   {
     "name": "Cringe",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6480,7 +6480,7 @@
   {
     "name": "Draconic Sycophant",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6497,7 +6497,7 @@
   {
     "name": "Dragon's Presence",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6515,7 +6515,7 @@
   {
     "name": "Dragonscaled Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6533,7 +6533,7 @@
   {
     "name": "Hoarder's Craw",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6551,7 +6551,7 @@
   {
     "name": "Kobold Breath",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6571,7 +6571,7 @@
   {
     "name": "Kobold Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6588,7 +6588,7 @@
   {
     "name": "Kobold Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6605,7 +6605,7 @@
   {
     "name": "Koi Secrets",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6622,7 +6622,7 @@
   {
     "name": "Scamper",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6639,7 +6639,7 @@
   {
     "name": "Snare Setter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6657,7 +6657,7 @@
   {
     "name": "Elite Dracomancer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6675,7 +6675,7 @@
   {
     "name": "Imperial Dragon Potion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6693,7 +6693,7 @@
   {
     "name": "Kaiju's Footfalls",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6711,7 +6711,7 @@
   {
     "name": "Resplendent Spellhorn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6729,7 +6729,7 @@
   {
     "name": "Tumbling Diversion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6747,7 +6747,7 @@
   {
     "name": "Vicious Snares",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6765,7 +6765,7 @@
   {
     "name": "Benefactor's Majesty",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6787,7 +6787,7 @@
   {
     "name": "Ally's Shelter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6807,7 +6807,7 @@
   {
     "name": "Benefactor's Strike",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6825,7 +6825,7 @@
   {
     "name": "Duck!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6843,7 +6843,7 @@
   {
     "name": "Friend of the Family",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6861,7 +6861,7 @@
   {
     "name": "Grovel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6887,7 +6887,7 @@
   {
     "name": "Kobold Momentum",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6905,7 +6905,7 @@
   {
     "name": "Snare Genius",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6923,7 +6923,7 @@
   {
     "name": "Tip the Scales",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6941,7 +6941,7 @@
   {
     "name": "Winglets",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6959,7 +6959,7 @@
   {
     "name": "Between the Scales",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6977,7 +6977,7 @@
   {
     "name": "Breath Unleashed",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6995,7 +6995,7 @@
   {
     "name": "Briar Battler",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7013,7 +7013,7 @@
   {
     "name": "Close Quarters",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7031,7 +7031,7 @@
   {
     "name": "Dracomancer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7049,7 +7049,7 @@
   {
     "name": "Draconic Paragon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7067,7 +7067,7 @@
   {
     "name": "Evolved Spellhorn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7085,7 +7085,7 @@
   {
     "name": "Fleeing Shriek",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7107,7 +7107,7 @@
   {
     "name": "Winglet Flight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7125,7 +7125,7 @@
   {
     "name": "Childlike Plant",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7143,7 +7143,7 @@
   {
     "name": "Grasping Reach",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7160,7 +7160,7 @@
   {
     "name": "Harmlessly Cute",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7177,7 +7177,7 @@
   {
     "name": "Leshy Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7194,7 +7194,7 @@
   {
     "name": "Leshy Superstition",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7211,7 +7211,7 @@
   {
     "name": "Seedpod",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7228,7 +7228,7 @@
   {
     "name": "Shadow of the Wilds",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7245,7 +7245,7 @@
   {
     "name": "Undaunted",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7262,7 +7262,7 @@
   {
     "name": "Call of the Green Man",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7280,7 +7280,7 @@
   {
     "name": "Cloak of Poison",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7300,7 +7300,7 @@
   {
     "name": "Flower Chimera",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7318,7 +7318,7 @@
   {
     "name": "Flourish and Ruin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7336,7 +7336,7 @@
   {
     "name": "Regrowth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7354,7 +7354,7 @@
   {
     "name": "Return to the Seed",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7372,7 +7372,7 @@
   {
     "name": "Anchoring Roots",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7390,7 +7390,7 @@
   {
     "name": "Leshy Glide",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7408,7 +7408,7 @@
   {
     "name": "Noble Bloom",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7432,7 +7432,7 @@
   {
     "name": "Ritual Reversion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7454,7 +7454,7 @@
   {
     "name": "Speak with Kindred",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7472,7 +7472,7 @@
   {
     "name": "Unassuming Heroes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7490,7 +7490,7 @@
   {
     "name": "Bark and Tendril",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7508,7 +7508,7 @@
   {
     "name": "Green Dash",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7526,7 +7526,7 @@
   {
     "name": "Kodama Call",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7544,7 +7544,7 @@
   {
     "name": "Lucky Keepsake",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7562,7 +7562,7 @@
   {
     "name": "Sash of the Wind",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7580,7 +7580,7 @@
   {
     "name": "Thorned Seedpod",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7598,7 +7598,7 @@
   {
     "name": "Bone Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7615,7 +7615,7 @@
   {
     "name": "Crocodile's Twin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7633,7 +7633,7 @@
   {
     "name": "Iruxi Armaments",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7650,7 +7650,7 @@
   {
     "name": "Lizardfolk Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7667,7 +7667,7 @@
   {
     "name": "Marsh Runner",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7685,7 +7685,7 @@
   {
     "name": "Parthenogenic Hatchling",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7702,7 +7702,7 @@
   {
     "name": "Reptile Speaker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7719,7 +7719,7 @@
   {
     "name": "Spirit Coffin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7737,7 +7737,7 @@
   {
     "name": "Bone Investiture",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7755,7 +7755,7 @@
   {
     "name": "Ferry Through Waves",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7773,7 +7773,7 @@
   {
     "name": "Iruxi Spirit Strike",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7791,7 +7791,7 @@
   {
     "name": "Primal Rampage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7809,7 +7809,7 @@
   {
     "name": "Spiritual Headhunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7827,7 +7827,7 @@
   {
     "name": "Fossil Rider",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7845,7 +7845,7 @@
   {
     "name": "Mooneater",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7865,7 +7865,7 @@
   {
     "name": "Scion Transformation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7885,7 +7885,7 @@
   {
     "name": "Envenom Fangs",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7903,7 +7903,7 @@
   {
     "name": "Flexible Tail",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7921,7 +7921,7 @@
   {
     "name": "Gecko's Grip",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7939,7 +7939,7 @@
   {
     "name": "Shed Tail",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7957,7 +7957,7 @@
   {
     "name": "Swift Swimmer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7975,7 +7975,7 @@
   {
     "name": "Ancestral Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7993,7 +7993,7 @@
   {
     "name": "Dangle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8011,7 +8011,7 @@
   {
     "name": "Hone Claws",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8029,7 +8029,7 @@
   {
     "name": "River Adaptation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8047,7 +8047,7 @@
   {
     "name": "Terrain Advantage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8065,7 +8065,7 @@
   {
     "name": "Merfolk Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8082,7 +8082,7 @@
   {
     "name": "Merfolk Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8099,7 +8099,7 @@
   {
     "name": "Ocean's Bite",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8117,7 +8117,7 @@
   {
     "name": "Seasong",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8134,7 +8134,7 @@
   {
     "name": "Swimmer's Guidance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8151,7 +8151,7 @@
   {
     "name": "Wave Speaker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8168,7 +8168,7 @@
   {
     "name": "Pummeling Whirlpool",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8194,7 +8194,7 @@
   {
     "name": "Sea Witch",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8212,7 +8212,7 @@
   {
     "name": "Doom of Sailors",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8242,7 +8242,7 @@
   {
     "name": "Kraken's Call",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8266,7 +8266,7 @@
   {
     "name": "Apprentice Sea Witch",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8284,7 +8284,7 @@
   {
     "name": "Fishblooded",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8302,7 +8302,7 @@
   {
     "name": "Healing Flesh",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8320,7 +8320,7 @@
   {
     "name": "Strong Tail",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8338,7 +8338,7 @@
   {
     "name": "Ill Tide",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8362,7 +8362,7 @@
   {
     "name": "Shore Gift",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8386,7 +8386,7 @@
   {
     "name": "Siren Song",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8410,7 +8410,7 @@
   {
     "name": "Tears of Pearl",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8438,7 +8438,7 @@
   {
     "name": "Artisanal Crafter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8455,7 +8455,7 @@
   {
     "name": "Cattle Speech",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8472,7 +8472,7 @@
   {
     "name": "Eye for Masonry",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8489,7 +8489,7 @@
   {
     "name": "Friendly Nudge",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8507,7 +8507,7 @@
   {
     "name": "Keen Nose",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8524,7 +8524,7 @@
   {
     "name": "Minotaur Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8541,7 +8541,7 @@
   {
     "name": "Minotaur Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8558,7 +8558,7 @@
   {
     "name": "Pantheon Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8575,7 +8575,7 @@
   {
     "name": "Phantom Charm",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8597,7 +8597,7 @@
   {
     "name": "Shift the Little Ones",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8615,7 +8615,7 @@
   {
     "name": "Threatening Pursuit",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8635,7 +8635,7 @@
   {
     "name": "Begin Stampede",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8655,7 +8655,7 @@
   {
     "name": "Into the Labyrinth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8673,7 +8673,7 @@
   {
     "name": "Alarming Disappearance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8691,7 +8691,7 @@
   {
     "name": "Beast of Burden",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8709,7 +8709,7 @@
   {
     "name": "Labyrinthine Echoes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8727,7 +8727,7 @@
   {
     "name": "Natural Orienteering",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8745,7 +8745,7 @@
   {
     "name": "Puzzle Solver",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8763,7 +8763,7 @@
   {
     "name": "Stretching Reach",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8783,7 +8783,7 @@
   {
     "name": "Friendly Fling",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8803,7 +8803,7 @@
   {
     "name": "Goring Charge",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8821,7 +8821,7 @@
   {
     "name": "Siphon Torment",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8839,7 +8839,7 @@
   {
     "name": "Stone Passage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8859,7 +8859,7 @@
   {
     "name": "It Takes a Village",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8876,7 +8876,7 @@
   {
     "name": "Nalinivati's Light",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8893,7 +8893,7 @@
   {
     "name": "Throat Pocket",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8910,7 +8910,7 @@
   {
     "name": "Synchronous Slither",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8928,7 +8928,7 @@
   {
     "name": "Form of the Beloved Mother",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8946,7 +8946,7 @@
   {
     "name": "Metabolic Control",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8964,7 +8964,7 @@
   {
     "name": "Venom Gulp",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8982,7 +8982,7 @@
   {
     "name": "Hypnotic Gaze",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9000,7 +9000,7 @@
   {
     "name": "Beast Trainer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9017,7 +9017,7 @@
   {
     "name": "Hold Mark",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9034,7 +9034,7 @@
   {
     "name": "Iron Fists",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9051,7 +9051,7 @@
   {
     "name": "Orc Ferocity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9068,7 +9068,7 @@
   {
     "name": "Orc Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9085,7 +9085,7 @@
   {
     "name": "Orc Superstition",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9104,7 +9104,7 @@
   {
     "name": "Orc Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9121,7 +9121,7 @@
   {
     "name": "Tusks (Orc)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9138,7 +9138,7 @@
   {
     "name": "Ferocious Beasts",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9156,7 +9156,7 @@
   {
     "name": "Incredible Ferocity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9174,7 +9174,7 @@
   {
     "name": "Spell Devourer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9192,7 +9192,7 @@
   {
     "name": "Rampaging Ferocity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9210,7 +9210,7 @@
   {
     "name": "Athletic Might",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9228,7 +9228,7 @@
   {
     "name": "Bloody Blows",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9246,7 +9246,7 @@
   {
     "name": "Defy Death",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9264,7 +9264,7 @@
   {
     "name": "Scar-Thick Skin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9282,7 +9282,7 @@
   {
     "name": "Spell Survivor",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9300,7 +9300,7 @@
   {
     "name": "Pervasive Superstition",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9318,7 +9318,7 @@
   {
     "name": "Undying Ferocity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9336,7 +9336,7 @@
   {
     "name": "Made for Combat",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9354,7 +9354,7 @@
   {
     "name": "Minuscule Mentee",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9371,7 +9371,7 @@
   {
     "name": "Sudden Terror",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9389,7 +9389,7 @@
   {
     "name": "Awaken the Obake",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9407,7 +9407,7 @@
   {
     "name": "Insulated Poppet",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9425,7 +9425,7 @@
   {
     "name": "No Hands, No Problem",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9443,7 +9443,7 @@
   {
     "name": "Solidarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9461,7 +9461,7 @@
   {
     "name": "Cheek Pouches",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9478,7 +9478,7 @@
   {
     "name": "Pack Rat",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9495,7 +9495,7 @@
   {
     "name": "Rat Familiar",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9512,7 +9512,7 @@
   {
     "name": "Ratfolk Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9529,7 +9529,7 @@
   {
     "name": "Ratspeak",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9546,7 +9546,7 @@
   {
     "name": "Tinkering Fingers",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9563,7 +9563,7 @@
   {
     "name": "Vicious Incisors",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9580,7 +9580,7 @@
   {
     "name": "Warren Navigator",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9597,7 +9597,7 @@
   {
     "name": "Shinstabber",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9615,7 +9615,7 @@
   {
     "name": "Skittering Sneak",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9633,7 +9633,7 @@
   {
     "name": "Warren Digger",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9651,7 +9651,7 @@
   {
     "name": "Call the Swarm",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9669,7 +9669,7 @@
   {
     "name": "Greater than the Sum",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9687,7 +9687,7 @@
   {
     "name": "Cornered Fury",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9705,7 +9705,7 @@
   {
     "name": "Lab Rat",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9723,7 +9723,7 @@
   {
     "name": "Quick Stow (Ratfolk)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9741,7 +9741,7 @@
   {
     "name": "Rat Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9759,7 +9759,7 @@
   {
     "name": "Ratfolk Roll",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9779,7 +9779,7 @@
   {
     "name": "Big Mouth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9797,7 +9797,7 @@
   {
     "name": "Overcrowd",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9815,7 +9815,7 @@
   {
     "name": "Rat Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9839,7 +9839,7 @@
   {
     "name": "Uncanny Cheeks",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9857,7 +9857,7 @@
   {
     "name": "All This Will Happen Again",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9878,7 +9878,7 @@
   {
     "name": "Elucidating Vision",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9895,7 +9895,7 @@
   {
     "name": "Innate Understanding",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9912,7 +9912,7 @@
   {
     "name": "Remnants of the Past",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9929,7 +9929,7 @@
   {
     "name": "Samsaran Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9946,7 +9946,7 @@
   {
     "name": "Samsaran Weapon Memory",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9963,7 +9963,7 @@
   {
     "name": "Memory of Mastery",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9981,7 +9981,7 @@
   {
     "name": "Water to Water",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9999,7 +9999,7 @@
   {
     "name": "The Cycle Continues",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10017,7 +10017,7 @@
   {
     "name": "This Too Shall Pass",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10035,7 +10035,7 @@
   {
     "name": "All This Has Happened Before",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10053,7 +10053,7 @@
   {
     "name": "And Will Do So Once More",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10071,7 +10071,7 @@
   {
     "name": "Blood Like Water",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10089,7 +10089,7 @@
   {
     "name": "Thousand-Year Grudge",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10109,7 +10109,7 @@
   {
     "name": "I Will Return",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10127,7 +10127,7 @@
   {
     "name": "Life's Blood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10149,7 +10149,7 @@
   {
     "name": "Memory of Skill",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10167,7 +10167,7 @@
   {
     "name": "Secrets of the Past",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10185,7 +10185,7 @@
   {
     "name": "Awakened Jewel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10204,7 +10204,7 @@
   {
     "name": "Crown of Bone",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10221,7 +10221,7 @@
   {
     "name": "Folk Healer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10238,7 +10238,7 @@
   {
     "name": "Sarangay Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10255,7 +10255,7 @@
   {
     "name": "Traveler's Counsel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10273,7 +10273,7 @@
   {
     "name": "Light-Bending Jewel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10291,7 +10291,7 @@
   {
     "name": "Rejuvenating Embrace",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10309,7 +10309,7 @@
   {
     "name": "Sheltering Jewel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10327,7 +10327,7 @@
   {
     "name": "Convocation of Earth and Moon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10351,7 +10351,7 @@
   {
     "name": "Trample (Sarangay)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10369,7 +10369,7 @@
   {
     "name": "Deflecting Jewel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10389,7 +10389,7 @@
   {
     "name": "Smoke Through Bamboo",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10407,7 +10407,7 @@
   {
     "name": "The Moon Weaver's Art",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10425,7 +10425,7 @@
   {
     "name": "Tikling Bird Twirl",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10443,7 +10443,7 @@
   {
     "name": "Warding Jewel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10463,7 +10463,7 @@
   {
     "name": "Ancestral Healer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10481,7 +10481,7 @@
   {
     "name": "Paralyzing Jewel",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10503,7 +10503,7 @@
   {
     "name": "Spiritual Echo",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10523,7 +10523,7 @@
   {
     "name": "Caustic Nectar",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10537,7 +10537,7 @@
   {
     "name": "Wilderness Born",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10551,7 +10551,7 @@
   {
     "name": "One with the Wild",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10565,7 +10565,7 @@
   {
     "name": "Unfettered Growth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10579,7 +10579,7 @@
   {
     "name": "Irresistible Bloom",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10605,7 +10605,7 @@
   {
     "name": "Potent Nectar",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10619,7 +10619,7 @@
   {
     "name": "Quick Root",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10633,7 +10633,7 @@
   {
     "name": "Skillful Tail",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10665,7 +10665,7 @@
   {
     "name": "Grow Tool",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10685,7 +10685,7 @@
   {
     "name": "Pollinate",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10699,7 +10699,7 @@
   {
     "name": "Solar Rejuvenation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10719,7 +10719,7 @@
   {
     "name": "Charmed Sleep",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10736,7 +10736,7 @@
   {
     "name": "Along the Deep River",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10754,7 +10754,7 @@
   {
     "name": "Elemental Spark",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10772,7 +10772,7 @@
   {
     "name": "Speak with the Sleeping",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10790,7 +10790,7 @@
   {
     "name": "Sequestered Spell",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10807,7 +10807,7 @@
   {
     "name": "Small Speak",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10824,7 +10824,7 @@
   {
     "name": "Surki Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10841,7 +10841,7 @@
   {
     "name": "Surki Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10858,7 +10858,7 @@
   {
     "name": "Vestigial Magicsense",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10875,7 +10875,7 @@
   {
     "name": "Generation Digger",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10893,7 +10893,7 @@
   {
     "name": "Magitaxis",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10911,7 +10911,7 @@
   {
     "name": "Nodal Regeneration",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10929,7 +10929,7 @@
   {
     "name": "Unlimited Pluripotency",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10947,7 +10947,7 @@
   {
     "name": "Chemical Trail",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10967,7 +10967,7 @@
   {
     "name": "Secondary Adaptation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10985,7 +10985,7 @@
   {
     "name": "Tunnel Roll",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11005,7 +11005,7 @@
   {
     "name": "Consume Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11023,7 +11023,7 @@
   {
     "name": "Grand Metamorphosis",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11041,7 +11041,7 @@
   {
     "name": "Nodal Healing",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11059,7 +11059,7 @@
   {
     "name": "Everyday Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11076,7 +11076,7 @@
   {
     "name": "Iron Belly",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11093,7 +11093,7 @@
   {
     "name": "Scorched on the Crackling Mountain",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11110,7 +11110,7 @@
   {
     "name": "Tanuki Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11127,7 +11127,7 @@
   {
     "name": "Teakettle Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11144,7 +11144,7 @@
   {
     "name": "Combined Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11164,7 +11164,7 @@
   {
     "name": "Ponpoko-Pon!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11186,7 +11186,7 @@
   {
     "name": "Splendid Illusion",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11204,7 +11204,7 @@
   {
     "name": "Landscape Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11222,7 +11222,7 @@
   {
     "name": "Start the Festival!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11240,7 +11240,7 @@
   {
     "name": "False Priest Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11258,7 +11258,7 @@
   {
     "name": "Hasty Celebration",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11280,7 +11280,7 @@
   {
     "name": "Leaf Transformation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11300,7 +11300,7 @@
   {
     "name": "Ponpoko",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11318,7 +11318,7 @@
   {
     "name": "Statue Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11336,7 +11336,7 @@
   {
     "name": "Many Faces",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11354,7 +11354,7 @@
   {
     "name": "Mud Boat's Passage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11374,7 +11374,7 @@
   {
     "name": "Phantom Orchestra",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11392,7 +11392,7 @@
   {
     "name": "Rolling White Bottle Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11410,7 +11410,7 @@
   {
     "name": "Mariner's Fire",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11427,7 +11427,7 @@
   {
     "name": "One-Toed Hop",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11444,7 +11444,7 @@
   {
     "name": "Scavenger's Search",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11461,7 +11461,7 @@
   {
     "name": "Squawk!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11478,7 +11478,7 @@
   {
     "name": "Storm's Lash",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11495,7 +11495,7 @@
   {
     "name": "Tengu Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11512,7 +11512,7 @@
   {
     "name": "Tengu Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11529,7 +11529,7 @@
   {
     "name": "Uncanny Agility",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11546,7 +11546,7 @@
   {
     "name": "Harbinger's Caw",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11570,7 +11570,7 @@
   {
     "name": "Jinx Glutton",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11588,7 +11588,7 @@
   {
     "name": "Thunder God's Fan",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11606,7 +11606,7 @@
   {
     "name": "Great Tengu Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11624,7 +11624,7 @@
   {
     "name": "Trickster Tengu",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11642,7 +11642,7 @@
   {
     "name": "Eat Fortune",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11664,7 +11664,7 @@
   {
     "name": "Long-Nosed Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11688,7 +11688,7 @@
   {
     "name": "Magpie Snatch",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11706,7 +11706,7 @@
   {
     "name": "Soaring Flight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11724,7 +11724,7 @@
   {
     "name": "Tengu Feather Fan",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11742,7 +11742,7 @@
   {
     "name": "Soaring Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11760,7 +11760,7 @@
   {
     "name": "Wind God's Fan",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11778,7 +11778,7 @@
   {
     "name": "Croak Talker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11795,7 +11795,7 @@
   {
     "name": "Hunter's Defense",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11813,7 +11813,7 @@
   {
     "name": "Jungle Strider",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11830,7 +11830,7 @@
   {
     "name": "Nocturnal Tripkee",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11847,7 +11847,7 @@
   {
     "name": "Terrifying Croak",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11865,7 +11865,7 @@
   {
     "name": "Tripkee Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11882,7 +11882,7 @@
   {
     "name": "Tripkee Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11899,7 +11899,7 @@
   {
     "name": "Envenomed Edge",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11917,7 +11917,7 @@
   {
     "name": "Hop Up",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11935,7 +11935,7 @@
   {
     "name": "Unbound Leaper",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11953,7 +11953,7 @@
   {
     "name": "Fantastic Leaps",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11971,7 +11971,7 @@
   {
     "name": "Long Tongue",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11989,7 +11989,7 @@
   {
     "name": "Prodigious Climber",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12007,7 +12007,7 @@
   {
     "name": "Tenacious Net",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12025,7 +12025,7 @@
   {
     "name": "Tripkee Glide",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12043,7 +12043,7 @@
   {
     "name": "Vomit Stomach",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12061,7 +12061,7 @@
   {
     "name": "Absorb Toxin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12079,7 +12079,7 @@
   {
     "name": "Moisture Bath",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12099,7 +12099,7 @@
   {
     "name": "Ricocheting Leap",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12117,7 +12117,7 @@
   {
     "name": "Tongue Tether",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12135,7 +12135,7 @@
   {
     "name": "Earned Glory",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12152,7 +12152,7 @@
   {
     "name": "Elf Atavism",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12169,7 +12169,7 @@
   {
     "name": "Inspire Imitation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12187,7 +12187,7 @@
   {
     "name": "Supernatural Charm",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12205,7 +12205,7 @@
   {
     "name": "Ambersoul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12224,7 +12224,7 @@
   {
     "name": "Flowering Path",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12246,7 +12246,7 @@
   {
     "name": "Grove-Harbored",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12263,7 +12263,7 @@
   {
     "name": "Kizidhar Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12281,7 +12281,7 @@
   {
     "name": "Moldersoul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12300,7 +12300,7 @@
   {
     "name": "Read the Roots",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12324,7 +12324,7 @@
   {
     "name": "Springsoul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12343,7 +12343,7 @@
   {
     "name": "Summon Wood Elemental",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12361,7 +12361,7 @@
   {
     "name": "Sunlit Vitality",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12378,7 +12378,7 @@
   {
     "name": "Treespeech",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12396,7 +12396,7 @@
   {
     "name": "Unbowed, Unbroken",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12415,7 +12415,7 @@
   {
     "name": "Wood Ward",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12441,7 +12441,7 @@
   {
     "name": "Wooden Mantle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12459,7 +12459,7 @@
   {
     "name": "Woodworker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12476,7 +12476,7 @@
   {
     "name": "Accursed Claws",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12494,7 +12494,7 @@
   {
     "name": "Brine May",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12513,7 +12513,7 @@
   {
     "name": "Called",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12531,7 +12531,7 @@
   {
     "name": "Callow May",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12550,7 +12550,7 @@
   {
     "name": "Changeling Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12567,7 +12567,7 @@
   {
     "name": "Dream May",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12586,7 +12586,7 @@
   {
     "name": "Hag Claws",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12603,7 +12603,7 @@
   {
     "name": "Hag Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12621,7 +12621,7 @@
   {
     "name": "Hag's Sight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12638,7 +12638,7 @@
   {
     "name": "Mist Child",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12656,7 +12656,7 @@
   {
     "name": "Occult Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12674,7 +12674,7 @@
   {
     "name": "Slag May",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12693,7 +12693,7 @@
   {
     "name": "Bloodletting Fangs",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12711,7 +12711,7 @@
   {
     "name": "Enthralling Allure",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12729,7 +12729,7 @@
   {
     "name": "Eyes of Night",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12747,7 +12747,7 @@
   {
     "name": "Fangs",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12764,7 +12764,7 @@
   {
     "name": "Form of the Bat",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12788,7 +12788,7 @@
   {
     "name": "Necromantic Physiology",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12806,7 +12806,7 @@
   {
     "name": "Night Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12824,7 +12824,7 @@
   {
     "name": "Straveika",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12843,7 +12843,7 @@
   {
     "name": "Svetocher",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12862,7 +12862,7 @@
   {
     "name": "Symphony of Blood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12880,7 +12880,7 @@
   {
     "name": "Undead Slayer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12898,7 +12898,7 @@
   {
     "name": "Vampire Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12915,7 +12915,7 @@
   {
     "name": "Voice of the Night",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12932,7 +12932,7 @@
   {
     "name": "Aqueous Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12951,7 +12951,7 @@
   {
     "name": "Arcane Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12970,7 +12970,7 @@
   {
     "name": "Ascendant Blood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12988,7 +12988,7 @@
   {
     "name": "Blood And Spirit",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13006,7 +13006,7 @@
   {
     "name": "Breath of the Dragon (Dragonblood)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13025,7 +13025,7 @@
   {
     "name": "Deadly Aspect",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13043,7 +13043,7 @@
   {
     "name": "Debilitating Breath",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13061,7 +13061,7 @@
   {
     "name": "Divine Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13080,7 +13080,7 @@
   {
     "name": "Draconic Aspect",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13097,7 +13097,7 @@
   {
     "name": "Draconic Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13114,7 +13114,7 @@
   {
     "name": "Draconic Scent",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13132,7 +13132,7 @@
   {
     "name": "Draconic Sight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13149,7 +13149,7 @@
   {
     "name": "Draconic Veil",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13167,7 +13167,7 @@
   {
     "name": "Dragon Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13184,7 +13184,7 @@
   {
     "name": "Dragon's Flight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13202,7 +13202,7 @@
   {
     "name": "Earthbond",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13220,7 +13220,7 @@
   {
     "name": "Energize Bite",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13238,7 +13238,7 @@
   {
     "name": "Form of the Dragon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13256,7 +13256,7 @@
   {
     "name": "Formidable Breath",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13274,7 +13274,7 @@
   {
     "name": "Heart of Earth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13292,7 +13292,7 @@
   {
     "name": "Home in the Deep",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13310,7 +13310,7 @@
   {
     "name": "Lingering Breath",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13328,7 +13328,7 @@
   {
     "name": "Majestic Presence",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13354,7 +13354,7 @@
   {
     "name": "Mineral Deposits",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13372,7 +13372,7 @@
   {
     "name": "Occult Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13391,7 +13391,7 @@
   {
     "name": "Primal Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13410,7 +13410,7 @@
   {
     "name": "Scaly Hide",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13427,7 +13427,7 @@
   {
     "name": "Sheltering Wing",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13445,7 +13445,7 @@
   {
     "name": "Summiting Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13464,7 +13464,7 @@
   {
     "name": "Tenacious Jaws",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13482,7 +13482,7 @@
   {
     "name": "Terra Dragonblood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13501,7 +13501,7 @@
   {
     "name": "Traditional Resistances",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13519,7 +13519,7 @@
   {
     "name": "True Dragon's Flight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13537,7 +13537,7 @@
   {
     "name": "Voice of the Elements",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13555,7 +13555,7 @@
   {
     "name": "Wing Buffet",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13575,7 +13575,7 @@
   {
     "name": "Monstrous Peacemaker",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13592,7 +13592,7 @@
   {
     "name": "Orc Sight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13610,7 +13610,7 @@
   {
     "name": "Boneyard's Call",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13628,7 +13628,7 @@
   {
     "name": "Chance Death",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13647,7 +13647,7 @@
   {
     "name": "Deliberate Death",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13664,7 +13664,7 @@
   {
     "name": "Duskwalker Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13681,7 +13681,7 @@
   {
     "name": "Duskwalker Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13699,7 +13699,7 @@
   {
     "name": "Duskwalker Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13716,7 +13716,7 @@
   {
     "name": "Ghost Hunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13733,7 +13733,7 @@
   {
     "name": "Gravesight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13751,7 +13751,7 @@
   {
     "name": "Lifesense",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13771,7 +13771,7 @@
   {
     "name": "Quietus Strikes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13789,7 +13789,7 @@
   {
     "name": "Resist Ruin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13807,7 +13807,7 @@
   {
     "name": "Spirit Soother",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13825,7 +13825,7 @@
   {
     "name": "Ward Against Corruption",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13843,7 +13843,7 @@
   {
     "name": "Blood Must Have Blood",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13861,7 +13861,7 @@
   {
     "name": "Bloodsoaked Dash",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13879,7 +13879,7 @@
   {
     "name": "Greater Transformation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13897,7 +13897,7 @@
   {
     "name": "Hungry Eyes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13914,7 +13914,7 @@
   {
     "name": "Kishin Rage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13936,7 +13936,7 @@
   {
     "name": "Oni Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13959,7 +13959,7 @@
   {
     "name": "Oni Rampage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13977,7 +13977,7 @@
   {
     "name": "Oni Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13994,7 +13994,7 @@
   {
     "name": "Oni's Mask",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14012,7 +14012,7 @@
   {
     "name": "Storming Gaze",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14032,7 +14032,7 @@
   {
     "name": "Tempest Gaze",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14050,7 +14050,7 @@
   {
     "name": "Aeonbound",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14069,7 +14069,7 @@
   {
     "name": "Alter Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14087,7 +14087,7 @@
   {
     "name": "Amorphous Aspect",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14105,7 +14105,7 @@
   {
     "name": "Anarchic Arcana",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14123,7 +14123,7 @@
   {
     "name": "Angelkin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14142,7 +14142,7 @@
   {
     "name": "Arise, Ye Worthy!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14160,7 +14160,7 @@
   {
     "name": "Battleblooded",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14179,7 +14179,7 @@
   {
     "name": "Bestial Brutality",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14197,7 +14197,7 @@
   {
     "name": "Bestial Manifestation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14214,7 +14214,7 @@
   {
     "name": "Blessed Blood (Nephilim)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14232,7 +14232,7 @@
   {
     "name": "Call to Battle",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14250,7 +14250,7 @@
   {
     "name": "Celestial Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14268,7 +14268,7 @@
   {
     "name": "Celestial Mercy",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14286,7 +14286,7 @@
   {
     "name": "Channel the Godmind",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14304,7 +14304,7 @@
   {
     "name": "Creative Prodigy",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14322,7 +14322,7 @@
   {
     "name": "Divine Countermeasures",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14340,7 +14340,7 @@
   {
     "name": "Divine Declaration",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14358,7 +14358,7 @@
   {
     "name": "Divine Wings",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14380,7 +14380,7 @@
   {
     "name": "Eternal Wings (Nephilim)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14398,7 +14398,7 @@
   {
     "name": "Extraplanar Cloud",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14416,7 +14416,7 @@
   {
     "name": "Extraplanar Haze",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14434,7 +14434,7 @@
   {
     "name": "Extraplanar Supplication",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14452,7 +14452,7 @@
   {
     "name": "Faultspawn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14471,7 +14471,7 @@
   {
     "name": "Fiendish Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14489,7 +14489,7 @@
   {
     "name": "Glory and Valor!",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14513,7 +14513,7 @@
   {
     "name": "Grimspawn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14532,7 +14532,7 @@
   {
     "name": "Halo",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14549,7 +14549,7 @@
   {
     "name": "Hellspawn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14568,7 +14568,7 @@
   {
     "name": "Impose Order",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14588,7 +14588,7 @@
   {
     "name": "Intuitive Crafting",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14606,7 +14606,7 @@
   {
     "name": "Irrepressible (Nephilim)",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14623,7 +14623,7 @@
   {
     "name": "Larcenous Tail",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14641,7 +14641,7 @@
   {
     "name": "Lawbringer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14660,7 +14660,7 @@
   {
     "name": "Methodical Magic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14678,7 +14678,7 @@
   {
     "name": "Musetouched",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14697,7 +14697,7 @@
   {
     "name": "Nephilim Eyes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14715,7 +14715,7 @@
   {
     "name": "Nephilim Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14732,7 +14732,7 @@
   {
     "name": "Nephilim Resistance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14750,7 +14750,7 @@
   {
     "name": "Nimble Hooves",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14767,7 +14767,7 @@
   {
     "name": "Pandemonium Eruption",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14785,7 +14785,7 @@
   {
     "name": "Pitborn",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14804,7 +14804,7 @@
   {
     "name": "Proteankin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14823,7 +14823,7 @@
   {
     "name": "Resilient Physiology",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14841,7 +14841,7 @@
   {
     "name": "Scion of Many Planes",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14859,7 +14859,7 @@
   {
     "name": "Slip Sideways",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14877,7 +14877,7 @@
   {
     "name": "Sublime Mobility",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14894,7 +14894,7 @@
   {
     "name": "Summon Nephilim Kin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14912,7 +14912,7 @@
   {
     "name": "Towering Presence",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14938,7 +14938,7 @@
   {
     "name": "Clone-Risen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14957,7 +14957,7 @@
   {
     "name": "Malleable Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14975,7 +14975,7 @@
   {
     "name": "Mirror Refuge",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14997,7 +14997,7 @@
   {
     "name": "Mirror-Risen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15016,7 +15016,7 @@
   {
     "name": "Mistaken Identity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15040,7 +15040,7 @@
   {
     "name": "Morph-Risen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15059,7 +15059,7 @@
   {
     "name": "Progenitor Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15076,7 +15076,7 @@
   {
     "name": "Redirect Attention",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15094,7 +15094,7 @@
   {
     "name": "Reflect Foe",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15112,7 +15112,7 @@
   {
     "name": "Reflective Pocket",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15132,7 +15132,7 @@
   {
     "name": "Replicate",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15150,7 +15150,7 @@
   {
     "name": "Two Truths",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15168,7 +15168,7 @@
   {
     "name": "Unyielding Disguise",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15186,7 +15186,7 @@
   {
     "name": "Warp Likeness",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15208,7 +15208,7 @@
   {
     "name": "Warped Reflection",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15235,7 +15235,7 @@
   {
     "name": "Conductor's Redirection",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15253,7 +15253,7 @@
   {
     "name": "Ferrousoul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15272,7 +15272,7 @@
   {
     "name": "Gildedsoul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15291,7 +15291,7 @@
   {
     "name": "Metallic Skin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15313,7 +15313,7 @@
   {
     "name": "Natural Magnetism",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15331,7 +15331,7 @@
   {
     "name": "Precious Alloys",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15349,7 +15349,7 @@
   {
     "name": "Quicksoul",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15368,7 +15368,7 @@
   {
     "name": "Reflective Defense",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15387,7 +15387,7 @@
   {
     "name": "Summon Metal Elemental",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15405,7 +15405,7 @@
   {
     "name": "Aegis of the Dissolution",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15422,7 +15422,7 @@
   {
     "name": "Dance of the Mousedeer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15447,7 +15447,7 @@
   {
     "name": "Inherit the Dreaming Heirloom",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15464,7 +15464,7 @@
   {
     "name": "Refined Motion in Darkness",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15481,7 +15481,7 @@
   {
     "name": "Wayang Lore",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15498,7 +15498,7 @@
   {
     "name": "Wayang Weapon Familiarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15515,7 +15515,7 @@
   {
     "name": "Dalang's Ally",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15537,7 +15537,7 @@
   {
     "name": "Dance of the Jester",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15555,7 +15555,7 @@
   {
     "name": "Palm-Leaf Silhouette",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15579,7 +15579,7 @@
   {
     "name": "Slay Giants Unseen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15597,7 +15597,7 @@
   {
     "name": "Dissolution's Sovereignty",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15615,7 +15615,7 @@
   {
     "name": "Sever the Dreaming Shadow",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15633,7 +15633,7 @@
   {
     "name": "Dissolution's Clarity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15651,7 +15651,7 @@
   {
     "name": "Shadowplay",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15675,7 +15675,7 @@
   {
     "name": "Dance of the Tiger",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15701,7 +15701,7 @@
   {
     "name": "Dissolution's Sight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15721,7 +15721,7 @@
   {
     "name": "Rouse the Dreaming Relic",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15739,7 +15739,7 @@
   {
     "name": "Shadow Tempo",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15757,7 +15757,7 @@
   {
     "name": "Ash-Piercing Gaze",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15774,7 +15774,7 @@
   {
     "name": "Avowed Insight",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15792,7 +15792,7 @@
   {
     "name": "Bamboo and Silt Repose",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15809,7 +15809,7 @@
   {
     "name": "Howling Aspect",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15830,7 +15830,7 @@
   {
     "name": "Meticulous Restorer",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15847,7 +15847,7 @@
   {
     "name": "Sage of Scattered Leaves",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15864,7 +15864,7 @@
   {
     "name": "Tangle-Tongue's Wit",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15881,7 +15881,7 @@
   {
     "name": "Unwavering Guide",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15898,7 +15898,7 @@
   {
     "name": "Adamantine Mantra",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15918,7 +15918,7 @@
   {
     "name": "Germination of Resolve",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15936,7 +15936,7 @@
   {
     "name": "Wild-Haired Fury",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15954,7 +15954,7 @@
   {
     "name": "Strength of Eight Legions",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15976,7 +15976,7 @@
   {
     "name": "Transcend the Azimuth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15996,7 +15996,7 @@
   {
     "name": "Colugo's Traversal",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16016,7 +16016,7 @@
   {
     "name": "Nourishing Symbiosis",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16034,7 +16034,7 @@
   {
     "name": "Stem the Tide",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16054,7 +16054,7 @@
   {
     "name": "Withstand the Storm",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16072,7 +16072,7 @@
   {
     "name": "Abjure the False Kin",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16090,7 +16090,7 @@
   {
     "name": "Fiend-Trampling Stature",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16108,7 +16108,7 @@
   {
     "name": "Four-Armed Aspect",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16130,7 +16130,7 @@
   {
     "name": "Horn and Bone Incantation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16150,7 +16150,7 @@
   {
     "name": "Witness of Earth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16170,7 +16170,7 @@
   {
     "name": "World-Protector's Hospitality",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16190,7 +16190,7 @@
   {
     "name": "Crawling Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16208,7 +16208,7 @@
   {
     "name": "Morphic Strike",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16225,7 +16225,7 @@
   {
     "name": "Natural Mutagen",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16242,7 +16242,7 @@
   {
     "name": "Polymorphic Escape",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16259,7 +16259,7 @@
   {
     "name": "Twilight Dweller",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16276,7 +16276,7 @@
   {
     "name": "Yaoguai Historian",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16293,7 +16293,7 @@
   {
     "name": "Elucidation",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16311,7 +16311,7 @@
   {
     "name": "Improved Signature Weapon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16329,7 +16329,7 @@
   {
     "name": "Unnerving Terror",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16355,7 +16355,7 @@
   {
     "name": "Gentle Death and Rebirth",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16375,7 +16375,7 @@
   {
     "name": "Legendary Monster",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16393,7 +16393,7 @@
   {
     "name": "Among Humanity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16415,7 +16415,7 @@
   {
     "name": "Awakened Yaoguai Heritage",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16433,7 +16433,7 @@
   {
     "name": "Bold Defiance",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16451,7 +16451,7 @@
   {
     "name": "Immobile Form",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16469,7 +16469,7 @@
   {
     "name": "Kin Hunter",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16487,7 +16487,7 @@
   {
     "name": "Signature Weapon",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16505,7 +16505,7 @@
   {
     "name": "Brilliant Vision",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16523,7 +16523,7 @@
   {
     "name": "Forever Among Humanity",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16541,7 +16541,7 @@
   {
     "name": "Quick Recovery",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16559,7 +16559,7 @@
   {
     "name": "Unleash Yaoguai Might",
     "rule_type": "Ancestry Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/armor.json
+++ b/db/seeds/pf2e/armor.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Alkenstar Phalanx",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17,7 +17,7 @@
   },
   {
     "name": "Ankhrav Carapace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32,7 +32,7 @@
   },
   {
     "name": "Anti-Dragon Barding (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48,7 +48,7 @@
   },
   {
     "name": "Anti-Dragon Barding",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -64,7 +64,7 @@
   },
   {
     "name": "Arachnid Harness (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -76,7 +76,7 @@
   },
   {
     "name": "Arachnid Harness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -88,7 +88,7 @@
   },
   {
     "name": "Arctic Worm Chitin Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -103,7 +103,7 @@
   },
   {
     "name": "Assassin's Skin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -118,7 +118,7 @@
   },
   {
     "name": "Aurochs Hide Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -133,7 +133,7 @@
   },
   {
     "name": "Autoload Leathers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -148,7 +148,7 @@
   },
   {
     "name": "Autumn's Embrace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -162,7 +162,7 @@
   },
   {
     "name": "Bakuwa Lizardfolk Bony Plates",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -177,7 +177,7 @@
   },
   {
     "name": "Balloon Padding",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -191,7 +191,7 @@
   },
   {
     "name": "Barding of the Zephyr",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -207,7 +207,7 @@
   },
   {
     "name": "Bastion of the Inheritor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -223,7 +223,7 @@
   },
   {
     "name": "Bastion Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -239,7 +239,7 @@
   },
   {
     "name": "Bismuth Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -255,7 +255,7 @@
   },
   {
     "name": "Bivouac Targe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -269,7 +269,7 @@
   },
   {
     "name": "Black Hole Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -285,7 +285,7 @@
   },
   {
     "name": "Blade Byrnie (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -300,7 +300,7 @@
   },
   {
     "name": "Blade Byrnie (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -315,7 +315,7 @@
   },
   {
     "name": "Blade Byrnie",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -330,7 +330,7 @@
   },
   {
     "name": "Bloodroot Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -346,7 +346,7 @@
   },
   {
     "name": "Bone Dreadnought Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -363,7 +363,7 @@
   },
   {
     "name": "Breastplate of the Mountain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -379,7 +379,7 @@
   },
   {
     "name": "Breastplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -391,7 +391,7 @@
   },
   {
     "name": "Broadleaf Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -407,7 +407,7 @@
   },
   {
     "name": "Broadleaf Shield (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -423,7 +423,7 @@
   },
   {
     "name": "Broadleaf Shield (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -439,7 +439,7 @@
   },
   {
     "name": "Broadleaf Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -455,7 +455,7 @@
   },
   {
     "name": "Buckler",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -467,7 +467,7 @@
   },
   {
     "name": "Buoyant Buckle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -482,7 +482,7 @@
   },
   {
     "name": "Canopy Bulwark",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -498,7 +498,7 @@
   },
   {
     "name": "Caster's Targe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -512,7 +512,7 @@
   },
   {
     "name": "Ceramic Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -527,7 +527,7 @@
   },
   {
     "name": "Chain Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -542,7 +542,7 @@
   },
   {
     "name": "Chain Shirt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -557,7 +557,7 @@
   },
   {
     "name": "Clockwork Diving Suit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -569,7 +569,7 @@
   },
   {
     "name": "Clockwork Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -583,7 +583,7 @@
   },
   {
     "name": "Clockwork Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -597,7 +597,7 @@
   },
   {
     "name": "Cloister Robe (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -613,7 +613,7 @@
   },
   {
     "name": "Cloister Robe (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -628,7 +628,7 @@
   },
   {
     "name": "Cloister Robe (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -644,7 +644,7 @@
   },
   {
     "name": "Cloister Robe (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -659,7 +659,7 @@
   },
   {
     "name": "Command Cuirass",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -674,7 +674,7 @@
   },
   {
     "name": "Coral Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -689,7 +689,7 @@
   },
   {
     "name": "Crafting Leathers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -704,7 +704,7 @@
   },
   {
     "name": "Crushing Coils",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -720,7 +720,7 @@
   },
   {
     "name": "Dart Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -734,7 +734,7 @@
   },
   {
     "name": "Deep Pockets",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -749,7 +749,7 @@
   },
   {
     "name": "Deep Sea Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -765,7 +765,7 @@
   },
   {
     "name": "Devil's Bargain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -779,7 +779,7 @@
   },
   {
     "name": "Dragon Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -793,7 +793,7 @@
   },
   {
     "name": "Dragon Turtle Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -809,7 +809,7 @@
   },
   {
     "name": "Dragon Turtle Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -823,7 +823,7 @@
   },
   {
     "name": "Dragonaut's Wingsuit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -838,7 +838,7 @@
   },
   {
     "name": "Dragonplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -854,7 +854,7 @@
   },
   {
     "name": "Dragonslayer's Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -868,7 +868,7 @@
   },
   {
     "name": "Eagle Wing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -883,7 +883,7 @@
   },
   {
     "name": "Electric Eelskin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -898,7 +898,7 @@
   },
   {
     "name": "Elven Chain (High-Grade)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -912,7 +912,7 @@
   },
   {
     "name": "Elven Chain (Standard-Grade)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -926,7 +926,7 @@
   },
   {
     "name": "Energized Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -940,7 +940,7 @@
   },
   {
     "name": "Energized Shield (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -954,7 +954,7 @@
   },
   {
     "name": "Energized Shield (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -968,7 +968,7 @@
   },
   {
     "name": "Energized Shield (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -982,7 +982,7 @@
   },
   {
     "name": "Energizing Lattice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -996,7 +996,7 @@
   },
   {
     "name": "Evil-Reflecting Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1010,7 +1010,7 @@
   },
   {
     "name": "Exploding Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1024,7 +1024,7 @@
   },
   {
     "name": "Explorer's Clothing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1038,7 +1038,7 @@
   },
   {
     "name": "Faerie Queen's Bower",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1055,7 +1055,7 @@
   },
   {
     "name": "Fiendsbane Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1070,7 +1070,7 @@
   },
   {
     "name": "Floating Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1084,7 +1084,7 @@
   },
   {
     "name": "Floating Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1098,7 +1098,7 @@
   },
   {
     "name": "Force Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1113,7 +1113,7 @@
   },
   {
     "name": "Forge Warden",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1127,7 +1127,7 @@
   },
   {
     "name": "Fortress Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1143,7 +1143,7 @@
   },
   {
     "name": "Fortress Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1157,7 +1157,7 @@
   },
   {
     "name": "Frost Furs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1173,7 +1173,7 @@
   },
   {
     "name": "Full Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1187,7 +1187,7 @@
   },
   {
     "name": "Gauntlet Buckler",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1201,7 +1201,7 @@
   },
   {
     "name": "Ghoul Hide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1216,7 +1216,7 @@
   },
   {
     "name": "Gi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1230,7 +1230,7 @@
   },
   {
     "name": "Glamorous Buckler",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1244,7 +1244,7 @@
   },
   {
     "name": "Grisly Brigandine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1259,7 +1259,7 @@
   },
   {
     "name": "Half Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1271,7 +1271,7 @@
   },
   {
     "name": "Hardshell Surki Carapace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1285,7 +1285,7 @@
   },
   {
     "name": "Harnessed Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1299,7 +1299,7 @@
   },
   {
     "name": "Heavy Barding (Large)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1314,7 +1314,7 @@
   },
   {
     "name": "Heavy Barding (Small or Medium)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1329,7 +1329,7 @@
   },
   {
     "name": "Heavy Rondache",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1341,7 +1341,7 @@
   },
   {
     "name": "Hellknight Breastplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1353,7 +1353,7 @@
   },
   {
     "name": "Hellknight Half Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1365,7 +1365,7 @@
   },
   {
     "name": "Hellknight Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1379,7 +1379,7 @@
   },
   {
     "name": "Helmsman's Recourse (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1394,7 +1394,7 @@
   },
   {
     "name": "Helmsman's Recourse (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1409,7 +1409,7 @@
   },
   {
     "name": "Helmsman's Recourse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1424,7 +1424,7 @@
   },
   {
     "name": "Hero's Plate (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1438,7 +1438,7 @@
   },
   {
     "name": "Hero's Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1452,7 +1452,7 @@
   },
   {
     "name": "Hide Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1464,7 +1464,7 @@
   },
   {
     "name": "Hide Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1478,7 +1478,7 @@
   },
   {
     "name": "Hippopotamus Klar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1494,7 +1494,7 @@
   },
   {
     "name": "Hodag Leather",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1509,7 +1509,7 @@
   },
   {
     "name": "Hollow Robes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1526,7 +1526,7 @@
   },
   {
     "name": "Holy Chain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1543,7 +1543,7 @@
   },
   {
     "name": "Immortal Bastion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1559,7 +1559,7 @@
   },
   {
     "name": "Impenetrable Scale",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1574,7 +1574,7 @@
   },
   {
     "name": "Imposing Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1588,7 +1588,7 @@
   },
   {
     "name": "Incendiary Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1605,7 +1605,7 @@
   },
   {
     "name": "Indestructible Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1619,7 +1619,7 @@
   },
   {
     "name": "Juggernaut Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1635,7 +1635,7 @@
   },
   {
     "name": "Kilted Breastplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1649,7 +1649,7 @@
   },
   {
     "name": "Kizidhar's Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1664,7 +1664,7 @@
   },
   {
     "name": "Klar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1678,7 +1678,7 @@
   },
   {
     "name": "Lamellar Breastplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1693,7 +1693,7 @@
   },
   {
     "name": "Lattice Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1705,7 +1705,7 @@
   },
   {
     "name": "Leaf Weave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1719,7 +1719,7 @@
   },
   {
     "name": "Leather Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1731,7 +1731,7 @@
   },
   {
     "name": "Leather Lamellar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1745,7 +1745,7 @@
   },
   {
     "name": "Library Robes (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1759,7 +1759,7 @@
   },
   {
     "name": "Library Robes (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1773,7 +1773,7 @@
   },
   {
     "name": "Library Robes (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1787,7 +1787,7 @@
   },
   {
     "name": "Library Robes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1801,7 +1801,7 @@
   },
   {
     "name": "Life-Saver Mail (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1815,7 +1815,7 @@
   },
   {
     "name": "Life-Saver Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1829,7 +1829,7 @@
   },
   {
     "name": "Lifting Leather",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1844,7 +1844,7 @@
   },
   {
     "name": "Light Barding",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1859,7 +1859,7 @@
   },
   {
     "name": "Limestone Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1874,7 +1874,7 @@
   },
   {
     "name": "Linnorm's Sankeit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1888,7 +1888,7 @@
   },
   {
     "name": "Lion's Armor (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1903,7 +1903,7 @@
   },
   {
     "name": "Lion's Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1918,7 +1918,7 @@
   },
   {
     "name": "Lion's Pelt (Chain)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1933,7 +1933,7 @@
   },
   {
     "name": "Lion's Pelt (Leather)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1945,7 +1945,7 @@
   },
   {
     "name": "Lion's Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1959,7 +1959,7 @@
   },
   {
     "name": "Living Leaf Weave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1976,7 +1976,7 @@
   },
   {
     "name": "Locust Leather",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1991,7 +1991,7 @@
   },
   {
     "name": "Lodestone Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2005,7 +2005,7 @@
   },
   {
     "name": "Magnetic Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2020,7 +2020,7 @@
   },
   {
     "name": "Mamlambo Scale",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2035,7 +2035,7 @@
   },
   {
     "name": "Mantis Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2051,7 +2051,7 @@
   },
   {
     "name": "Mantis Shell",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2065,7 +2065,7 @@
   },
   {
     "name": "Mariner's Splint",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2080,7 +2080,7 @@
   },
   {
     "name": "Martyr's Shield (Hellbreakers)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2092,7 +2092,7 @@
   },
   {
     "name": "Martyr's Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2107,7 +2107,7 @@
   },
   {
     "name": "Medic's Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2121,7 +2121,7 @@
   },
   {
     "name": "Medusa Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2137,7 +2137,7 @@
   },
   {
     "name": "Medusa's Scream (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2151,7 +2151,7 @@
   },
   {
     "name": "Medusa's Scream",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2165,7 +2165,7 @@
   },
   {
     "name": "Message Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2182,7 +2182,7 @@
   },
   {
     "name": "Meteor Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2196,7 +2196,7 @@
   },
   {
     "name": "Mitigation Mail (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2213,7 +2213,7 @@
   },
   {
     "name": "Mitigation Mail (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2230,7 +2230,7 @@
   },
   {
     "name": "Mitigation Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2247,7 +2247,7 @@
   },
   {
     "name": "Moonlit Chain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2264,7 +2264,7 @@
   },
   {
     "name": "Niyaháat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2278,7 +2278,7 @@
   },
   {
     "name": "O-Yoroi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2293,7 +2293,7 @@
   },
   {
     "name": "Onslaught Hide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2308,7 +2308,7 @@
   },
   {
     "name": "Ooze Skin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2322,7 +2322,7 @@
   },
   {
     "name": "Ouroboros Buckles",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2337,7 +2337,7 @@
   },
   {
     "name": "Padded Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2351,7 +2351,7 @@
   },
   {
     "name": "Parachute Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2368,7 +2368,7 @@
   },
   {
     "name": "Power Suit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2380,7 +2380,7 @@
   },
   {
     "name": "Powered Full Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2395,7 +2395,7 @@
   },
   {
     "name": "Quilted Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2409,7 +2409,7 @@
   },
   {
     "name": "Rattan Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2423,7 +2423,7 @@
   },
   {
     "name": "Razor Disc",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2438,7 +2438,7 @@
   },
   {
     "name": "Reactive Mail (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2455,7 +2455,7 @@
   },
   {
     "name": "Reactive Mail (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2472,7 +2472,7 @@
   },
   {
     "name": "Reactive Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2489,7 +2489,7 @@
   },
   {
     "name": "Reef Heart (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2503,7 +2503,7 @@
   },
   {
     "name": "Reef Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2517,7 +2517,7 @@
   },
   {
     "name": "Reflecting Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2531,7 +2531,7 @@
   },
   {
     "name": "Reinforced Chassis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2545,7 +2545,7 @@
   },
   {
     "name": "Robes of Xin-Edasseril",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2561,7 +2561,7 @@
   },
   {
     "name": "Rusting Carapace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2575,7 +2575,7 @@
   },
   {
     "name": "Salvo Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2589,7 +2589,7 @@
   },
   {
     "name": "Sanguine Klar (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2604,7 +2604,7 @@
   },
   {
     "name": "Sanguine Klar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2619,7 +2619,7 @@
   },
   {
     "name": "Sankeit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2633,7 +2633,7 @@
   },
   {
     "name": "Sapling Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2647,7 +2647,7 @@
   },
   {
     "name": "Sapling Shield (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2661,7 +2661,7 @@
   },
   {
     "name": "Sapling Shield (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2675,7 +2675,7 @@
   },
   {
     "name": "Sapling Shield (Minor)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2689,7 +2689,7 @@
   },
   {
     "name": "Sapling Shield (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2703,7 +2703,7 @@
   },
   {
     "name": "Sapling Shield (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2717,7 +2717,7 @@
   },
   {
     "name": "Scale Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2729,7 +2729,7 @@
   },
   {
     "name": "Scale of Igroon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2744,7 +2744,7 @@
   },
   {
     "name": "Scene Stealer's Tunic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2759,7 +2759,7 @@
   },
   {
     "name": "Scroll Robes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2773,7 +2773,7 @@
   },
   {
     "name": "Shadow Shroud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2788,7 +2788,7 @@
   },
   {
     "name": "Shared-Pain Sankeit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2805,7 +2805,7 @@
   },
   {
     "name": "Shield of Snakes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2820,7 +2820,7 @@
   },
   {
     "name": "Siege Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2834,7 +2834,7 @@
   },
   {
     "name": "Slithermaw's Bane (Heroic)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2853,7 +2853,7 @@
   },
   {
     "name": "Slithermaw's Bane",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2869,7 +2869,7 @@
   },
   {
     "name": "Smoldering Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2884,7 +2884,7 @@
   },
   {
     "name": "Sorshen's Scintillating Garment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2901,7 +2901,7 @@
   },
   {
     "name": "Spellguard Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2915,7 +2915,7 @@
   },
   {
     "name": "Spined Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2929,7 +2929,7 @@
   },
   {
     "name": "Splint Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2941,7 +2941,7 @@
   },
   {
     "name": "Starfall Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2955,7 +2955,7 @@
   },
   {
     "name": "Steel Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2967,7 +2967,7 @@
   },
   {
     "name": "Studded Leather Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2979,7 +2979,7 @@
   },
   {
     "name": "Sturdy Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2993,7 +2993,7 @@
   },
   {
     "name": "Sturdy Shield (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3007,7 +3007,7 @@
   },
   {
     "name": "Sturdy Shield (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3021,7 +3021,7 @@
   },
   {
     "name": "Sturdy Shield (Minor)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3035,7 +3035,7 @@
   },
   {
     "name": "Sturdy Shield (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3049,7 +3049,7 @@
   },
   {
     "name": "Sturdy Shield (Supreme)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3063,7 +3063,7 @@
   },
   {
     "name": "Subterfuge Suit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3075,7 +3075,7 @@
   },
   {
     "name": "Sun Slayer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3089,7 +3089,7 @@
   },
   {
     "name": "Swordstealer Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3103,7 +3103,7 @@
   },
   {
     "name": "Tales in Timber (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3119,7 +3119,7 @@
   },
   {
     "name": "Tales in Timber (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3135,7 +3135,7 @@
   },
   {
     "name": "Tales in Timber",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3151,7 +3151,7 @@
   },
   {
     "name": "Testudo Shield (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3165,7 +3165,7 @@
   },
   {
     "name": "Testudo Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3179,7 +3179,7 @@
   },
   {
     "name": "Thunder Mail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3196,7 +3196,7 @@
   },
   {
     "name": "Tideplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3208,7 +3208,7 @@
   },
   {
     "name": "Tiger Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3222,7 +3222,7 @@
   },
   {
     "name": "Tower Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3234,7 +3234,7 @@
   },
   {
     "name": "Troll Hide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3249,7 +3249,7 @@
   },
   {
     "name": "Trollhound Vest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3261,7 +3261,7 @@
   },
   {
     "name": "Turnabout Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3276,7 +3276,7 @@
   },
   {
     "name": "Umbral Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3291,7 +3291,7 @@
   },
   {
     "name": "Unholy Plate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3308,7 +3308,7 @@
   },
   {
     "name": "Vambrace of Gorum",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3324,7 +3324,7 @@
   },
   {
     "name": "Vanguard's Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3338,7 +3338,7 @@
   },
   {
     "name": "Vernai Shell",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3355,7 +3355,7 @@
   },
   {
     "name": "War Mage's Buckler",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3369,7 +3369,7 @@
   },
   {
     "name": "Warding Escutcheon (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3383,7 +3383,7 @@
   },
   {
     "name": "Warding Escutcheon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3397,7 +3397,7 @@
   },
   {
     "name": "Warleader's Bulwark (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3412,7 +3412,7 @@
   },
   {
     "name": "Warleader's Bulwark",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3427,7 +3427,7 @@
   },
   {
     "name": "Wasp Guard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3439,7 +3439,7 @@
   },
   {
     "name": "Wilderness Weave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3455,7 +3455,7 @@
   },
   {
     "name": "Wisp Chain (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3471,7 +3471,7 @@
   },
   {
     "name": "Wisp Chain (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3487,7 +3487,7 @@
   },
   {
     "name": "Wisp Chain (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3503,7 +3503,7 @@
   },
   {
     "name": "Wisp Chain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3519,7 +3519,7 @@
   },
   {
     "name": "Wolfjaw Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3533,7 +3533,7 @@
   },
   {
     "name": "Wooden Breastplate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3545,7 +3545,7 @@
   },
   {
     "name": "Wooden Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3557,7 +3557,7 @@
   },
   {
     "name": "Worldscale Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3572,7 +3572,7 @@
   },
   {
     "name": "Zetogeki Hide Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/backgrounds.json
+++ b/db/seeds/pf2e/backgrounds.json
@@ -2,7 +2,7 @@
   {
     "name": "Academic Scion",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15,7 +15,7 @@
   {
     "name": "Acolyte",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28,7 +28,7 @@
   {
     "name": "Acrobat",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41,7 +41,7 @@
   {
     "name": "Acupuncturist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -54,7 +54,7 @@
   {
     "name": "Always Chosen Last",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -71,7 +71,7 @@
   {
     "name": "Amateur Director",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -88,7 +88,7 @@
   {
     "name": "Art Tutor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -105,7 +105,7 @@
   {
     "name": "Bully or Baiter?",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -122,7 +122,7 @@
   {
     "name": "Sideshow Scion",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -139,7 +139,7 @@
   {
     "name": "Supportive Sponsor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -156,7 +156,7 @@
   {
     "name": "Town Troublemaker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -173,7 +173,7 @@
   {
     "name": "Wandering Libertine",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -190,7 +190,7 @@
   {
     "name": "Archdevil Apostate",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -203,7 +203,7 @@
   {
     "name": "Breachill Survivor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -216,7 +216,7 @@
   {
     "name": "Chelaxian Exile",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -229,7 +229,7 @@
   {
     "name": "Foreign Aid",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -242,7 +242,7 @@
   {
     "name": "Goblinblood Survivor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -255,7 +255,7 @@
   {
     "name": "Isgeri Reclaimer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -268,7 +268,7 @@
   {
     "name": "Beast Seeker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -281,7 +281,7 @@
   {
     "name": "Child of the Polis",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -294,7 +294,7 @@
   {
     "name": "Glory Hound",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -307,7 +307,7 @@
   {
     "name": "Kartaji Epicurean",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -320,7 +320,7 @@
   {
     "name": "Obari Wanderer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -333,7 +333,7 @@
   {
     "name": "Student of Apotheosis",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -346,7 +346,7 @@
   {
     "name": "Distant Traveler",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -359,7 +359,7 @@
   {
     "name": "Escaped from Time",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -372,7 +372,7 @@
   {
     "name": "Heroic Ancestry",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -385,7 +385,7 @@
   {
     "name": "Local Savior",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -398,7 +398,7 @@
   {
     "name": "Runelord Researcher",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -411,7 +411,7 @@
   {
     "name": "Runelord Survivor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -424,7 +424,7 @@
   {
     "name": "Child of the Colony",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -437,7 +437,7 @@
   {
     "name": "Company Agent",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -450,7 +450,7 @@
   {
     "name": "Hunted by the Night",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -463,7 +463,7 @@
   {
     "name": "Knack for Contraptions",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -476,7 +476,7 @@
   {
     "name": "Stargazer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -489,7 +489,7 @@
   {
     "name": "Student of the Ancients",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -502,7 +502,7 @@
   {
     "name": "Blight Survivor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -515,7 +515,7 @@
   {
     "name": "Demon Hunted",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -528,7 +528,7 @@
   {
     "name": "Fiendbreaking Pilgrim",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -541,7 +541,7 @@
   {
     "name": "Portal Scholar",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -554,7 +554,7 @@
   {
     "name": "Story Collector",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -567,7 +567,7 @@
   {
     "name": "Student of Archery",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -580,7 +580,7 @@
   {
     "name": "Badlands Scout",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -593,7 +593,7 @@
   {
     "name": "Belkzen Anthropologist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -606,7 +606,7 @@
   {
     "name": "Empty Hand Loyalist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -619,7 +619,7 @@
   {
     "name": "Foreign Diplomat",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -632,7 +632,7 @@
   {
     "name": "Self-Made",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -645,7 +645,7 @@
   {
     "name": "Trade Representative",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -658,7 +658,7 @@
   {
     "name": "Fey Friend",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -671,7 +671,7 @@
   {
     "name": "Green Faith Pilgrim",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -684,7 +684,7 @@
   {
     "name": "Moot Guard",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -697,7 +697,7 @@
   {
     "name": "Tree Friend",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -710,7 +710,7 @@
   {
     "name": "Verduran City Folk",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -723,7 +723,7 @@
   {
     "name": "Wood Warden",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -736,7 +736,7 @@
   {
     "name": "Aeronaut",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -749,7 +749,7 @@
   {
     "name": "Alkenstar Outlaw",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -762,7 +762,7 @@
   {
     "name": "Alkenstar Sojourner",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -775,7 +775,7 @@
   {
     "name": "Alloysmith",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -788,7 +788,7 @@
   {
     "name": "Amnesiac",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -801,7 +801,7 @@
   {
     "name": "Animal Whisperer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -814,7 +814,7 @@
   {
     "name": "Anti-Tech Activist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -827,7 +827,7 @@
   {
     "name": "Arcane Revolutionary",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -840,7 +840,7 @@
   {
     "name": "Artisan",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -853,7 +853,7 @@
   {
     "name": "Artist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -866,7 +866,7 @@
   {
     "name": "Astrologer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -879,7 +879,7 @@
   {
     "name": "Bachuan Revolutionary",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -892,7 +892,7 @@
   {
     "name": "Back-Alley Doctor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -905,7 +905,7 @@
   {
     "name": "Bandit",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -918,7 +918,7 @@
   {
     "name": "Banished Celestial",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -931,7 +931,7 @@
   {
     "name": "Barber",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -944,7 +944,7 @@
   {
     "name": "Barkeep",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -957,7 +957,7 @@
   {
     "name": "Barrister",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -970,7 +970,7 @@
   {
     "name": "Battle Mechanic",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -983,7 +983,7 @@
   {
     "name": "Battlefield Scrounger",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -996,7 +996,7 @@
   {
     "name": "Blessed",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1009,7 +1009,7 @@
   {
     "name": "Bookkeeper",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1022,7 +1022,7 @@
   {
     "name": "Bounty Hunter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1035,7 +1035,7 @@
   {
     "name": "Cannoneer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1048,7 +1048,7 @@
   {
     "name": "Charlatan",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1061,7 +1061,7 @@
   {
     "name": "Circuit Judge",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1074,7 +1074,7 @@
   {
     "name": "Clockfighter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1087,7 +1087,7 @@
   {
     "name": "Clockwork Researcher",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1100,7 +1100,7 @@
   {
     "name": "Codebreaker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1113,7 +1113,7 @@
   {
     "name": "Combat Carpenter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1126,7 +1126,7 @@
   {
     "name": "Combat Chaplain",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1139,7 +1139,7 @@
   {
     "name": "Concordance Researcher",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1152,7 +1152,7 @@
   {
     "name": "Concordance Scout",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1165,7 +1165,7 @@
   {
     "name": "Conscript",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1178,7 +1178,7 @@
   {
     "name": "Convocation Scout",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1191,7 +1191,7 @@
   {
     "name": "Cook",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1204,7 +1204,7 @@
   {
     "name": "Courier",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1217,7 +1217,7 @@
   {
     "name": "Criminal",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1230,7 +1230,7 @@
   {
     "name": "Crystal Healer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1243,7 +1243,7 @@
   {
     "name": "Cultist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1256,7 +1256,7 @@
   {
     "name": "Cursed",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1269,7 +1269,7 @@
   {
     "name": "Deep-Sea Diver",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1282,7 +1282,7 @@
   {
     "name": "Dendrologist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1295,7 +1295,7 @@
   {
     "name": "Deputy",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1308,7 +1308,7 @@
   {
     "name": "Detective",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1321,7 +1321,7 @@
   {
     "name": "Discarded Duplicate",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1334,7 +1334,7 @@
   {
     "name": "Disciple of the Gear",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1347,7 +1347,7 @@
   {
     "name": "Driver",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1360,7 +1360,7 @@
   {
     "name": "Eagle Hunter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1373,7 +1373,7 @@
   {
     "name": "Elementally Infused",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1386,7 +1386,7 @@
   {
     "name": "Emissary",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1399,7 +1399,7 @@
   {
     "name": "Empty Whispers",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1412,7 +1412,7 @@
   {
     "name": "Entertainer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1425,7 +1425,7 @@
   {
     "name": "Farmhand",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1438,7 +1438,7 @@
   {
     "name": "Farmsteader",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1451,7 +1451,7 @@
   {
     "name": "Fated Rival",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1464,7 +1464,7 @@
   {
     "name": "Favored",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1477,7 +1477,7 @@
   {
     "name": "Feral Child",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1490,7 +1490,7 @@
   {
     "name": "Feybound",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1503,7 +1503,7 @@
   {
     "name": "Field Medic",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1516,7 +1516,7 @@
   {
     "name": "Fire Warden",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1529,7 +1529,7 @@
   {
     "name": "Fireworks Performer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1542,7 +1542,7 @@
   {
     "name": "Fortune Teller",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1555,7 +1555,7 @@
   {
     "name": "Gambler",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1568,7 +1568,7 @@
   {
     "name": "Ghostwriter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1581,7 +1581,7 @@
   {
     "name": "Gladiator",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1594,7 +1594,7 @@
   {
     "name": "Goldhand Arms Dealer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1607,7 +1607,7 @@
   {
     "name": "Gossip",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1620,7 +1620,7 @@
   {
     "name": "Guard",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1633,7 +1633,7 @@
   {
     "name": "Gunsmith",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1646,7 +1646,7 @@
   {
     "name": "Haunted",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1659,7 +1659,7 @@
   {
     "name": "Herbalist",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1672,7 +1672,7 @@
   {
     "name": "Hermit",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1685,7 +1685,7 @@
   {
     "name": "Hired Killer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1698,7 +1698,7 @@
   {
     "name": "Hounded Thief",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1711,7 +1711,7 @@
   {
     "name": "Hunter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1724,7 +1724,7 @@
   {
     "name": "Insurgent",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1737,7 +1737,7 @@
   {
     "name": "Jeweler",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1750,7 +1750,7 @@
   {
     "name": "Junk Collector",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1763,7 +1763,7 @@
   {
     "name": "Junker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1776,7 +1776,7 @@
   {
     "name": "Kaiju Stalker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1789,7 +1789,7 @@
   {
     "name": "Laborer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1802,7 +1802,7 @@
   {
     "name": "Legacy of the Hammer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1815,7 +1815,7 @@
   {
     "name": "Library Dweller",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1828,7 +1828,7 @@
   {
     "name": "Martial Disciple",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1841,7 +1841,7 @@
   {
     "name": "Martial Musician",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1854,7 +1854,7 @@
   {
     "name": "Mechanic",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1867,7 +1867,7 @@
   {
     "name": "Mechanical Symbiosis",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1880,7 +1880,7 @@
   {
     "name": "Medicinal Clocksmith",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1893,7 +1893,7 @@
   {
     "name": "Merchant",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1906,7 +1906,7 @@
   {
     "name": "Miner",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1919,7 +1919,7 @@
   {
     "name": "Noble",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1932,7 +1932,7 @@
   {
     "name": "Nomad",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1945,7 +1945,7 @@
   {
     "name": "Ocean Diver",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1958,7 +1958,7 @@
   {
     "name": "Otherworldly Mission",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1971,7 +1971,7 @@
   {
     "name": "Outrider",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1984,7 +1984,7 @@
   {
     "name": "Party Scholar",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1997,7 +1997,7 @@
   {
     "name": "Pilgrim",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2010,7 +2010,7 @@
   {
     "name": "Plague Doctor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2023,7 +2023,7 @@
   {
     "name": "Planar Migrant",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2036,7 +2036,7 @@
   {
     "name": "Press-Ganged (G&G)",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2049,7 +2049,7 @@
   {
     "name": "Printer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2062,7 +2062,7 @@
   {
     "name": "Prisoner",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2075,7 +2075,7 @@
   {
     "name": "Professional Letter Writer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2088,7 +2088,7 @@
   {
     "name": "Quartermaster",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2101,7 +2101,7 @@
   {
     "name": "Raised by Belief",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2114,7 +2114,7 @@
   {
     "name": "Reborn Soul",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2127,7 +2127,7 @@
   {
     "name": "Refugee (PC2)",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2140,7 +2140,7 @@
   {
     "name": "Remittance Agent",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2153,7 +2153,7 @@
   {
     "name": "Report Runner",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2166,7 +2166,7 @@
   {
     "name": "Respected Mentor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2179,7 +2179,7 @@
   {
     "name": "Returned",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2192,7 +2192,7 @@
   {
     "name": "Revenant",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2205,7 +2205,7 @@
   {
     "name": "Root Worker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2218,7 +2218,7 @@
   {
     "name": "Royalty",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2231,7 +2231,7 @@
   {
     "name": "Runaway Noble",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2244,7 +2244,7 @@
   {
     "name": "Saboteur",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2257,7 +2257,7 @@
   {
     "name": "Sailor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2270,7 +2270,7 @@
   {
     "name": "Saloon Entertainer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2283,7 +2283,7 @@
   {
     "name": "Saved by Clockwork",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2296,7 +2296,7 @@
   {
     "name": "Scavenger",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2309,7 +2309,7 @@
   {
     "name": "Scholar",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2322,7 +2322,7 @@
   {
     "name": "School Medic",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2335,7 +2335,7 @@
   {
     "name": "Scout",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2348,7 +2348,7 @@
   {
     "name": "Servant",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2361,7 +2361,7 @@
   {
     "name": "Sheriff",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2374,7 +2374,7 @@
   {
     "name": "Silk Farmer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2387,7 +2387,7 @@
   {
     "name": "Sky Rider",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2400,7 +2400,7 @@
   {
     "name": "Spotter",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2413,7 +2413,7 @@
   {
     "name": "Squire",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2426,7 +2426,7 @@
   {
     "name": "Star Athlete",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2439,7 +2439,7 @@
   {
     "name": "Street Urchin",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2452,7 +2452,7 @@
   {
     "name": "Streetfood Vendor",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2465,7 +2465,7 @@
   {
     "name": "Tall Tale",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2478,7 +2478,7 @@
   {
     "name": "Tax Collector",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2491,7 +2491,7 @@
   {
     "name": "Teacher",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2504,7 +2504,7 @@
   {
     "name": "Tech-Reliant",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2517,7 +2517,7 @@
   {
     "name": "Tiffin Box Deliverer",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2530,7 +2530,7 @@
   {
     "name": "Tinker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2543,7 +2543,7 @@
   {
     "name": "Toymaker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2556,7 +2556,7 @@
   {
     "name": "Traveling Gourmand",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2569,7 +2569,7 @@
   {
     "name": "Undertaker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2582,7 +2582,7 @@
   {
     "name": "Veteran",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2595,7 +2595,7 @@
   {
     "name": "Wandering Preacher",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2608,7 +2608,7 @@
   {
     "name": "War Orphan",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2621,7 +2621,7 @@
   {
     "name": "Ward",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2634,7 +2634,7 @@
   {
     "name": "Warded by Kami",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2647,7 +2647,7 @@
   {
     "name": "Warrior",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2660,7 +2660,7 @@
   {
     "name": "Waste Walker",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2673,7 +2673,7 @@
   {
     "name": "Weaver",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2686,7 +2686,7 @@
   {
     "name": "Wished Alive",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2699,7 +2699,7 @@
   {
     "name": "Working Student",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2712,7 +2712,7 @@
   {
     "name": "Zodiac Bound",
     "rule_type": "Background",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/class-feats.json
+++ b/db/seeds/pf2e/class-feats.json
@@ -2,7 +2,7 @@
   {
     "name": "Alchemical Assessment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20,7 +20,7 @@
   {
     "name": "Alchemical Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37,7 +37,7 @@
   {
     "name": "Blowgun Poisoner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -54,7 +54,7 @@
   {
     "name": "Far Lobber",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -71,7 +71,7 @@
   {
     "name": "Quick Bomber",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -88,7 +88,7 @@
   {
     "name": "Soothing Vials",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -105,7 +105,7 @@
   {
     "name": "Advanced Efficient Alchemy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -123,7 +123,7 @@
   {
     "name": "Expanded Splash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -141,7 +141,7 @@
   {
     "name": "Greater Debilitating Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -159,7 +159,7 @@
   {
     "name": "Sour Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -181,7 +181,7 @@
   {
     "name": "Unstable Concoction",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -201,7 +201,7 @@
   {
     "name": "Extend Elixir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -219,7 +219,7 @@
   {
     "name": "Supreme Invigorating Elixir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -237,7 +237,7 @@
   {
     "name": "Uncanny Bombs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -255,7 +255,7 @@
   {
     "name": "Double Poison",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -273,7 +273,7 @@
   {
     "name": "Mutant Innervation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -291,7 +291,7 @@
   {
     "name": "True Debilitating Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -309,7 +309,7 @@
   {
     "name": "Eternal Elixir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -327,7 +327,7 @@
   {
     "name": "Exploitive Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -347,7 +347,7 @@
   {
     "name": "Persistent Mutagen",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -365,7 +365,7 @@
   {
     "name": "Improbable Elixirs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -383,7 +383,7 @@
   {
     "name": "Miracle Worker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -401,7 +401,7 @@
   {
     "name": "Perfect Debilitation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -419,7 +419,7 @@
   {
     "name": "Clotting Elixirs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -437,7 +437,7 @@
   {
     "name": "Improvise Admixture",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -459,7 +459,7 @@
   {
     "name": "Pernicious Poison",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -479,7 +479,7 @@
   {
     "name": "Revivifying Mutagen",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -499,7 +499,7 @@
   {
     "name": "Smoke Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -519,7 +519,7 @@
   {
     "name": "Alchemical Revivification",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -537,7 +537,7 @@
   {
     "name": "Craft Philosopher's Stone",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -555,7 +555,7 @@
   {
     "name": "Mega Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -577,7 +577,7 @@
   {
     "name": "Efficient Alchemy (Alchemist)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -595,7 +595,7 @@
   {
     "name": "Enduring Alchemy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -613,7 +613,7 @@
   {
     "name": "Fermenting Liquors",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -635,7 +635,7 @@
   {
     "name": "Healing Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -655,7 +655,7 @@
   {
     "name": "Invigorating Elixir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -675,7 +675,7 @@
   {
     "name": "Numbing Spice Exhalation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -695,7 +695,7 @@
   {
     "name": "Regurgitate Mutagen",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -715,7 +715,7 @@
   {
     "name": "Tenacious Toxins",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -733,7 +733,7 @@
   {
     "name": "Combine Elixirs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -753,7 +753,7 @@
   {
     "name": "Debilitating Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -773,7 +773,7 @@
   {
     "name": "Directional Bombs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -791,7 +791,7 @@
   {
     "name": "Fortified Elixirs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -809,7 +809,7 @@
   {
     "name": "Sticky Poison",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -827,7 +827,7 @@
   {
     "name": "Alter Admixture",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -847,7 +847,7 @@
   {
     "name": "Glitter Crystals",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -869,7 +869,7 @@
   {
     "name": "Improved Invigorating Elixir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -887,7 +887,7 @@
   {
     "name": "Mutant Physique",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -905,7 +905,7 @@
   {
     "name": "Pinpoint Poisoner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -923,7 +923,7 @@
   {
     "name": "Sticky Bomb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -943,7 +943,7 @@
   {
     "name": "Apparition Sense",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -962,7 +962,7 @@
   {
     "name": "Channeler's Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -981,7 +981,7 @@
   {
     "name": "Circle of Spirits",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1002,7 +1002,7 @@
   {
     "name": "Relinquish Control",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1021,7 +1021,7 @@
   {
     "name": "Spirit Familiar (Animist)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1038,7 +1038,7 @@
   {
     "name": "Apparition's Quickening",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1062,7 +1062,7 @@
   {
     "name": "Fly on Shadowed Wings",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1082,7 +1082,7 @@
   {
     "name": "Incredible Familiar (Animist)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1100,7 +1100,7 @@
   {
     "name": "Apparition Cloud",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1122,7 +1122,7 @@
   {
     "name": "Shadows Within Shadows",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1148,7 +1148,7 @@
   {
     "name": "Whispers of Warning",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1174,7 +1174,7 @@
   {
     "name": "Banish Falsehoods of Flesh",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1196,7 +1196,7 @@
   {
     "name": "Cardinal Guardians",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1214,7 +1214,7 @@
   {
     "name": "Forest's Heart",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1240,7 +1240,7 @@
   {
     "name": "Jester's Gambol",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1266,7 +1266,7 @@
   {
     "name": "Monstrous Inclinations",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1288,7 +1288,7 @@
   {
     "name": "Spiritual Spellshape Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1314,7 +1314,7 @@
   {
     "name": "Cycle of Souls",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1334,7 +1334,7 @@
   {
     "name": "Spirit's Sacrifice",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1354,7 +1354,7 @@
   {
     "name": "Embodiment of the Balance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1372,7 +1372,7 @@
   {
     "name": "Grasping Spirits Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1396,7 +1396,7 @@
   {
     "name": "Spiritual Expansion Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1420,7 +1420,7 @@
   {
     "name": "Eternal Guide",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1440,7 +1440,7 @@
   {
     "name": "True Channel Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1458,7 +1458,7 @@
   {
     "name": "Apparition's Enhancement",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1482,7 +1482,7 @@
   {
     "name": "Channeled Protection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1504,7 +1504,7 @@
   {
     "name": "Walk the Wilds",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1522,7 +1522,7 @@
   {
     "name": "Apparition Stabilization",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1544,7 +1544,7 @@
   {
     "name": "Blazing Spirit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1570,7 +1570,7 @@
   {
     "name": "Grudge Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1594,7 +1594,7 @@
   {
     "name": "Medium's Awareness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1618,7 +1618,7 @@
   {
     "name": "Roaring Heart",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1642,7 +1642,7 @@
   {
     "name": "Apparition's Reflection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1664,7 +1664,7 @@
   {
     "name": "Instinctive Maneuvers",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1684,7 +1684,7 @@
   {
     "name": "Spirit Walk",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1708,7 +1708,7 @@
   {
     "name": "Wind Seeker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1726,7 +1726,7 @@
   {
     "name": "Acute Vision",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1743,7 +1743,7 @@
   {
     "name": "Adrenaline Rush",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1762,7 +1762,7 @@
   {
     "name": "Draconic Arrogance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1782,7 +1782,7 @@
   {
     "name": "Moment of Clarity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1803,7 +1803,7 @@
   {
     "name": "Raging Intimidation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1820,7 +1820,7 @@
   {
     "name": "Raging Thrower",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1837,7 +1837,7 @@
   {
     "name": "Come and Get Me",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1859,7 +1859,7 @@
   {
     "name": "Furious Sprint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1879,7 +1879,7 @@
   {
     "name": "Great Cleave",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1899,7 +1899,7 @@
   {
     "name": "Impressive Landing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1917,7 +1917,7 @@
   {
     "name": "Knockback",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1937,7 +1937,7 @@
   {
     "name": "Resounding Blow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1957,7 +1957,7 @@
   {
     "name": "Silencing Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1979,7 +1979,7 @@
   {
     "name": "Tangle of Battle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1999,7 +1999,7 @@
   {
     "name": "Terrifying Howl",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2021,7 +2021,7 @@
   {
     "name": "Dragon's Rage Wings",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2043,7 +2043,7 @@
   {
     "name": "Embrace the Pain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2063,7 +2063,7 @@
   {
     "name": "Furious Grab",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2083,7 +2083,7 @@
   {
     "name": "Predator's Pounce",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2105,7 +2105,7 @@
   {
     "name": "Spirit's Wrath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2129,7 +2129,7 @@
   {
     "name": "Sunder Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2153,7 +2153,7 @@
   {
     "name": "Titan's Stature",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2171,7 +2171,7 @@
   {
     "name": "Unbalancing Sweep",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2191,7 +2191,7 @@
   {
     "name": "Awesome Blow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2213,7 +2213,7 @@
   {
     "name": "Giant's Lunge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2235,7 +2235,7 @@
   {
     "name": "Impaling Thrust",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2255,7 +2255,7 @@
   {
     "name": "Meditate on This!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2283,7 +2283,7 @@
   {
     "name": "Sunder Enchantment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2301,7 +2301,7 @@
   {
     "name": "Vengeful Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2321,7 +2321,7 @@
   {
     "name": "Collateral Thrash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2341,7 +2341,7 @@
   {
     "name": "Desperate Wrath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2361,7 +2361,7 @@
   {
     "name": "Dragon Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2387,7 +2387,7 @@
   {
     "name": "Furious Vengeance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2407,7 +2407,7 @@
   {
     "name": "Penetrating Projectile",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2429,7 +2429,7 @@
   {
     "name": "Shattering Blows",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2449,7 +2449,7 @@
   {
     "name": "Brutal Critical",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2467,7 +2467,7 @@
   {
     "name": "Perfect Clarity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2491,7 +2491,7 @@
   {
     "name": "Vicious Evisceration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2511,7 +2511,7 @@
   {
     "name": "Whirlwind Toss",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2531,7 +2531,7 @@
   {
     "name": "Acute Scent",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2549,7 +2549,7 @@
   {
     "name": "Bashing Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2569,7 +2569,7 @@
   {
     "name": "Elemental Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2587,7 +2587,7 @@
   {
     "name": "Furious Finish",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2607,7 +2607,7 @@
   {
     "name": "No Escape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2627,7 +2627,7 @@
   {
     "name": "Second Wind",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2645,7 +2645,7 @@
   {
     "name": "Shake it Off",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2667,7 +2667,7 @@
   {
     "name": "Annihilating Swing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2685,7 +2685,7 @@
   {
     "name": "Contagious Rage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2709,7 +2709,7 @@
   {
     "name": "Quaking Stomp",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2731,7 +2731,7 @@
   {
     "name": "Unstoppable Juggernaut",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2749,7 +2749,7 @@
   {
     "name": "Oversized Throw",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2769,7 +2769,7 @@
   {
     "name": "Raging Athlete",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2787,7 +2787,7 @@
   {
     "name": "Scars of Steel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2807,7 +2807,7 @@
   {
     "name": "Spiritual Guides",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2829,7 +2829,7 @@
   {
     "name": "Supernatural Senses",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2849,7 +2849,7 @@
   {
     "name": "Wounded Rage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2867,7 +2867,7 @@
   {
     "name": "Animal Skin",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2889,7 +2889,7 @@
   {
     "name": "Brutal Bully",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2907,7 +2907,7 @@
   {
     "name": "Cleave",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2927,7 +2927,7 @@
   {
     "name": "Dragon's Rage Breath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2949,7 +2949,7 @@
   {
     "name": "Elemental Explosion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2973,7 +2973,7 @@
   {
     "name": "Giant's Stature",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2997,7 +2997,7 @@
   {
     "name": "Inner Strength",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3019,7 +3019,7 @@
   {
     "name": "Mage Hunter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3039,7 +3039,7 @@
   {
     "name": "Nocturnal Senses",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3059,7 +3059,7 @@
   {
     "name": "Scouring Rage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3077,7 +3077,7 @@
   {
     "name": "Spirits' Interference",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3099,7 +3099,7 @@
   {
     "name": "Animalistic Brutality",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3125,7 +3125,7 @@
   {
     "name": "Disarming Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3147,7 +3147,7 @@
   {
     "name": "Follow-Up Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3167,7 +3167,7 @@
   {
     "name": "Friendly Toss",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3189,7 +3189,7 @@
   {
     "name": "Furious Bully",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3207,7 +3207,7 @@
   {
     "name": "Instinctive Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3225,7 +3225,7 @@
   {
     "name": "Invulnerable Rager",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3243,7 +3243,7 @@
   {
     "name": "Renewed Vigor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3265,7 +3265,7 @@
   {
     "name": "Share Rage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3289,7 +3289,7 @@
   {
     "name": "Thrash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3309,7 +3309,7 @@
   {
     "name": "Bardic Lore",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3327,7 +3327,7 @@
   {
     "name": "Hymn of Healing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3344,7 +3344,7 @@
   {
     "name": "Lingering Composition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3362,7 +3362,7 @@
   {
     "name": "Martial Performance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3380,7 +3380,7 @@
   {
     "name": "Versatile Performance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3398,7 +3398,7 @@
   {
     "name": "Well-Versed",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3415,7 +3415,7 @@
   {
     "name": "Zoophonic Communication",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3433,7 +3433,7 @@
   {
     "name": "Annotate Composition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3455,7 +3455,7 @@
   {
     "name": "Courageous Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3479,7 +3479,7 @@
   {
     "name": "House of Imaginary Walls",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3497,7 +3497,7 @@
   {
     "name": "Ode to Ouroboros",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3515,7 +3515,7 @@
   {
     "name": "Symphony of the Unfettered Heart",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3533,7 +3533,7 @@
   {
     "name": "Unusual Composition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3557,7 +3557,7 @@
   {
     "name": "Chorus Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3575,7 +3575,7 @@
   {
     "name": "Eclectic Polymath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3593,7 +3593,7 @@
   {
     "name": "Enigma's Knowledge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3611,7 +3611,7 @@
   {
     "name": "Inspirational Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3629,7 +3629,7 @@
   {
     "name": "Reverberate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3647,7 +3647,7 @@
   {
     "name": "Shared Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3665,7 +3665,7 @@
   {
     "name": "Allegro",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3683,7 +3683,7 @@
   {
     "name": "Earworm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3703,7 +3703,7 @@
   {
     "name": "Musical Summons",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3721,7 +3721,7 @@
   {
     "name": "Soothing Ballad",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3739,7 +3739,7 @@
   {
     "name": "Triumphant Inspiration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3757,7 +3757,7 @@
   {
     "name": "True Hypercognition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3775,7 +3775,7 @@
   {
     "name": "Vigorous Anthem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3799,7 +3799,7 @@
   {
     "name": "Courageous Onslaught",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3823,7 +3823,7 @@
   {
     "name": "Resounding Finale",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3843,7 +3843,7 @@
   {
     "name": "Studious Capacity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3861,7 +3861,7 @@
   {
     "name": "All in My Head",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3883,7 +3883,7 @@
   {
     "name": "Deep Lore",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3901,7 +3901,7 @@
   {
     "name": "Discordant Voice",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3921,7 +3921,7 @@
   {
     "name": "Eternal Composition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3939,7 +3939,7 @@
   {
     "name": "Impossible Polymath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3957,7 +3957,7 @@
   {
     "name": "Pack Performance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3975,7 +3975,7 @@
   {
     "name": "Bestial Snarling",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4001,7 +4001,7 @@
   {
     "name": "Directed Audience",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4019,7 +4019,7 @@
   {
     "name": "Emotional Push",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4039,7 +4039,7 @@
   {
     "name": "Esoteric Polymath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4057,7 +4057,7 @@
   {
     "name": "Loremaster's Etude",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4077,7 +4077,7 @@
   {
     "name": "Multifarious Muse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4095,7 +4095,7 @@
   {
     "name": "Song of Strength",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4113,7 +4113,7 @@
   {
     "name": "Uplifting Overture",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4131,7 +4131,7 @@
   {
     "name": "Fatal Aria",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4149,7 +4149,7 @@
   {
     "name": "Perfect Encore",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4167,7 +4167,7 @@
   {
     "name": "Pied Piping",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4185,7 +4185,7 @@
   {
     "name": "Symphony of the Muse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4203,7 +4203,7 @@
   {
     "name": "Ultimate Polymath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4221,7 +4221,7 @@
   {
     "name": "Combat Reading",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4241,7 +4241,7 @@
   {
     "name": "Courageous Advance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4265,7 +4265,7 @@
   {
     "name": "In Tune",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4287,7 +4287,7 @@
   {
     "name": "Melodious Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4311,7 +4311,7 @@
   {
     "name": "Rallying Anthem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4329,7 +4329,7 @@
   {
     "name": "Ritual Researcher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4347,7 +4347,7 @@
   {
     "name": "Triple Time",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4365,7 +4365,7 @@
   {
     "name": "Versatile Signature",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4383,7 +4383,7 @@
   {
     "name": "Zoophonic Composition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4401,7 +4401,7 @@
   {
     "name": "Assured Knowledge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4419,7 +4419,7 @@
   {
     "name": "Defensive Coordination",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4443,7 +4443,7 @@
   {
     "name": "Dirge of Doom",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4461,7 +4461,7 @@
   {
     "name": "Educate Allies",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4481,7 +4481,7 @@
   {
     "name": "Harmonize",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4505,7 +4505,7 @@
   {
     "name": "Song of Marching",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4523,7 +4523,7 @@
   {
     "name": "Accompany",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4545,7 +4545,7 @@
   {
     "name": "Call and Response",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4569,7 +4569,7 @@
   {
     "name": "Ears of the Forest",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4587,7 +4587,7 @@
   {
     "name": "Eclectic Skill",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4605,7 +4605,7 @@
   {
     "name": "Fortissimo Composition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4623,7 +4623,7 @@
   {
     "name": "Reflexive Courage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4645,7 +4645,7 @@
   {
     "name": "Songbird's Call",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4663,7 +4663,7 @@
   {
     "name": "Soulsight (Bard)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4681,7 +4681,7 @@
   {
     "name": "Brilliant Flash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4699,7 +4699,7 @@
   {
     "name": "Deity's Domain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4716,7 +4716,7 @@
   {
     "name": "Desperate Prayer",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4733,7 +4733,7 @@
   {
     "name": "Faithful Steed",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4750,7 +4750,7 @@
   {
     "name": "Iron Repercussions",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4768,7 +4768,7 @@
   {
     "name": "Nimble Reprisal",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4786,7 +4786,7 @@
   {
     "name": "Ongoing Selfishness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4804,7 +4804,7 @@
   {
     "name": "Unimpeded Step",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4822,7 +4822,7 @@
   {
     "name": "Vicious Vengeance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4840,7 +4840,7 @@
   {
     "name": "Weight of Guilt",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4858,7 +4858,7 @@
   {
     "name": "Devoted Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4876,7 +4876,7 @@
   {
     "name": "Imposing Destrier",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4894,7 +4894,7 @@
   {
     "name": "Radiant Armament",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4912,7 +4912,7 @@
   {
     "name": "Shield of Reckoning",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4930,7 +4930,7 @@
   {
     "name": "Spectral Advance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4954,7 +4954,7 @@
   {
     "name": "Affliction Mercy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4972,7 +4972,7 @@
   {
     "name": "Aura of Faith",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4990,7 +4990,7 @@
   {
     "name": "Blessed Counterstrike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5010,7 +5010,7 @@
   {
     "name": "Champion's Sacrifice",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5028,7 +5028,7 @@
   {
     "name": "Divine Wall",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5046,7 +5046,7 @@
   {
     "name": "Enforce Oath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5064,7 +5064,7 @@
   {
     "name": "Gruesome Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5082,7 +5082,7 @@
   {
     "name": "Pale Horse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5100,7 +5100,7 @@
   {
     "name": "Steed's Toppling Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5120,7 +5120,7 @@
   {
     "name": "Aura of Determination",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5138,7 +5138,7 @@
   {
     "name": "Aura of Life",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5156,7 +5156,7 @@
   {
     "name": "Aura of Righteousness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5174,7 +5174,7 @@
   {
     "name": "Divine Reflexes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5192,7 +5192,7 @@
   {
     "name": "Exalted Greatness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5210,7 +5210,7 @@
   {
     "name": "Auspicious Mount",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5228,7 +5228,7 @@
   {
     "name": "Instrument of Slaughter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5246,7 +5246,7 @@
   {
     "name": "Instrument of Zeal",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5264,7 +5264,7 @@
   {
     "name": "Shield of Grace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5282,7 +5282,7 @@
   {
     "name": "Celestial Form",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5300,7 +5300,7 @@
   {
     "name": "Fiendish Form",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5318,7 +5318,7 @@
   {
     "name": "Rejuvenating Touch",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5336,7 +5336,7 @@
   {
     "name": "Retributive Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5354,7 +5354,7 @@
   {
     "name": "Swift Retribution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5372,7 +5372,7 @@
   {
     "name": "Ultimate Mercy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5390,7 +5390,7 @@
   {
     "name": "Divine Grace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5408,7 +5408,7 @@
   {
     "name": "Divine Health",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5426,7 +5426,7 @@
   {
     "name": "Oath of the Avenger",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5446,7 +5446,7 @@
   {
     "name": "Oath of the Defender",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5466,7 +5466,7 @@
   {
     "name": "Oath of the Slayer",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5486,7 +5486,7 @@
   {
     "name": "Armament Paragon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5504,7 +5504,7 @@
   {
     "name": "Sacred Defender",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5522,7 +5522,7 @@
   {
     "name": "Shield Paragon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5540,7 +5540,7 @@
   {
     "name": "Swift Paragon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5558,7 +5558,7 @@
   {
     "name": "Acclimated Mount",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5576,7 +5576,7 @@
   {
     "name": "Aura of Courage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5594,7 +5594,7 @@
   {
     "name": "Aura of Despair",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5612,7 +5612,7 @@
   {
     "name": "Cruelty",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5630,7 +5630,7 @@
   {
     "name": "Mercy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5648,7 +5648,7 @@
   {
     "name": "Security",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5666,7 +5666,7 @@
   {
     "name": "Expand Aura",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5686,7 +5686,7 @@
   {
     "name": "Loyal Warhorse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5704,7 +5704,7 @@
   {
     "name": "Smite",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5724,7 +5724,7 @@
   {
     "name": "Advanced Deity's Domain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5742,7 +5742,7 @@
   {
     "name": "Faithful Stride",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5762,7 +5762,7 @@
   {
     "name": "Greater Cruelty",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5780,7 +5780,7 @@
   {
     "name": "Greater Mercy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5798,7 +5798,7 @@
   {
     "name": "Greater Security",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5816,7 +5816,7 @@
   {
     "name": "Heal Mount",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5834,7 +5834,7 @@
   {
     "name": "Second Blessing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5852,7 +5852,7 @@
   {
     "name": "Sense Holiness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5870,7 +5870,7 @@
   {
     "name": "Sense Unholiness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5888,7 +5888,7 @@
   {
     "name": "Deadly Simplicity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5906,7 +5906,7 @@
   {
     "name": "Divine Castigation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5924,7 +5924,7 @@
   {
     "name": "Domain Initiate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5941,7 +5941,7 @@
   {
     "name": "Harming Hands",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5959,7 +5959,7 @@
   {
     "name": "Healing Hands",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5977,7 +5977,7 @@
   {
     "name": "Premonition of Avoidance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5994,7 +5994,7 @@
   {
     "name": "Castigating Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6012,7 +6012,7 @@
   {
     "name": "Heroic Recovery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6034,7 +6034,7 @@
   {
     "name": "Replenishment of War",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6052,7 +6052,7 @@
   {
     "name": "Shared Avoidance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6070,7 +6070,7 @@
   {
     "name": "Shield of Faith",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6088,7 +6088,7 @@
   {
     "name": "Defensive Recovery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6110,7 +6110,7 @@
   {
     "name": "Domain Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6128,7 +6128,7 @@
   {
     "name": "Emblazon Antimagic",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6146,7 +6146,7 @@
   {
     "name": "Fortunate Relief",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6166,7 +6166,7 @@
   {
     "name": "Sapping Symbol",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6186,7 +6186,7 @@
   {
     "name": "Shared Replenishment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6204,7 +6204,7 @@
   {
     "name": "Channeling Block",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6222,7 +6222,7 @@
   {
     "name": "Deity's Protection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6240,7 +6240,7 @@
   {
     "name": "Ebb and Flow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6262,7 +6262,7 @@
   {
     "name": "Fast Channel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6280,7 +6280,7 @@
   {
     "name": "Lasting Armament",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6298,7 +6298,7 @@
   {
     "name": "Premonition of Clarity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6318,7 +6318,7 @@
   {
     "name": "Swift Banishment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6336,7 +6336,7 @@
   {
     "name": "Eternal Bane",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6354,7 +6354,7 @@
   {
     "name": "Eternal Blessing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6372,7 +6372,7 @@
   {
     "name": "Rebounding Smite",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6390,7 +6390,7 @@
   {
     "name": "Remediate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6412,7 +6412,7 @@
   {
     "name": "Resurrectionist",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6430,7 +6430,7 @@
   {
     "name": "Divine Apex",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6448,7 +6448,7 @@
   {
     "name": "Improved Swift Banishment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6466,7 +6466,7 @@
   {
     "name": "Inviolable",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6484,7 +6484,7 @@
   {
     "name": "Miraculous Possibility",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6502,7 +6502,7 @@
   {
     "name": "Shared Clarity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6520,7 +6520,7 @@
   {
     "name": "Communal Healing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6542,7 +6542,7 @@
   {
     "name": "Emblazon Armament",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6562,7 +6562,7 @@
   {
     "name": "Panic the Dead",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6586,7 +6586,7 @@
   {
     "name": "Rapid Response",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6604,7 +6604,7 @@
   {
     "name": "Sap Life",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6624,7 +6624,7 @@
   {
     "name": "Versatile Font",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6642,7 +6642,7 @@
   {
     "name": "Warpriest's Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6660,7 +6660,7 @@
   {
     "name": "Avatar's Audience",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6678,7 +6678,7 @@
   {
     "name": "Avatar's Protection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6696,7 +6696,7 @@
   {
     "name": "Maker of Miracles",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6714,7 +6714,7 @@
   {
     "name": "Spellshape Channel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6734,7 +6734,7 @@
   {
     "name": "Channel Smite",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6754,7 +6754,7 @@
   {
     "name": "Directed Channel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6772,7 +6772,7 @@
   {
     "name": "Divine Infusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6794,7 +6794,7 @@
   {
     "name": "Expanded Domain Initiate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6812,7 +6812,7 @@
   {
     "name": "Raise Symbol",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6830,7 +6830,7 @@
   {
     "name": "Restorative Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6848,7 +6848,7 @@
   {
     "name": "Sacred Ground",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6872,7 +6872,7 @@
   {
     "name": "Cast Down",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6894,7 +6894,7 @@
   {
     "name": "Divine Rebuttal",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6914,7 +6914,7 @@
   {
     "name": "Divine Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6932,7 +6932,7 @@
   {
     "name": "Magic Hands",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6950,7 +6950,7 @@
   {
     "name": "Selective Energy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6968,7 +6968,7 @@
   {
     "name": "Advanced Domain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6986,7 +6986,7 @@
   {
     "name": "Cremate Undead",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7004,7 +7004,7 @@
   {
     "name": "Emblazon Energy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7022,7 +7022,7 @@
   {
     "name": "Martyr",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7042,7 +7042,7 @@
   {
     "name": "Restorative Channel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7060,7 +7060,7 @@
   {
     "name": "Sanctify Armament",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7080,7 +7080,7 @@
   {
     "name": "Surging Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7098,7 +7098,7 @@
   {
     "name": "Void Siphon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7116,7 +7116,7 @@
   {
     "name": "Zealous Rush",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7134,7 +7134,7 @@
   {
     "name": "Armored Regiment Training",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7151,7 +7151,7 @@
   {
     "name": "Commander's Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7168,7 +7168,7 @@
   {
     "name": "Deceptive Tactics",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7185,7 +7185,7 @@
   {
     "name": "Officer's Medical Training",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7202,7 +7202,7 @@
   {
     "name": "Plant Banner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7221,7 +7221,7 @@
   {
     "name": "Battle-Hardened Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7239,7 +7239,7 @@
   {
     "name": "Drilled Reflexes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7257,7 +7257,7 @@
   {
     "name": "Standard-Bearer's Sacrifice",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7281,7 +7281,7 @@
   {
     "name": "Targeting Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7299,7 +7299,7 @@
   {
     "name": "Fortunate Blow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7319,7 +7319,7 @@
   {
     "name": "Perfected Evaluations",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7337,7 +7337,7 @@
   {
     "name": "Contact With the Enemy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7355,7 +7355,7 @@
   {
     "name": "Desperate Resuscitation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7377,7 +7377,7 @@
   {
     "name": "Quickening Banner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7399,7 +7399,7 @@
   {
     "name": "Confusing Commands",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7421,7 +7421,7 @@
   {
     "name": "Peerless Mascot Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7439,7 +7439,7 @@
   {
     "name": "Demand Surrender",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7463,7 +7463,7 @@
   {
     "name": "Mercenary Reversal",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7489,7 +7489,7 @@
   {
     "name": "Practiced Reflexes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7507,7 +7507,7 @@
   {
     "name": "Adaptive Stratagem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7525,7 +7525,7 @@
   {
     "name": "Defensive Swap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7543,7 +7543,7 @@
   {
     "name": "Guiding Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7563,7 +7563,7 @@
   {
     "name": "Rapid Assessment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7581,7 +7581,7 @@
   {
     "name": "Set-Up Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7601,7 +7601,7 @@
   {
     "name": "Tactical Expansion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7619,7 +7619,7 @@
   {
     "name": "Glorious Banner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7637,7 +7637,7 @@
   {
     "name": "Pennant of Victory",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7659,7 +7659,7 @@
   {
     "name": "Banner Twirl",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7681,7 +7681,7 @@
   {
     "name": "Banner's Inspiration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7709,7 +7709,7 @@
   {
     "name": "Observational Analysis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7727,7 +7727,7 @@
   {
     "name": "Shielded Recovery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7745,7 +7745,7 @@
   {
     "name": "Unsteadying Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7765,7 +7765,7 @@
   {
     "name": "Battle-Tested Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7783,7 +7783,7 @@
   {
     "name": "Claim the Field",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7801,7 +7801,7 @@
   {
     "name": "Efficient Preparation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7819,7 +7819,7 @@
   {
     "name": "Defiant Banner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7845,7 +7845,7 @@
   {
     "name": "Officer's Education",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7863,7 +7863,7 @@
   {
     "name": "Rallying Banner",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7891,7 +7891,7 @@
   {
     "name": "Unrivaled Analysis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7909,7 +7909,7 @@
   {
     "name": "Animal Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7927,7 +7927,7 @@
   {
     "name": "Animal Empathy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7944,7 +7944,7 @@
   {
     "name": "Leshy Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7962,7 +7962,7 @@
   {
     "name": "Plant Empathy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7979,7 +7979,7 @@
   {
     "name": "Storm Born",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7997,7 +7997,7 @@
   {
     "name": "Untamed Form",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8015,7 +8015,7 @@
   {
     "name": "Verdant Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8034,7 +8034,7 @@
   {
     "name": "Elemental Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8052,7 +8052,7 @@
   {
     "name": "Healing Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8072,7 +8072,7 @@
   {
     "name": "Plant Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8090,7 +8090,7 @@
   {
     "name": "Primal Howl",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8108,7 +8108,7 @@
   {
     "name": "Pristine Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8126,7 +8126,7 @@
   {
     "name": "Side by Side (Druid)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8144,7 +8144,7 @@
   {
     "name": "Defensive Dismissal",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8162,7 +8162,7 @@
   {
     "name": "Dragon Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8180,7 +8180,7 @@
   {
     "name": "Explosive Metamorphosis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8200,7 +8200,7 @@
   {
     "name": "Garland Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8222,7 +8222,7 @@
   {
     "name": "Primal Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8240,7 +8240,7 @@
   {
     "name": "Primal Summons",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8258,7 +8258,7 @@
   {
     "name": "Uplifting Winds",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8276,7 +8276,7 @@
   {
     "name": "Wandering Oasis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8294,7 +8294,7 @@
   {
     "name": "Bizarre Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8316,7 +8316,7 @@
   {
     "name": "Cleansing Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8334,7 +8334,7 @@
   {
     "name": "Reactive Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8352,7 +8352,7 @@
   {
     "name": "Sow Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8374,7 +8374,7 @@
   {
     "name": "Specialized Companion (Druid)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8392,7 +8392,7 @@
   {
     "name": "Timeless Nature",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8410,7 +8410,7 @@
   {
     "name": "Verdant Metamorphosis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8428,7 +8428,7 @@
   {
     "name": "Impaling Briars",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8446,7 +8446,7 @@
   {
     "name": "Monstrosity Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8464,7 +8464,7 @@
   {
     "name": "Too Much to Swallow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8482,7 +8482,7 @@
   {
     "name": "Invoke Disaster",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8500,7 +8500,7 @@
   {
     "name": "Perfect Form Control",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8518,7 +8518,7 @@
   {
     "name": "Primal Aegis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8536,7 +8536,7 @@
   {
     "name": "Call of the Wild",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8554,7 +8554,7 @@
   {
     "name": "Order Explorer",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8572,7 +8572,7 @@
   {
     "name": "Hierophant's Power",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8590,7 +8590,7 @@
   {
     "name": "Ley Line Conduit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8614,7 +8614,7 @@
   {
     "name": "True Shapeshifter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8634,7 +8634,7 @@
   {
     "name": "Anthropomorphic Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8652,7 +8652,7 @@
   {
     "name": "Cryptic Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8674,7 +8674,7 @@
   {
     "name": "Elemental Summons",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8692,7 +8692,7 @@
   {
     "name": "Forest Passage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8710,7 +8710,7 @@
   {
     "name": "Form Control",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8732,7 +8732,7 @@
   {
     "name": "Leshy Familiar Secrets",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8750,7 +8750,7 @@
   {
     "name": "Mature Animal Companion (Druid)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8768,7 +8768,7 @@
   {
     "name": "Order Magic",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8786,7 +8786,7 @@
   {
     "name": "Snowdrift Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8810,7 +8810,7 @@
   {
     "name": "Current Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8832,7 +8832,7 @@
   {
     "name": "Fungal Exhalation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8852,7 +8852,7 @@
   {
     "name": "Grown of Oak",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8870,7 +8870,7 @@
   {
     "name": "Hedge Prison",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8890,7 +8890,7 @@
   {
     "name": "Insect Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8908,7 +8908,7 @@
   {
     "name": "Instinctive Support",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8926,7 +8926,7 @@
   {
     "name": "Misty Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8946,7 +8946,7 @@
   {
     "name": "Storm Retribution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8964,7 +8964,7 @@
   {
     "name": "Toppling Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8982,7 +8982,7 @@
   {
     "name": "Deimatic Display",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9000,7 +9000,7 @@
   {
     "name": "Ferocious Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9018,7 +9018,7 @@
   {
     "name": "Fey Caller",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9036,7 +9036,7 @@
   {
     "name": "Floral Restoration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9058,7 +9058,7 @@
   {
     "name": "Forgotten Presence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9076,7 +9076,7 @@
   {
     "name": "Incredible Companion (Druid)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9094,7 +9094,7 @@
   {
     "name": "Raise Menhir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9112,7 +9112,7 @@
   {
     "name": "Soaring Shape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9130,7 +9130,7 @@
   {
     "name": "Thunderclap Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9152,7 +9152,7 @@
   {
     "name": "Wind Caller",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9170,7 +9170,7 @@
   {
     "name": "Energized Spark",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9187,7 +9187,7 @@
   {
     "name": "Sanctified Soul",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9204,7 +9204,7 @@
   {
     "name": "Twin Stars",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9223,7 +9223,7 @@
   {
     "name": "Vow of Mortal Defiance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9249,7 +9249,7 @@
   {
     "name": "Breath of Vital Ash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9269,7 +9269,7 @@
   {
     "name": "Exult in Violence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9295,7 +9295,7 @@
   {
     "name": "Fish From the Falls' Edge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9319,7 +9319,7 @@
   {
     "name": "Journey of the Sky Chariot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9339,7 +9339,7 @@
   {
     "name": "Mated Birds in Paired Flight",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9359,7 +9359,7 @@
   {
     "name": "Compliant Gold",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9379,7 +9379,7 @@
   {
     "name": "Extract Vow of Nonviolence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9401,7 +9401,7 @@
   {
     "name": "Rapid Spark",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9419,7 +9419,7 @@
   {
     "name": "Warped by Rage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9441,7 +9441,7 @@
   {
     "name": "Complete the Hero's Journey",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9463,7 +9463,7 @@
   {
     "name": "Destined Victory",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9483,7 +9483,7 @@
   {
     "name": "Infinite Blades Celestial Arrow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9503,7 +9503,7 @@
   {
     "name": "Crown of Rule",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9523,7 +9523,7 @@
   {
     "name": "Gift of the Immortal Herb",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9549,7 +9549,7 @@
   {
     "name": "Mark of the Sage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9569,7 +9569,7 @@
   {
     "name": "Shroud of Ghosts",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9589,7 +9589,7 @@
   {
     "name": "Strike Rivers, Seize Winds",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9607,7 +9607,7 @@
   {
     "name": "Branched Tree of Pain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9627,7 +9627,7 @@
   {
     "name": "Eternity-Incinerating Blaze",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9649,7 +9649,7 @@
   {
     "name": "Seven-Colored Cosmic Bridge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9669,7 +9669,7 @@
   {
     "name": "Sunwrecker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9689,7 +9689,7 @@
   {
     "name": "Hurl at the Horizon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9709,7 +9709,7 @@
   {
     "name": "Leap the Falls",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9729,7 +9729,7 @@
   {
     "name": "Red-Gold Mortality",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9751,7 +9751,7 @@
   {
     "name": "Cutting Without Blade",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9769,7 +9769,7 @@
   {
     "name": "Reach for Immortality",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9787,7 +9787,7 @@
   {
     "name": "Remake the World",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9807,7 +9807,7 @@
   {
     "name": "Follow the Threads of Fate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9829,7 +9829,7 @@
   {
     "name": "Only the Worthy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9849,7 +9849,7 @@
   {
     "name": "Steel on Steel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9869,7 +9869,7 @@
   {
     "name": "Through the Needle's Eye",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9889,7 +9889,7 @@
   {
     "name": "Topple The Titans",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9907,7 +9907,7 @@
   {
     "name": "Binding Serpents Celestial Arrow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9927,7 +9927,7 @@
   {
     "name": "Flow of War",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9945,7 +9945,7 @@
   {
     "name": "Motionless Cutter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9965,7 +9965,7 @@
   {
     "name": "Riddle The Sphinx",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9985,7 +9985,7 @@
   {
     "name": "Shield of Stone",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10005,7 +10005,7 @@
   {
     "name": "Additional Ikon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10023,7 +10023,7 @@
   {
     "name": "As a Thousand Soldiers",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10047,7 +10047,7 @@
   {
     "name": "Battle Hymn to the Lost",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10069,7 +10069,7 @@
   {
     "name": "Forward Gaze Into Life",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10095,7 +10095,7 @@
   {
     "name": "Raise Island",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10117,7 +10117,7 @@
   {
     "name": "Rejoice in Solstice Storm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10141,7 +10141,7 @@
   {
     "name": "Double Slice",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10158,7 +10158,7 @@
   {
     "name": "Exacting Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10177,7 +10177,7 @@
   {
     "name": "Point Blank Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10196,7 +10196,7 @@
   {
     "name": "Snagging Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10213,7 +10213,7 @@
   {
     "name": "Vicious Swing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10232,7 +10232,7 @@
   {
     "name": "Agile Grace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10250,7 +10250,7 @@
   {
     "name": "Certain Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10270,7 +10270,7 @@
   {
     "name": "Crashing Slam",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10288,7 +10288,7 @@
   {
     "name": "Cut From the Air",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10306,7 +10306,7 @@
   {
     "name": "Debilitating Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10326,7 +10326,7 @@
   {
     "name": "Disarming Twist",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10346,7 +10346,7 @@
   {
     "name": "Disruptive Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10366,7 +10366,7 @@
   {
     "name": "Fearsome Brute",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10384,7 +10384,7 @@
   {
     "name": "Flinging Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10404,7 +10404,7 @@
   {
     "name": "Mirror Shield",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10422,7 +10422,7 @@
   {
     "name": "Tactical Reflexes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10440,7 +10440,7 @@
   {
     "name": "Brutal Finish",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10460,7 +10460,7 @@
   {
     "name": "Dashing Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10480,7 +10480,7 @@
   {
     "name": "Dueling Dance (Fighter)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10500,7 +10500,7 @@
   {
     "name": "Flinging Shove",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10518,7 +10518,7 @@
   {
     "name": "Improved Dueling Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10536,7 +10536,7 @@
   {
     "name": "Incredible Ricochet",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10558,7 +10558,7 @@
   {
     "name": "Lunging Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10578,7 +10578,7 @@
   {
     "name": "Desperate Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10598,7 +10598,7 @@
   {
     "name": "Determination",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10618,7 +10618,7 @@
   {
     "name": "Guiding Finish",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10638,7 +10638,7 @@
   {
     "name": "Guiding Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10656,7 +10656,7 @@
   {
     "name": "Improved Twin Riposte (Fighter)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10674,7 +10674,7 @@
   {
     "name": "Two-Weapon Flurry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10696,7 +10696,7 @@
   {
     "name": "Graceful Poise",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10716,7 +10716,7 @@
   {
     "name": "Multishot Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10736,7 +10736,7 @@
   {
     "name": "Overwhelming Blow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10754,7 +10754,7 @@
   {
     "name": "Twinned Defense (Fighter)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10774,7 +10774,7 @@
   {
     "name": "Savage Critical",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10792,7 +10792,7 @@
   {
     "name": "Smash from the Air",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10810,7 +10810,7 @@
   {
     "name": "Assisting Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10830,7 +10830,7 @@
   {
     "name": "Blade Brake",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10850,7 +10850,7 @@
   {
     "name": "Brutish Shove",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10870,7 +10870,7 @@
   {
     "name": "Combat Grab",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10890,7 +10890,7 @@
   {
     "name": "Dueling Parry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10908,7 +10908,7 @@
   {
     "name": "Lunge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10926,7 +10926,7 @@
   {
     "name": "Rebounding Toss",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10946,7 +10946,7 @@
   {
     "name": "Sleek Reposition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10966,7 +10966,7 @@
   {
     "name": "Ultimate Flexibility",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10984,7 +10984,7 @@
   {
     "name": "Weapon Supremacy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11002,7 +11002,7 @@
   {
     "name": "Double Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11022,7 +11022,7 @@
   {
     "name": "Dual-Handed Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11042,7 +11042,7 @@
   {
     "name": "Parting Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11060,7 +11060,7 @@
   {
     "name": "Powerful Shove",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11078,7 +11078,7 @@
   {
     "name": "Quick Reversal",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11100,7 +11100,7 @@
   {
     "name": "Shielded Stride",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11118,7 +11118,7 @@
   {
     "name": "Slam Down",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11138,7 +11138,7 @@
   {
     "name": "Advanced Weapon Training",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11156,7 +11156,7 @@
   {
     "name": "Advantageous Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11176,7 +11176,7 @@
   {
     "name": "Dazing Blow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11196,7 +11196,7 @@
   {
     "name": "Disarming Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11216,7 +11216,7 @@
   {
     "name": "Furious Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11234,7 +11234,7 @@
   {
     "name": "Guardian's Deflection (Fighter)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11252,7 +11252,7 @@
   {
     "name": "Revealing Stab",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11270,7 +11270,7 @@
   {
     "name": "Ricochet Stance (Fighter)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11290,7 +11290,7 @@
   {
     "name": "Shatter Defenses",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11310,7 +11310,7 @@
   {
     "name": "Triple Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11328,7 +11328,7 @@
   {
     "name": "Disorienting Opening",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11346,7 +11346,7 @@
   {
     "name": "Dueling Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11364,7 +11364,7 @@
   {
     "name": "Felling Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11382,7 +11382,7 @@
   {
     "name": "Incredible Aim",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11402,7 +11402,7 @@
   {
     "name": "Mobile Shot Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11422,7 +11422,7 @@
   {
     "name": "Positioning Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11442,7 +11442,7 @@
   {
     "name": "Resounding Bravery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11460,7 +11460,7 @@
   {
     "name": "Bodyguard",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11477,7 +11477,7 @@
   {
     "name": "Larger Than Life (Guardian)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11494,7 +11494,7 @@
   {
     "name": "Long-Distance Taunt",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11511,7 +11511,7 @@
   {
     "name": "Punishing Shove",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11529,7 +11529,7 @@
   {
     "name": "Shield Warfare",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11546,7 +11546,7 @@
   {
     "name": "Shoulder Check",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11563,7 +11563,7 @@
   {
     "name": "Belly Flop",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11581,7 +11581,7 @@
   {
     "name": "Get Behind Me!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11599,7 +11599,7 @@
   {
     "name": "Momentum Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11619,7 +11619,7 @@
   {
     "name": "Shield Salvation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11637,7 +11637,7 @@
   {
     "name": "Sure-Footed",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11655,7 +11655,7 @@
   {
     "name": "Tough Cookie",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11673,7 +11673,7 @@
   {
     "name": "Armor Break",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11691,7 +11691,7 @@
   {
     "name": "Armored Counterattack",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11709,7 +11709,7 @@
   {
     "name": "Devastating Shield Wallop",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11729,7 +11729,7 @@
   {
     "name": "Right Where You Want Them",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11747,7 +11747,7 @@
   {
     "name": "Scattering Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11767,7 +11767,7 @@
   {
     "name": "Weakening Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11785,7 +11785,7 @@
   {
     "name": "Blanket Defense",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11805,7 +11805,7 @@
   {
     "name": "Bloody Denial",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11825,7 +11825,7 @@
   {
     "name": "Keep Up the Good Fight",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11843,7 +11843,7 @@
   {
     "name": "Clang!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11861,7 +11861,7 @@
   {
     "name": "Clobber",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11879,7 +11879,7 @@
   {
     "name": "Never!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11897,7 +11897,7 @@
   {
     "name": "Demolish Defenses",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11915,7 +11915,7 @@
   {
     "name": "Perfect Protection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11933,7 +11933,7 @@
   {
     "name": "Quick Vengeance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11951,7 +11951,7 @@
   {
     "name": "Shield from Spells",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11969,7 +11969,7 @@
   {
     "name": "Covering Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11989,7 +11989,7 @@
   {
     "name": "Hampering Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12011,7 +12011,7 @@
   {
     "name": "Phalanx Formation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12029,7 +12029,7 @@
   {
     "name": "Raise Haft",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12047,7 +12047,7 @@
   {
     "name": "Shield Your Eyes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12065,7 +12065,7 @@
   {
     "name": "Shielding Taunt",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12085,7 +12085,7 @@
   {
     "name": "Taunting Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12105,7 +12105,7 @@
   {
     "name": "Great Shield Mastery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12123,7 +12123,7 @@
   {
     "name": "Unyielding Force",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12141,7 +12141,7 @@
   {
     "name": "Area Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12159,7 +12159,7 @@
   {
     "name": "Armored Courage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12177,7 +12177,7 @@
   {
     "name": "Energy Interceptor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12195,7 +12195,7 @@
   {
     "name": "Flying Tackle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12215,7 +12215,7 @@
   {
     "name": "Not So Fast!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12233,7 +12233,7 @@
   {
     "name": "Proud Nail",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12253,7 +12253,7 @@
   {
     "name": "Shielded Attrition",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12271,7 +12271,7 @@
   {
     "name": "Disarming Intercept",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12289,7 +12289,7 @@
   {
     "name": "Guarded Advance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12307,7 +12307,7 @@
   {
     "name": "Lock Down",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12327,7 +12327,7 @@
   {
     "name": "Retaliating Rescue",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12345,7 +12345,7 @@
   {
     "name": "Ring Their Bell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12367,7 +12367,7 @@
   {
     "name": "Stomp Ground",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12385,7 +12385,7 @@
   {
     "name": "Group Taunt",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12403,7 +12403,7 @@
   {
     "name": "Juggernaut Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12423,7 +12423,7 @@
   {
     "name": "Mighty Bulwark",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12441,7 +12441,7 @@
   {
     "name": "Repositioning Block",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12459,7 +12459,7 @@
   {
     "name": "Shield from Arrows",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12477,7 +12477,7 @@
   {
     "name": "Shield Wallop",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12497,7 +12497,7 @@
   {
     "name": "Blast Lock",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12516,7 +12516,7 @@
   {
     "name": "Cover Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12533,7 +12533,7 @@
   {
     "name": "Crossbow Crack Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12550,7 +12550,7 @@
   {
     "name": "Dual-Weapon Reload",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12568,7 +12568,7 @@
   {
     "name": "Hit the Dirt!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12585,7 +12585,7 @@
   {
     "name": "Munitions Crafter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12602,7 +12602,7 @@
   {
     "name": "Sword and Pistol",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12619,7 +12619,7 @@
   {
     "name": "Called Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12639,7 +12639,7 @@
   {
     "name": "Deflecting Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12657,7 +12657,7 @@
   {
     "name": "Penetrating Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12675,7 +12675,7 @@
   {
     "name": "Precious Munitions",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12693,7 +12693,7 @@
   {
     "name": "Rebounding Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12711,7 +12711,7 @@
   {
     "name": "Redirecting Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12731,7 +12731,7 @@
   {
     "name": "Trick Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12749,7 +12749,7 @@
   {
     "name": "Twin Shot Knockdown",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12767,7 +12767,7 @@
   {
     "name": "Blood in the Air",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12787,7 +12787,7 @@
   {
     "name": "Deadeye",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12807,7 +12807,7 @@
   {
     "name": "Flesh Wound",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12825,7 +12825,7 @@
   {
     "name": "Ricochet Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12845,7 +12845,7 @@
   {
     "name": "Shattering Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12863,7 +12863,7 @@
   {
     "name": "Shooter's Camouflage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12881,7 +12881,7 @@
   {
     "name": "Unshakable Grit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12899,7 +12899,7 @@
   {
     "name": "Blast Tackle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12917,7 +12917,7 @@
   {
     "name": "Come at Me!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12935,7 +12935,7 @@
   {
     "name": "Dance of Thunder",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12955,7 +12955,7 @@
   {
     "name": "Disruptive Blur",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12973,7 +12973,7 @@
   {
     "name": "Headshot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12993,7 +12993,7 @@
   {
     "name": "Showstopper",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13011,7 +13011,7 @@
   {
     "name": "Two-Weapon Fusillade",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13031,7 +13031,7 @@
   {
     "name": "Fatal Bullet",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13049,7 +13049,7 @@
   {
     "name": "Hair Trigger",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13067,7 +13067,7 @@
   {
     "name": "Instant Return",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13085,7 +13085,7 @@
   {
     "name": "Ricochet Master",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13103,7 +13103,7 @@
   {
     "name": "Final Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13121,7 +13121,7 @@
   {
     "name": "Piercing Critical",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13139,7 +13139,7 @@
   {
     "name": "Reach for the Stars",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13157,7 +13157,7 @@
   {
     "name": "Unerring Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13175,7 +13175,7 @@
   {
     "name": "Defensive Armaments",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13193,7 +13193,7 @@
   {
     "name": "Fake Out",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13213,7 +13213,7 @@
   {
     "name": "Pistol Twirl",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13231,7 +13231,7 @@
   {
     "name": "Risky Reload",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13251,7 +13251,7 @@
   {
     "name": "Warning Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13269,7 +13269,7 @@
   {
     "name": "Perfect Readiness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13287,7 +13287,7 @@
   {
     "name": "Ricochet Legend",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13305,7 +13305,7 @@
   {
     "name": "Slinger's Reflexes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13323,7 +13323,7 @@
   {
     "name": "Alchemical Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13341,7 +13341,7 @@
   {
     "name": "Black Powder Boost",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13359,7 +13359,7 @@
   {
     "name": "Instant Backup",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13377,7 +13377,7 @@
   {
     "name": "Paired Shots",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13395,7 +13395,7 @@
   {
     "name": "Advanced Shooter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13413,7 +13413,7 @@
   {
     "name": "Cauterize",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13433,7 +13433,7 @@
   {
     "name": "Drifter's Juke",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13453,7 +13453,7 @@
   {
     "name": "Munitions Machinist",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13471,7 +13471,7 @@
   {
     "name": "Phalanx Breaker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13489,7 +13489,7 @@
   {
     "name": "Pistolero's Challenge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13515,7 +13515,7 @@
   {
     "name": "Scatter Blast",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13533,7 +13533,7 @@
   {
     "name": "Sniper's Aim",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13553,7 +13553,7 @@
   {
     "name": "Bullet Split",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13573,7 +13573,7 @@
   {
     "name": "Grit and Tenacity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13593,7 +13593,7 @@
   {
     "name": "Leap and Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13611,7 +13611,7 @@
   {
     "name": "Smoke Curtain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13629,7 +13629,7 @@
   {
     "name": "Stab and Blast",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13649,7 +13649,7 @@
   {
     "name": "Built-In Tools",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13668,7 +13668,7 @@
   {
     "name": "Explosive Leap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13691,7 +13691,7 @@
   {
     "name": "Haphazard Repair",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13710,7 +13710,7 @@
   {
     "name": "No! No! I Created You!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13732,7 +13732,7 @@
   {
     "name": "Prototype Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13749,7 +13749,7 @@
   {
     "name": "Tamper",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13768,7 +13768,7 @@
   {
     "name": "Variable Core",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13787,7 +13787,7 @@
   {
     "name": "Distracting Explosion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13807,7 +13807,7 @@
   {
     "name": "Electrify Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13827,7 +13827,7 @@
   {
     "name": "Geobukseon Retaliation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13851,7 +13851,7 @@
   {
     "name": "Helpful Tinkering",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13871,7 +13871,7 @@
   {
     "name": "Lock On",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13889,7 +13889,7 @@
   {
     "name": "Boost Modulation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13909,7 +13909,7 @@
   {
     "name": "Celestial Cacophony",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13935,7 +13935,7 @@
   {
     "name": "Contingency Gadgets",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13953,7 +13953,7 @@
   {
     "name": "Deep Freeze",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13975,7 +13975,7 @@
   {
     "name": "Gigavolt",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13993,7 +13993,7 @@
   {
     "name": "Shared Overdrive",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14011,7 +14011,7 @@
   {
     "name": "Explosive Maneuver",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14029,7 +14029,7 @@
   {
     "name": "Paragon Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14047,7 +14047,7 @@
   {
     "name": "Soaring Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14067,7 +14067,7 @@
   {
     "name": "Unstable Redundancies",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14085,7 +14085,7 @@
   {
     "name": "Just the Thing!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14103,7 +14103,7 @@
   {
     "name": "Persistent Boost",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14121,7 +14121,7 @@
   {
     "name": "You Failed to Account For... This!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14139,7 +14139,7 @@
   {
     "name": "Devastating Weaponry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14157,7 +14157,7 @@
   {
     "name": "Engine of Destruction",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14175,7 +14175,7 @@
   {
     "name": "Negate Damage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14193,7 +14193,7 @@
   {
     "name": "Collapse Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14215,7 +14215,7 @@
   {
     "name": "Collapse Construct",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14237,7 +14237,7 @@
   {
     "name": "Oil Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14261,7 +14261,7 @@
   {
     "name": "Reverse Engineer",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14279,7 +14279,7 @@
   {
     "name": "Searing Restoration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14305,7 +14305,7 @@
   {
     "name": "Wukong Extension",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14327,7 +14327,7 @@
   {
     "name": "Full Automation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14345,7 +14345,7 @@
   {
     "name": "Ubiquitous Overdrive",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14363,7 +14363,7 @@
   {
     "name": "Advanced Construct Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14381,7 +14381,7 @@
   {
     "name": "Diving Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14401,7 +14401,7 @@
   {
     "name": "Dual-Form Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14421,7 +14421,7 @@
   {
     "name": "Duo Dragon Kick",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14439,7 +14439,7 @@
   {
     "name": "Gadget Specialist",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14457,7 +14457,7 @@
   {
     "name": "Megaton Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14475,7 +14475,7 @@
   {
     "name": "Clockwork Celerity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14497,7 +14497,7 @@
   {
     "name": "Construct Shell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14515,7 +14515,7 @@
   {
     "name": "Megavolt",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14537,7 +14537,7 @@
   {
     "name": "Silk Bracelet",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14557,7 +14557,7 @@
   {
     "name": "Visual Fidelity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14575,7 +14575,7 @@
   {
     "name": "Xidao Sea Mine Drop",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14593,7 +14593,7 @@
   {
     "name": "Gigaton Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14611,7 +14611,7 @@
   {
     "name": "Guardian Lion Roar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14633,7 +14633,7 @@
   {
     "name": "Incredible Construct Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14651,7 +14651,7 @@
   {
     "name": "Manifold Modifications",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14671,7 +14671,7 @@
   {
     "name": "Overdrive Ally",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14691,7 +14691,7 @@
   {
     "name": "Ubiquitous Gadgets",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14709,7 +14709,7 @@
   {
     "name": "Eliminate Red Herrings",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14726,7 +14726,7 @@
   {
     "name": "Flexible Studies",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14743,7 +14743,7 @@
   {
     "name": "Known Weaknesses",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14760,7 +14760,7 @@
   {
     "name": "Takedown Expert",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14777,7 +14777,7 @@
   {
     "name": "That's Odd",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14794,7 +14794,7 @@
   {
     "name": "Underworld Investigator",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14811,7 +14811,7 @@
   {
     "name": "Just One More Thing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14831,7 +14831,7 @@
   {
     "name": "Ongoing Strategy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14849,7 +14849,7 @@
   {
     "name": "Suspect of Opportunity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14867,7 +14867,7 @@
   {
     "name": "Empiricist's Eye",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14885,7 +14885,7 @@
   {
     "name": "Foresee Danger",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14905,7 +14905,7 @@
   {
     "name": "Just as Planned",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14925,7 +14925,7 @@
   {
     "name": "Make 'Em Sweat",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14943,7 +14943,7 @@
   {
     "name": "Reason Rapidly",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14961,7 +14961,7 @@
   {
     "name": "Share Tincture",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14979,7 +14979,7 @@
   {
     "name": "Surgical Shock",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14999,7 +14999,7 @@
   {
     "name": "Plot the Future",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15021,7 +15021,7 @@
   {
     "name": "Strategic Bypass",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15039,7 +15039,7 @@
   {
     "name": "Didactic Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15057,7 +15057,7 @@
   {
     "name": "Implausible Purchase (Investigator)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15075,7 +15075,7 @@
   {
     "name": "Lead Investigator",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15095,7 +15095,7 @@
   {
     "name": "Athletic Strategist",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15113,7 +15113,7 @@
   {
     "name": "Certain Stratagem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15131,7 +15131,7 @@
   {
     "name": "Exploit Blunder",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15149,7 +15149,7 @@
   {
     "name": "Person of Interest",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15167,7 +15167,7 @@
   {
     "name": "Shared Stratagem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15185,7 +15185,7 @@
   {
     "name": "Solid Lead",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15203,7 +15203,7 @@
   {
     "name": "Everyone's a Suspect",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15221,7 +15221,7 @@
   {
     "name": "Just the Facts",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15239,7 +15239,7 @@
   {
     "name": "Alchemical Discoveries",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15257,7 +15257,7 @@
   {
     "name": "Detective's Readiness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15275,7 +15275,7 @@
   {
     "name": "Lie Detector",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15293,7 +15293,7 @@
   {
     "name": "Ongoing Investigation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15311,7 +15311,7 @@
   {
     "name": "Scalpel's Point",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15329,7 +15329,7 @@
   {
     "name": "Strategic Assessment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15347,7 +15347,7 @@
   {
     "name": "Connect the Dots",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15371,7 +15371,7 @@
   {
     "name": "Predictive Purchase (Investigator)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15389,7 +15389,7 @@
   {
     "name": "Thorough Research",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15407,7 +15407,7 @@
   {
     "name": "Clue Them All In",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15425,7 +15425,7 @@
   {
     "name": "Defensive Stratagem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15443,7 +15443,7 @@
   {
     "name": "Whodunnit?",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15461,7 +15461,7 @@
   {
     "name": "Aerial Boomerang",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15484,7 +15484,7 @@
   {
     "name": "Air Cushion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15507,7 +15507,7 @@
   {
     "name": "Armor in Earth",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15530,7 +15530,7 @@
   {
     "name": "Burning Jet",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15553,7 +15553,7 @@
   {
     "name": "Deflecting Wave",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15576,7 +15576,7 @@
   {
     "name": "Elemental Familiar (Kineticist)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15593,7 +15593,7 @@
   {
     "name": "Eternal Torch",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15620,7 +15620,7 @@
   {
     "name": "Extended Kinesis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15638,7 +15638,7 @@
   {
     "name": "Flashforge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15661,7 +15661,7 @@
   {
     "name": "Flying Flame",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15684,7 +15684,7 @@
   {
     "name": "Four Winds",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15707,7 +15707,7 @@
   {
     "name": "Fresh Produce",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15736,7 +15736,7 @@
   {
     "name": "Geologic Attunement",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15761,7 +15761,7 @@
   {
     "name": "Hail of Splinters",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15786,7 +15786,7 @@
   {
     "name": "Hardwood Armor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15809,7 +15809,7 @@
   {
     "name": "Magnetic Pinions",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15836,7 +15836,7 @@
   {
     "name": "Metal Carapace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15859,7 +15859,7 @@
   {
     "name": "Ocean's Balm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15888,7 +15888,7 @@
   {
     "name": "Scorching Column",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15913,7 +15913,7 @@
   {
     "name": "Shard Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15936,7 +15936,7 @@
   {
     "name": "Stepping Stones",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15961,7 +15961,7 @@
   {
     "name": "Tidal Hands",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15986,7 +15986,7 @@
   {
     "name": "Timber Sentinel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16011,7 +16011,7 @@
   {
     "name": "Tremor",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16036,7 +16036,7 @@
   {
     "name": "Versatile Blasts",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16053,7 +16053,7 @@
   {
     "name": "Weapon Infusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16072,7 +16072,7 @@
   {
     "name": "Whisper on the Wind",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16101,7 +16101,7 @@
   {
     "name": "Winter's Clutch",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16126,7 +16126,7 @@
   {
     "name": "Aura Shaping",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16144,7 +16144,7 @@
   {
     "name": "Chain Infusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16164,7 +16164,7 @@
   {
     "name": "Elemental Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16186,7 +16186,7 @@
   {
     "name": "Architect of Flame",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16214,7 +16214,7 @@
   {
     "name": "Effortless Impulse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16232,7 +16232,7 @@
   {
     "name": "Furnace Form",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16260,7 +16260,7 @@
   {
     "name": "Ghosts in the Storm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16288,7 +16288,7 @@
   {
     "name": "Glacial Prison",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16318,7 +16318,7 @@
   {
     "name": "Hedge Maze",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16346,7 +16346,7 @@
   {
     "name": "Rain of Razors",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16372,7 +16372,7 @@
   {
     "name": "Rattle the Earth",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16398,7 +16398,7 @@
   {
     "name": "Rock Rampart",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16426,7 +16426,7 @@
   {
     "name": "Sea Glass Guardians",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16452,7 +16452,7 @@
   {
     "name": "Shattershields",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16478,7 +16478,7 @@
   {
     "name": "Wiles on the Wind",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16506,7 +16506,7 @@
   {
     "name": "Witchwood Seed",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16536,7 +16536,7 @@
   {
     "name": "Alloy Flesh and Steel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16564,7 +16564,7 @@
   {
     "name": "Assume Earth's Mantle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16590,7 +16590,7 @@
   {
     "name": "Barrier of Boreal Frost",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16620,7 +16620,7 @@
   {
     "name": "Body of Air",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16648,7 +16648,7 @@
   {
     "name": "Nourishing Gate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16666,7 +16666,7 @@
   {
     "name": "Orchard's Endurance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16694,7 +16694,7 @@
   {
     "name": "Rapid Reattunement",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16716,7 +16716,7 @@
   {
     "name": "Walk Through the Conflagration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16744,7 +16744,7 @@
   {
     "name": "Imperious Aura",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16766,7 +16766,7 @@
   {
     "name": "All Shall End in Flames",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16794,7 +16794,7 @@
   {
     "name": "Beasts of Slumbering Steel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16818,7 +16818,7 @@
   {
     "name": "Crowned in Tempest's Fury",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16846,7 +16846,7 @@
   {
     "name": "Elemental Apotheosis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16864,7 +16864,7 @@
   {
     "name": "Hell of 1,000,000 Needles",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16890,7 +16890,7 @@
   {
     "name": "Ignite the Sun",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16916,7 +16916,7 @@
   {
     "name": "Infinite Expanse of Bluest Heaven",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16948,7 +16948,7 @@
   {
     "name": "Rebirth in Living Stone",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16974,7 +16974,7 @@
   {
     "name": "Ride the Tsunami",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17000,7 +17000,7 @@
   {
     "name": "Rouse the Forest's Fury",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17028,7 +17028,7 @@
   {
     "name": "The Shattered Mountain Weeps",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17054,7 +17054,7 @@
   {
     "name": "The Thousand Lashes of the Weeping Willow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17082,7 +17082,7 @@
   {
     "name": "Turn the Wheel of Seasons",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17108,7 +17108,7 @@
   {
     "name": "Usurp the Lunar Reins",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17134,7 +17134,7 @@
   {
     "name": "Kinetic Activation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17152,7 +17152,7 @@
   {
     "name": "Voice of Elements",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17170,7 +17170,7 @@
   {
     "name": "Kinetic Pinnacle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17188,7 +17188,7 @@
   {
     "name": "Omnikinesis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17206,7 +17206,7 @@
   {
     "name": "Air Shroud",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17232,7 +17232,7 @@
   {
     "name": "Ambush Bladderwort",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17262,7 +17262,7 @@
   {
     "name": "Blazing Wave",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17288,7 +17288,7 @@
   {
     "name": "Born to the Trees",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17314,7 +17314,7 @@
   {
     "name": "Calcifying Sand",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17342,7 +17342,7 @@
   {
     "name": "Command Elemental",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17364,7 +17364,7 @@
   {
     "name": "Igneogenesis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17390,7 +17390,7 @@
   {
     "name": "Lava Leap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17420,7 +17420,7 @@
   {
     "name": "Lightning Dash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17452,7 +17452,7 @@
   {
     "name": "Living Bonfire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17480,7 +17480,7 @@
   {
     "name": "Magnetic Field",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17506,7 +17506,7 @@
   {
     "name": "Plate in Treasure",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17530,7 +17530,7 @@
   {
     "name": "Rain of Rust",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17558,7 +17558,7 @@
   {
     "name": "Ravel of Thorns",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17586,7 +17586,7 @@
   {
     "name": "Return to the Sea",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17612,7 +17612,7 @@
   {
     "name": "Safe Elements",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17630,7 +17630,7 @@
   {
     "name": "Thermal Nimbus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17656,7 +17656,7 @@
   {
     "name": "Tumbling Lumber",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17680,7 +17680,7 @@
   {
     "name": "Whirling Grindstone",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17710,7 +17710,7 @@
   {
     "name": "Winter Sleet",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17738,7 +17738,7 @@
   {
     "name": "Ash Strider",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17770,7 +17770,7 @@
   {
     "name": "Clear as Air",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17798,7 +17798,7 @@
   {
     "name": "Consume Power",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17822,7 +17822,7 @@
   {
     "name": "Counter Element",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17842,7 +17842,7 @@
   {
     "name": "Crawling Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17868,7 +17868,7 @@
   {
     "name": "Dash of Herbs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17898,7 +17898,7 @@
   {
     "name": "Desert Wind",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17928,7 +17928,7 @@
   {
     "name": "Driving Rain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17954,7 +17954,7 @@
   {
     "name": "Elemental Artillery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17984,7 +17984,7 @@
   {
     "name": "Fearsome Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18006,7 +18006,7 @@
   {
     "name": "Flinging Updraft",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18030,7 +18030,7 @@
   {
     "name": "Jagged Berms",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18060,7 +18060,7 @@
   {
     "name": "Lightning Rod",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18088,7 +18088,7 @@
   {
     "name": "Molten Wire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18118,7 +18118,7 @@
   {
     "name": "Rising Hurricane",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18148,7 +18148,7 @@
   {
     "name": "Roiling Mudslide",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18176,7 +18176,7 @@
   {
     "name": "Sand Snatcher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18200,7 +18200,7 @@
   {
     "name": "Scrap Barricade",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18228,7 +18228,7 @@
   {
     "name": "Steam Knight",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18258,7 +18258,7 @@
   {
     "name": "Torrent in the Blood",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18290,7 +18290,7 @@
   {
     "name": "Tree of Duality",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18318,7 +18318,7 @@
   {
     "name": "Two-Element Infusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18338,7 +18338,7 @@
   {
     "name": "Volcanic Escape",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18364,7 +18364,7 @@
   {
     "name": "Weight of Stone",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18390,7 +18390,7 @@
   {
     "name": "Wooden Palisade",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18418,7 +18418,7 @@
   {
     "name": "Call the Hurricane",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18444,7 +18444,7 @@
   {
     "name": "Conductive Sphere",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18472,7 +18472,7 @@
   {
     "name": "Cyclonic Ascent",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18496,7 +18496,7 @@
   {
     "name": "Drifting Pollen",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18524,7 +18524,7 @@
   {
     "name": "Elemental Overlap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18542,7 +18542,7 @@
   {
     "name": "Impenetrable Fog",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18570,7 +18570,7 @@
   {
     "name": "Kindle Inner Flames",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18596,7 +18596,7 @@
   {
     "name": "Purify Element",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18618,7 +18618,7 @@
   {
     "name": "Retch Rust",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18644,7 +18644,7 @@
   {
     "name": "Sanguivolent Roots",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18672,7 +18672,7 @@
   {
     "name": "Solar Detonation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18702,7 +18702,7 @@
   {
     "name": "Spike Skin",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18726,7 +18726,7 @@
   {
     "name": "Storm Spiral",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18756,7 +18756,7 @@
   {
     "name": "Swim Through Earth",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18780,7 +18780,7 @@
   {
     "name": "Maelstrom Flow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18798,7 +18798,7 @@
   {
     "name": "Unsheathing the Sword-Light",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18820,7 +18820,7 @@
   {
     "name": "Vermillion Threads",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18840,7 +18840,7 @@
   {
     "name": "Convergent Tides",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18860,7 +18860,7 @@
   {
     "name": "Distant Waterbird's Poise",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18880,7 +18880,7 @@
   {
     "name": "Heaven-Earth Encompassing Sleeves",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18902,7 +18902,7 @@
   {
     "name": "Shattering Spellstrike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18922,7 +18922,7 @@
   {
     "name": "Surface Tension",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18942,7 +18942,7 @@
   {
     "name": "Crosscurrent Counter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18962,7 +18962,7 @@
   {
     "name": "Whirlpool's Pull",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18982,7 +18982,7 @@
   {
     "name": "Crane Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19001,7 +19001,7 @@
   {
     "name": "Dragon Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19020,7 +19020,7 @@
   {
     "name": "Flood Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19041,7 +19041,7 @@
   {
     "name": "Monastic Archer Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19060,7 +19060,7 @@
   {
     "name": "Monastic Weaponry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19077,7 +19077,7 @@
   {
     "name": "Mountain Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19096,7 +19096,7 @@
   {
     "name": "Qi Spells",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19113,7 +19113,7 @@
   {
     "name": "Reflective Ripple Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19134,7 +19134,7 @@
   {
     "name": "Rushing Goat Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19153,7 +19153,7 @@
   {
     "name": "Stumbling Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19173,7 +19173,7 @@
   {
     "name": "Tiger Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19192,7 +19192,7 @@
   {
     "name": "Twisting Petal Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19212,7 +19212,7 @@
   {
     "name": "Wolf Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19231,7 +19231,7 @@
   {
     "name": "Cobra Envenom",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19251,7 +19251,7 @@
   {
     "name": "Knockback Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19271,7 +19271,7 @@
   {
     "name": "Lessons of Flux",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19291,7 +19291,7 @@
   {
     "name": "Prevailing Position",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19309,7 +19309,7 @@
   {
     "name": "Sleeper Hold",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19329,7 +19329,7 @@
   {
     "name": "Wave Dashes Rocks",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19349,7 +19349,7 @@
   {
     "name": "Wind Jump",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19367,7 +19367,7 @@
   {
     "name": "Winding Flow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19385,7 +19385,7 @@
   {
     "name": "Disrupt Qi",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19405,7 +19405,7 @@
   {
     "name": "Dodging Roll",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19423,7 +19423,7 @@
   {
     "name": "Five-Gods Ram",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19441,7 +19441,7 @@
   {
     "name": "Focused Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19461,7 +19461,7 @@
   {
     "name": "Improved Knockback",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19479,7 +19479,7 @@
   {
     "name": "Meditative Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19497,7 +19497,7 @@
   {
     "name": "Overwhelming Breath",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19519,7 +19519,7 @@
   {
     "name": "Reflexive Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19537,7 +19537,7 @@
   {
     "name": "Wave Spiral",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19561,7 +19561,7 @@
   {
     "name": "Whirling in the Summer Storm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19579,7 +19579,7 @@
   {
     "name": "Ironblood Surge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19597,7 +19597,7 @@
   {
     "name": "Mountain Quake",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19615,7 +19615,7 @@
   {
     "name": "Peerless Form",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19633,7 +19633,7 @@
   {
     "name": "Shadow's Web",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19651,7 +19651,7 @@
   {
     "name": "Tangled Forest Rake",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19669,7 +19669,7 @@
   {
     "name": "Whirling Blade Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19689,7 +19689,7 @@
   {
     "name": "Wild Winds Gust",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19713,7 +19713,7 @@
   {
     "name": "World-Breaking Footfall",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19731,7 +19731,7 @@
   {
     "name": "Fuse Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19749,7 +19749,7 @@
   {
     "name": "Master Qi Spells",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19767,7 +19767,7 @@
   {
     "name": "One-Millimeter Punch",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19785,7 +19785,7 @@
   {
     "name": "Shattering Strike (Monk)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19803,7 +19803,7 @@
   {
     "name": "Diamond Fists",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19821,7 +19821,7 @@
   {
     "name": "Grandmaster Qi Spells",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19839,7 +19839,7 @@
   {
     "name": "Qi Center",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19857,7 +19857,7 @@
   {
     "name": "Swift River",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19875,7 +19875,7 @@
   {
     "name": "Triangle Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19897,7 +19897,7 @@
   {
     "name": "Crushing Grab",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19915,7 +19915,7 @@
   {
     "name": "Dancing Leaf",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19933,7 +19933,7 @@
   {
     "name": "Elemental Fist",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19951,7 +19951,7 @@
   {
     "name": "Shooting Stars Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19971,7 +19971,7 @@
   {
     "name": "Student of Water",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19991,7 +19991,7 @@
   {
     "name": "Stunning Blows",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20009,7 +20009,7 @@
   {
     "name": "Waterfowl Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20031,7 +20031,7 @@
   {
     "name": "Enduring Quickness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20049,7 +20049,7 @@
   {
     "name": "Godbreaker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20067,7 +20067,7 @@
   {
     "name": "Immortal Techniques",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20085,7 +20085,7 @@
   {
     "name": "Impossible Technique",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20105,7 +20105,7 @@
   {
     "name": "Lightning Qi",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20123,7 +20123,7 @@
   {
     "name": "Wake of Devastation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20141,7 +20141,7 @@
   {
     "name": "Cobra Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20161,7 +20161,7 @@
   {
     "name": "Deflect Projectile",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20179,7 +20179,7 @@
   {
     "name": "Divert Streamflow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20197,7 +20197,7 @@
   {
     "name": "Flurry of Maneuvers",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20215,7 +20215,7 @@
   {
     "name": "Flying Kick",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20233,7 +20233,7 @@
   {
     "name": "Guarded Movement",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20251,7 +20251,7 @@
   {
     "name": "Harmonize Self",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20269,7 +20269,7 @@
   {
     "name": "Stand Still",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20287,7 +20287,7 @@
   {
     "name": "Tributary Circulation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20311,7 +20311,7 @@
   {
     "name": "Advanced Monastic Weaponry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20329,7 +20329,7 @@
   {
     "name": "Advanced Qi Spells",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20347,7 +20347,7 @@
   {
     "name": "Align Qi",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20365,7 +20365,7 @@
   {
     "name": "Crane Flutter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20383,7 +20383,7 @@
   {
     "name": "Culvert's Collapse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20403,7 +20403,7 @@
   {
     "name": "Dragon Roar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20429,7 +20429,7 @@
   {
     "name": "Momentous Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20447,7 +20447,7 @@
   {
     "name": "Mountain Stronghold",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20465,7 +20465,7 @@
   {
     "name": "One-Inch Punch",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20483,7 +20483,7 @@
   {
     "name": "Return Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20501,7 +20501,7 @@
   {
     "name": "Stumbling Feint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20519,7 +20519,7 @@
   {
     "name": "Tiger Slash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20537,7 +20537,7 @@
   {
     "name": "Water Step",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20555,7 +20555,7 @@
   {
     "name": "Whirling Throw",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20575,7 +20575,7 @@
   {
     "name": "Wolf Drag",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20593,7 +20593,7 @@
   {
     "name": "Clinging Shadows Initiate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20611,7 +20611,7 @@
   {
     "name": "Ironblood Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20631,7 +20631,7 @@
   {
     "name": "Kaiju Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20653,7 +20653,7 @@
   {
     "name": "Mixed Maneuver",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20671,7 +20671,7 @@
   {
     "name": "Pinning Fire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20689,7 +20689,7 @@
   {
     "name": "Projectile Snatching",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20707,7 +20707,7 @@
   {
     "name": "Rippling Spin",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20731,7 +20731,7 @@
   {
     "name": "Scattering in Spring",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20749,7 +20749,7 @@
   {
     "name": "Snakebird's Shadow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20773,7 +20773,7 @@
   {
     "name": "Tangled Forest Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20793,7 +20793,7 @@
   {
     "name": "Wake to Strife",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20815,7 +20815,7 @@
   {
     "name": "Wall Run",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20833,7 +20833,7 @@
   {
     "name": "Wild Winds Initiate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20851,7 +20851,7 @@
   {
     "name": "Foretell Harm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20872,7 +20872,7 @@
   {
     "name": "Glean Lore",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20893,7 +20893,7 @@
   {
     "name": "Nudge the Scales",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20918,7 +20918,7 @@
   {
     "name": "Oracular Warning",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20945,7 +20945,7 @@
   {
     "name": "Trance of Celerity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20966,7 +20966,7 @@
   {
     "name": "Whispers of Weakness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20987,7 +20987,7 @@
   {
     "name": "On Borrowed Time",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21009,7 +21009,7 @@
   {
     "name": "Roll the Bones of Fate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21033,7 +21033,7 @@
   {
     "name": "The Dead Walk",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21055,7 +21055,7 @@
   {
     "name": "Trial by Skyfire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21079,7 +21079,7 @@
   {
     "name": "Waters of Creation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21107,7 +21107,7 @@
   {
     "name": "Domain Fluency",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21125,7 +21125,7 @@
   {
     "name": "Epiphany at the Crossroads",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21145,7 +21145,7 @@
   {
     "name": "Greater Revelation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21163,7 +21163,7 @@
   {
     "name": "Forestall Curse",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21183,7 +21183,7 @@
   {
     "name": "Lighter than Air",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21203,7 +21203,7 @@
   {
     "name": "Mysterious Repertoire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21221,7 +21221,7 @@
   {
     "name": "Revelation's Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21239,7 +21239,7 @@
   {
     "name": "Conduit of Void and Vitality",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21261,7 +21261,7 @@
   {
     "name": "Diverse Mystery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21279,7 +21279,7 @@
   {
     "name": "Portentous Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21305,7 +21305,7 @@
   {
     "name": "Blaze of Revelation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21323,7 +21323,7 @@
   {
     "name": "Divine Effusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21341,7 +21341,7 @@
   {
     "name": "Divine Aegis",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21361,7 +21361,7 @@
   {
     "name": "Domain Acumen",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21379,7 +21379,7 @@
   {
     "name": "Meddling Futures",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21401,7 +21401,7 @@
   {
     "name": "Mystery Conduit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21423,7 +21423,7 @@
   {
     "name": "Oracular Providence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21441,7 +21441,7 @@
   {
     "name": "Paradoxical Mystery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21459,7 +21459,7 @@
   {
     "name": "Knowledge of Shapes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21481,7 +21481,7 @@
   {
     "name": "Thousand Visions",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21503,7 +21503,7 @@
   {
     "name": "Advanced Revelation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21521,7 +21521,7 @@
   {
     "name": "Gifted Power",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21539,7 +21539,7 @@
   {
     "name": "Spiritual Sense",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21559,7 +21559,7 @@
   {
     "name": "Debilitating Dichotomy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21585,7 +21585,7 @@
   {
     "name": "Read Disaster",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21607,7 +21607,7 @@
   {
     "name": "Surging Might",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21629,7 +21629,7 @@
   {
     "name": "Water Walker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21647,7 +21647,7 @@
   {
     "name": "Ancestral Mind",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21664,7 +21664,7 @@
   {
     "name": "Counter Thought",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21683,7 +21683,7 @@
   {
     "name": "Mental Buffer",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21700,7 +21700,7 @@
   {
     "name": "Psychic Rapport",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21717,7 +21717,7 @@
   {
     "name": "Dream Guise",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21741,7 +21741,7 @@
   {
     "name": "Emotional Surge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21765,7 +21765,7 @@
   {
     "name": "Impose Order (Psychic)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21787,7 +21787,7 @@
   {
     "name": "Scour the Library",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21807,7 +21807,7 @@
   {
     "name": "Signature Spell Expansion (Psychic)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21825,7 +21825,7 @@
   {
     "name": "Amp Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21843,7 +21843,7 @@
   {
     "name": "Foreseen Failure",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21865,7 +21865,7 @@
   {
     "name": "No!!!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21883,7 +21883,7 @@
   {
     "name": "Psi Catastrophe",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21909,7 +21909,7 @@
   {
     "name": "Conscious Spell Specialization",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21927,7 +21927,7 @@
   {
     "name": "Deep Roots",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21945,7 +21945,7 @@
   {
     "name": "Constant Levitation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21963,7 +21963,7 @@
   {
     "name": "Target of Psychic Ire",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21985,7 +21985,7 @@
   {
     "name": "Wandering Thoughts",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22011,7 +22011,7 @@
   {
     "name": "All in Your Head",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22031,7 +22031,7 @@
   {
     "name": "Cranial Detonation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22055,7 +22055,7 @@
   {
     "name": "Twin Psyche",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22073,7 +22073,7 @@
   {
     "name": "Mental Balm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22097,7 +22097,7 @@
   {
     "name": "Psi Burst",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22123,7 +22123,7 @@
   {
     "name": "Warp Space",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22143,7 +22143,7 @@
   {
     "name": "Autonomic Psychic Action",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22161,7 +22161,7 @@
   {
     "name": "Become Thought",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22179,7 +22179,7 @@
   {
     "name": "Mind Over Matter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22197,7 +22197,7 @@
   {
     "name": "Unlimited Potential",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22221,7 +22221,7 @@
   {
     "name": "Astral Tether",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22241,7 +22241,7 @@
   {
     "name": "Homing Beacon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22261,7 +22261,7 @@
   {
     "name": "Psi Strikes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22281,7 +22281,7 @@
   {
     "name": "Thoughtform Summoning",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22299,7 +22299,7 @@
   {
     "name": "Violent Unleash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22321,7 +22321,7 @@
   {
     "name": "Inertial Barrier",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22343,7 +22343,7 @@
   {
     "name": "Parallel Breakthrough",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22361,7 +22361,7 @@
   {
     "name": "Sixth Sense",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22381,7 +22381,7 @@
   {
     "name": "Strain Mind",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22399,7 +22399,7 @@
   {
     "name": "Brain Drain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22421,7 +22421,7 @@
   {
     "name": "Dark Persona's Presence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22447,7 +22447,7 @@
   {
     "name": "Mental Static",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22471,7 +22471,7 @@
   {
     "name": "Remove Presence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22497,7 +22497,7 @@
   {
     "name": "Thoughtsense",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22519,7 +22519,7 @@
   {
     "name": "Whispering Steps",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22543,7 +22543,7 @@
   {
     "name": "Animal Companion (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22560,7 +22560,7 @@
   {
     "name": "Crossbow Ace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22577,7 +22577,7 @@
   {
     "name": "Hunted Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22596,7 +22596,7 @@
   {
     "name": "Initiate Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22613,7 +22613,7 @@
   {
     "name": "Monster Hunter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22630,7 +22630,7 @@
   {
     "name": "Twin Takedown",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22649,7 +22649,7 @@
   {
     "name": "Camouflage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22667,7 +22667,7 @@
   {
     "name": "Incredible Companion (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22685,7 +22685,7 @@
   {
     "name": "Master Monster Hunter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22703,7 +22703,7 @@
   {
     "name": "Peerless Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22721,7 +22721,7 @@
   {
     "name": "Penetrating Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22739,7 +22739,7 @@
   {
     "name": "Warden's Step",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22757,7 +22757,7 @@
   {
     "name": "Distracting Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22775,7 +22775,7 @@
   {
     "name": "Double Prey",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22793,7 +22793,7 @@
   {
     "name": "Obscured Emergence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22811,7 +22811,7 @@
   {
     "name": "Second Sting",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22831,7 +22831,7 @@
   {
     "name": "Side by Side (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22849,7 +22849,7 @@
   {
     "name": "Warden's Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22867,7 +22867,7 @@
   {
     "name": "Shared Prey",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22885,7 +22885,7 @@
   {
     "name": "Stealthy Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22903,7 +22903,7 @@
   {
     "name": "Warden's Guidance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22921,7 +22921,7 @@
   {
     "name": "Greater Distracting Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22939,7 +22939,7 @@
   {
     "name": "Improved Twin Riposte (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22957,7 +22957,7 @@
   {
     "name": "Legendary Monster Hunter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22975,7 +22975,7 @@
   {
     "name": "Specialized Companion (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22993,7 +22993,7 @@
   {
     "name": "Warden's Reload",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23011,7 +23011,7 @@
   {
     "name": "Impossible Flurry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23031,7 +23031,7 @@
   {
     "name": "Manifold Edge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23049,7 +23049,7 @@
   {
     "name": "Masterful Companion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23067,7 +23067,7 @@
   {
     "name": "Perfect Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23087,7 +23087,7 @@
   {
     "name": "Shadow Hunter",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23105,7 +23105,7 @@
   {
     "name": "Animal Empathy (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23123,7 +23123,7 @@
   {
     "name": "Favored Terrain",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23141,7 +23141,7 @@
   {
     "name": "Hunter's Aim",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23161,7 +23161,7 @@
   {
     "name": "Monster Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23179,7 +23179,7 @@
   {
     "name": "Legendary Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23197,7 +23197,7 @@
   {
     "name": "To the Ends of the Earth",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23215,7 +23215,7 @@
   {
     "name": "Triple Threat",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23233,7 +23233,7 @@
   {
     "name": "Ultimate Skirmisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23251,7 +23251,7 @@
   {
     "name": "Advanced Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23269,7 +23269,7 @@
   {
     "name": "Companion's Cry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23287,7 +23287,7 @@
   {
     "name": "Disrupt Prey",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23305,7 +23305,7 @@
   {
     "name": "Far Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23323,7 +23323,7 @@
   {
     "name": "Favored Prey",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23341,7 +23341,7 @@
   {
     "name": "Natural Conduit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23363,7 +23363,7 @@
   {
     "name": "Wolf in Sheep's Clothing",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23381,7 +23381,7 @@
   {
     "name": "Additional Recollection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23399,7 +23399,7 @@
   {
     "name": "Animal Strength",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23417,7 +23417,7 @@
   {
     "name": "Masterful Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23435,7 +23435,7 @@
   {
     "name": "Mature Animal Companion (Ranger)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23453,7 +23453,7 @@
   {
     "name": "Nature Prowler",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23471,7 +23471,7 @@
   {
     "name": "Snap Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23489,7 +23489,7 @@
   {
     "name": "Swift Tracker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23507,7 +23507,7 @@
   {
     "name": "Deadly Aim",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23527,7 +23527,7 @@
   {
     "name": "Hazard Finder",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23545,7 +23545,7 @@
   {
     "name": "Terrain Master",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23563,7 +23563,7 @@
   {
     "name": "Warden's Boon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23581,7 +23581,7 @@
   {
     "name": "Nimble Dodge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23598,7 +23598,7 @@
   {
     "name": "Overextending Feint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23616,7 +23616,7 @@
   {
     "name": "Plant Evidence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23634,7 +23634,7 @@
   {
     "name": "Tumble Behind (Rogue)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23651,7 +23651,7 @@
   {
     "name": "Twin Feint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23668,7 +23668,7 @@
   {
     "name": "Methodical Debilitations",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23686,7 +23686,7 @@
   {
     "name": "Nimble Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23704,7 +23704,7 @@
   {
     "name": "Precise Debilitations",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23722,7 +23722,7 @@
   {
     "name": "Sneak Adept",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23740,7 +23740,7 @@
   {
     "name": "Tactical Debilitations",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23758,7 +23758,7 @@
   {
     "name": "Vicious Debilitations",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23776,7 +23776,7 @@
   {
     "name": "Bloody Debilitation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23794,7 +23794,7 @@
   {
     "name": "Critical Debilitation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23814,7 +23814,7 @@
   {
     "name": "Fantastic Leap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23832,7 +23832,7 @@
   {
     "name": "Felling Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23850,7 +23850,7 @@
   {
     "name": "Preparation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23870,7 +23870,7 @@
   {
     "name": "Ricochet Feint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23888,7 +23888,7 @@
   {
     "name": "Spring from the Shadows",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23908,7 +23908,7 @@
   {
     "name": "Defensive Roll",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23926,7 +23926,7 @@
   {
     "name": "Instant Opening",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23946,7 +23946,7 @@
   {
     "name": "Leave an Opening",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23964,7 +23964,7 @@
   {
     "name": "Stay Down!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23982,7 +23982,7 @@
   {
     "name": "Blank Slate",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24000,7 +24000,7 @@
   {
     "name": "Cloud Step",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24018,7 +24018,7 @@
   {
     "name": "Cognitive Loophole",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24036,7 +24036,7 @@
   {
     "name": "Dispelling Slice",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24054,7 +24054,7 @@
   {
     "name": "Perfect Distraction",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24072,7 +24072,7 @@
   {
     "name": "Swift Elusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24090,7 +24090,7 @@
   {
     "name": "Implausible Infiltration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24112,7 +24112,7 @@
   {
     "name": "Implausible Purchase (Rogue)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24130,7 +24130,7 @@
   {
     "name": "Powerful Sneak",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24148,7 +24148,7 @@
   {
     "name": "Brutal Beating",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24172,7 +24172,7 @@
   {
     "name": "Clever Gambit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24190,7 +24190,7 @@
   {
     "name": "Distracting Feint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24208,7 +24208,7 @@
   {
     "name": "Mobility",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24226,7 +24226,7 @@
   {
     "name": "Strong Arm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24244,7 +24244,7 @@
   {
     "name": "Unbalancing Blow",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24262,7 +24262,7 @@
   {
     "name": "Underhanded Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24280,7 +24280,7 @@
   {
     "name": "Hidden Paragon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24298,7 +24298,7 @@
   {
     "name": "Impossible Striker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24316,7 +24316,7 @@
   {
     "name": "Reactive Distraction",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24338,7 +24338,7 @@
   {
     "name": "Dread Striker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24356,7 +24356,7 @@
   {
     "name": "Head Stomp",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24374,7 +24374,7 @@
   {
     "name": "Mug",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24392,7 +24392,7 @@
   {
     "name": "Poison Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24412,7 +24412,7 @@
   {
     "name": "Predictable!",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24430,7 +24430,7 @@
   {
     "name": "Reactive Pursuit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24448,7 +24448,7 @@
   {
     "name": "Sabotage",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24468,7 +24468,7 @@
   {
     "name": "Scoundrel's Surprise",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24486,7 +24486,7 @@
   {
     "name": "The Harder They Fall",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24504,7 +24504,7 @@
   {
     "name": "Twin Distraction",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24522,7 +24522,7 @@
   {
     "name": "Analyze Weakness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24540,7 +24540,7 @@
   {
     "name": "Anticipate Ambush",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24560,7 +24560,7 @@
   {
     "name": "Far Throw",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24578,7 +24578,7 @@
   {
     "name": "Gang Up",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24596,7 +24596,7 @@
   {
     "name": "Light Step",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24614,7 +24614,7 @@
   {
     "name": "Shove Down",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24632,7 +24632,7 @@
   {
     "name": "Sly Disarm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24650,7 +24650,7 @@
   {
     "name": "Twist the Knife",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24668,7 +24668,7 @@
   {
     "name": "Watch Your Back",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24692,7 +24692,7 @@
   {
     "name": "Bullseye",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24710,7 +24710,7 @@
   {
     "name": "Delay Trap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24728,7 +24728,7 @@
   {
     "name": "Improved Poison Weapon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24746,7 +24746,7 @@
   {
     "name": "Inspired Stratagem",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24764,7 +24764,7 @@
   {
     "name": "Nimble Roll",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24782,7 +24782,7 @@
   {
     "name": "Opportune Backstab",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24800,7 +24800,7 @@
   {
     "name": "Predictive Purchase (Rogue)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24818,7 +24818,7 @@
   {
     "name": "Ricochet Stance (Rogue)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24838,7 +24838,7 @@
   {
     "name": "Sidestep",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24856,7 +24856,7 @@
   {
     "name": "Sly Striker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24874,7 +24874,7 @@
   {
     "name": "Swipe Souvenir",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24892,7 +24892,7 @@
   {
     "name": "Tactical Entry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24910,7 +24910,7 @@
   {
     "name": "Combat Assessment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24929,7 +24929,7 @@
   {
     "name": "Counterspell (Prepared)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24948,7 +24948,7 @@
   {
     "name": "Defensive Advance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24969,7 +24969,7 @@
   {
     "name": "Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24992,7 +24992,7 @@
   {
     "name": "Reach Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25025,7 +25025,7 @@
   {
     "name": "Reactive Shield",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25044,7 +25044,7 @@
   {
     "name": "Splinter Faith",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25063,7 +25063,7 @@
   {
     "name": "Sudden Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25084,7 +25084,7 @@
   {
     "name": "Trap Finder",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25103,7 +25103,7 @@
   {
     "name": "Widen Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25132,7 +25132,7 @@
   {
     "name": "You're Next",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25158,7 +25158,7 @@
   {
     "name": "Eerie Proclamation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25190,7 +25190,7 @@
   {
     "name": "Haft Beatdown",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25212,7 +25212,7 @@
   {
     "name": "Overpowering Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25232,7 +25232,7 @@
   {
     "name": "Overwhelming Energy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25258,7 +25258,7 @@
   {
     "name": "Quickened Casting",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25288,7 +25288,7 @@
   {
     "name": "Twin Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25308,7 +25308,7 @@
   {
     "name": "Magic Sense",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25332,7 +25332,7 @@
   {
     "name": "Paragon's Guard",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25354,7 +25354,7 @@
   {
     "name": "Reactive Interference",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25374,7 +25374,7 @@
   {
     "name": "Opening Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25394,7 +25394,7 @@
   {
     "name": "Reflect Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25416,7 +25416,7 @@
   {
     "name": "Sacral Monarch",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25436,7 +25436,7 @@
   {
     "name": "Sense the Unseen",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25458,7 +25458,7 @@
   {
     "name": "Towering Transformation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25488,7 +25488,7 @@
   {
     "name": "Whirlwind Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25510,7 +25510,7 @@
   {
     "name": "Effortless Concentration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25538,7 +25538,7 @@
   {
     "name": "Improved Reflexive Shield",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25558,7 +25558,7 @@
   {
     "name": "Master of Many Styles",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25578,7 +25578,7 @@
   {
     "name": "Reconstruct the Scene",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25600,7 +25600,7 @@
   {
     "name": "Scintillating Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25626,7 +25626,7 @@
   {
     "name": "Echoing Channel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25650,7 +25650,7 @@
   {
     "name": "Impossible Volley",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25672,7 +25672,7 @@
   {
     "name": "Trickster's Ace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25694,7 +25694,7 @@
   {
     "name": "Aggressive Block",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25714,7 +25714,7 @@
   {
     "name": "Cantrip Expansion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25746,7 +25746,7 @@
   {
     "name": "Conceal Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25772,7 +25772,7 @@
   {
     "name": "Enhanced Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25802,7 +25802,7 @@
   {
     "name": "Intimidating Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25828,7 +25828,7 @@
   {
     "name": "Lightning Swap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25850,7 +25850,7 @@
   {
     "name": "Poison Resistance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25870,7 +25870,7 @@
   {
     "name": "Quick Draw",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25892,7 +25892,7 @@
   {
     "name": "Boundless Reprisals",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25912,7 +25912,7 @@
   {
     "name": "Spellshape Mastery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25932,7 +25932,7 @@
   {
     "name": "Barreling Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25954,7 +25954,7 @@
   {
     "name": "Bespell Strikes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25976,7 +25976,7 @@
   {
     "name": "Brutal Crush",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25998,7 +25998,7 @@
   {
     "name": "Creature Comforts",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26018,7 +26018,7 @@
   {
     "name": "Haft Striker Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26042,7 +26042,7 @@
   {
     "name": "Rip and Tear",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26062,7 +26062,7 @@
   {
     "name": "Running Reload",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26082,7 +26082,7 @@
   {
     "name": "Sacral Lord",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26102,7 +26102,7 @@
   {
     "name": "Scout's Warning",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26122,7 +26122,7 @@
   {
     "name": "Swipe",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26144,7 +26144,7 @@
   {
     "name": "Twin Parry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26164,7 +26164,7 @@
   {
     "name": "Intensified Element Stance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26186,7 +26186,7 @@
   {
     "name": "Reactive Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26216,7 +26216,7 @@
   {
     "name": "Reflexive Shield",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26236,7 +26236,7 @@
   {
     "name": "Shield Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26258,7 +26258,7 @@
   {
     "name": "Skirmish Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26280,7 +26280,7 @@
   {
     "name": "Steady Spellcasting",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26312,7 +26312,7 @@
   {
     "name": "Blind-Fight",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26336,7 +26336,7 @@
   {
     "name": "Can't You See?",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26356,7 +26356,7 @@
   {
     "name": "Eerie Environs",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26376,7 +26376,7 @@
   {
     "name": "Eerie Traces",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26402,7 +26402,7 @@
   {
     "name": "Incredible Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26422,7 +26422,7 @@
   {
     "name": "Know-It-All",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26442,7 +26442,7 @@
   {
     "name": "Quick Shield Block",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26462,7 +26462,7 @@
   {
     "name": "Sudden Leap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26482,7 +26482,7 @@
   {
     "name": "Blood Rising",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26499,7 +26499,7 @@
   {
     "name": "Tap into Blood",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26518,7 +26518,7 @@
   {
     "name": "Energy Fusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26540,7 +26540,7 @@
   {
     "name": "Greater Bloodline",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26558,7 +26558,7 @@
   {
     "name": "Signature Spell Expansion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26576,7 +26576,7 @@
   {
     "name": "Blood Sovereignty",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26594,7 +26594,7 @@
   {
     "name": "Bloodline Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26612,7 +26612,7 @@
   {
     "name": "Greater Physical Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26630,7 +26630,7 @@
   {
     "name": "Greater Spiritual Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26648,7 +26648,7 @@
   {
     "name": "Terraforming Trickery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26670,7 +26670,7 @@
   {
     "name": "Blood Ascendancy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26688,7 +26688,7 @@
   {
     "name": "Interweave Dispel",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26708,7 +26708,7 @@
   {
     "name": "Reflect Harm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26726,7 +26726,7 @@
   {
     "name": "Spell Shroud",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26748,7 +26748,7 @@
   {
     "name": "Greater Mental Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26766,7 +26766,7 @@
   {
     "name": "Greater Vital Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26784,7 +26784,7 @@
   {
     "name": "Echoing Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26806,7 +26806,7 @@
   {
     "name": "Greater Crossblooded Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26824,7 +26824,7 @@
   {
     "name": "Anoint Ally",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26844,7 +26844,7 @@
   {
     "name": "Bleed Out",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26864,7 +26864,7 @@
   {
     "name": "Propelling Sorcery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26882,7 +26882,7 @@
   {
     "name": "Bloodline Conduit",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26902,7 +26902,7 @@
   {
     "name": "Bloodline Mutation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26920,7 +26920,7 @@
   {
     "name": "Bloodline Perfection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26938,7 +26938,7 @@
   {
     "name": "Arcane Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26958,7 +26958,7 @@
   {
     "name": "Divine Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26978,7 +26978,7 @@
   {
     "name": "Occult Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26998,7 +26998,7 @@
   {
     "name": "Primal Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27018,7 +27018,7 @@
   {
     "name": "Split Shot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27040,7 +27040,7 @@
   {
     "name": "Advanced Bloodline",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27058,7 +27058,7 @@
   {
     "name": "Diverting Vortex",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27076,7 +27076,7 @@
   {
     "name": "Energy Ward",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27094,7 +27094,7 @@
   {
     "name": "Safeguard Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27116,7 +27116,7 @@
   {
     "name": "Spell Relay",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27136,7 +27136,7 @@
   {
     "name": "Bloodline Resistance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27154,7 +27154,7 @@
   {
     "name": "Crossblooded Evolution",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27172,7 +27172,7 @@
   {
     "name": "Explosion of Power",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27190,7 +27190,7 @@
   {
     "name": "Protective Pose",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27210,7 +27210,7 @@
   {
     "name": "Disarming Flair",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27227,7 +27227,7 @@
   {
     "name": "Elegant Buckler",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27244,7 +27244,7 @@
   {
     "name": "Extravagant Parry",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27261,7 +27261,7 @@
   {
     "name": "Flashy Dodge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27278,7 +27278,7 @@
   {
     "name": "Flying Blade",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27296,7 +27296,7 @@
   {
     "name": "Focused Fascination",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27314,7 +27314,7 @@
   {
     "name": "Goading Feint",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27332,7 +27332,7 @@
   {
     "name": "One for All",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27360,7 +27360,7 @@
   {
     "name": "Plummeting Roll",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27378,7 +27378,7 @@
   {
     "name": "Buckler Dance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27398,7 +27398,7 @@
   {
     "name": "Derring-Do",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27418,7 +27418,7 @@
   {
     "name": "Reflexive Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27436,7 +27436,7 @@
   {
     "name": "Stumbling Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27456,7 +27456,7 @@
   {
     "name": "Switcheroo",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27474,7 +27474,7 @@
   {
     "name": "Targeting Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27494,7 +27494,7 @@
   {
     "name": "Cheat Death",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27512,7 +27512,7 @@
   {
     "name": "Get Used to Disappointment",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27532,7 +27532,7 @@
   {
     "name": "Mobile Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27552,7 +27552,7 @@
   {
     "name": "The Bigger They Are",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27572,7 +27572,7 @@
   {
     "name": "Flamboyant Leap",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27590,7 +27590,7 @@
   {
     "name": "Impossible Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27608,7 +27608,7 @@
   {
     "name": "Perfect Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27630,7 +27630,7 @@
   {
     "name": "Deadly Grace",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27648,7 +27648,7 @@
   {
     "name": "Felicitous Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27668,7 +27668,7 @@
   {
     "name": "Revitalizing Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27688,7 +27688,7 @@
   {
     "name": "Incredible Luck (Swashbuckler)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27708,7 +27708,7 @@
   {
     "name": "Lethal Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27730,7 +27730,7 @@
   {
     "name": "Parry and Riposte",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27748,7 +27748,7 @@
   {
     "name": "After You",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27766,7 +27766,7 @@
   {
     "name": "Antagonize",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27784,7 +27784,7 @@
   {
     "name": "Brandishing Draw",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27802,7 +27802,7 @@
   {
     "name": "Charmed Life",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27820,7 +27820,7 @@
   {
     "name": "Enjoy the Show",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27838,7 +27838,7 @@
   {
     "name": "Finishing Follow-Through",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27856,7 +27856,7 @@
   {
     "name": "Retreating Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27876,7 +27876,7 @@
   {
     "name": "Tumble Behind (Swashbuckler)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27894,7 +27894,7 @@
   {
     "name": "Unbalancing Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27914,7 +27914,7 @@
   {
     "name": "Illimitable Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27936,7 +27936,7 @@
   {
     "name": "Inexhaustible Countermoves",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27954,7 +27954,7 @@
   {
     "name": "Panache Paragon",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27972,7 +27972,7 @@
   {
     "name": "Dastardly Dash",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27992,7 +27992,7 @@
   {
     "name": "Even the Odds",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28010,7 +28010,7 @@
   {
     "name": "Flamboyant Athlete",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28028,7 +28028,7 @@
   {
     "name": "Guardian's Deflection (Swashbuckler)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28046,7 +28046,7 @@
   {
     "name": "Impaling Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28066,7 +28066,7 @@
   {
     "name": "Leading Dance",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28088,7 +28088,7 @@
   {
     "name": "Swaggering Initiative",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28106,7 +28106,7 @@
   {
     "name": "Twirling Throw",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28126,7 +28126,7 @@
   {
     "name": "Agile Maneuvers",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28144,7 +28144,7 @@
   {
     "name": "Combination Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28162,7 +28162,7 @@
   {
     "name": "Precise Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28180,7 +28180,7 @@
   {
     "name": "Vexing Tumble",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28200,7 +28200,7 @@
   {
     "name": "Bleeding Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28220,7 +28220,7 @@
   {
     "name": "Distracting Toss",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28242,7 +28242,7 @@
   {
     "name": "Dual Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28262,7 +28262,7 @@
   {
     "name": "Flashy Roll",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28280,7 +28280,7 @@
   {
     "name": "Stunning Finisher",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28300,7 +28300,7 @@
   {
     "name": "Vivacious Bravado",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28318,7 +28318,7 @@
   {
     "name": "Ammunition Thaumaturgy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28335,7 +28335,7 @@
   {
     "name": "Diverse Lore",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28352,7 +28352,7 @@
   {
     "name": "Divine Disharmony",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28375,7 +28375,7 @@
   {
     "name": "Haunt Ingenuity",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28396,7 +28396,7 @@
   {
     "name": "Root to Life",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28419,7 +28419,7 @@
   {
     "name": "Scroll Thaumaturgy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28436,7 +28436,7 @@
   {
     "name": "Share Weakness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28458,7 +28458,7 @@
   {
     "name": "Thaumaturge's Investiture",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28476,7 +28476,7 @@
   {
     "name": "Twin Weakness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28496,7 +28496,7 @@
   {
     "name": "Elaborate Scroll Esoterica",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28514,7 +28514,7 @@
   {
     "name": "Intensify Investiture",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28532,7 +28532,7 @@
   {
     "name": "Shared Warding",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28550,7 +28550,7 @@
   {
     "name": "Thaumaturge's Demesne",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28570,7 +28570,7 @@
   {
     "name": "Esoteric Reflexes",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28588,7 +28588,7 @@
   {
     "name": "Grand Talisman Esoterica",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28606,7 +28606,7 @@
   {
     "name": "Trespass Teleportation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28628,7 +28628,7 @@
   {
     "name": "Implement's Flight",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28648,7 +28648,7 @@
   {
     "name": "Seven-Part Link",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28666,7 +28666,7 @@
   {
     "name": "Sever Magic",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28688,7 +28688,7 @@
   {
     "name": "Grand Scroll Esoterica",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28706,7 +28706,7 @@
   {
     "name": "Implement's Assault",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28726,7 +28726,7 @@
   {
     "name": "Intense Implement",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28744,7 +28744,7 @@
   {
     "name": "Call Implement",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28768,7 +28768,7 @@
   {
     "name": "Esoteric Warden",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28786,7 +28786,7 @@
   {
     "name": "Talisman Esoterica",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28806,7 +28806,7 @@
   {
     "name": "Turn Away Misfortune",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28832,7 +28832,7 @@
   {
     "name": "Ubiquitous Weakness",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28852,7 +28852,7 @@
   {
     "name": "Unlimited Demesne",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28872,7 +28872,7 @@
   {
     "name": "Wonder Worker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28890,7 +28890,7 @@
   {
     "name": "Breached Defenses",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28908,7 +28908,7 @@
   {
     "name": "Paired Link",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28932,7 +28932,7 @@
   {
     "name": "One More Activation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28950,7 +28950,7 @@
   {
     "name": "Scroll Esoterica",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28970,7 +28970,7 @@
   {
     "name": "Sympathetic Vulnerabilities",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28988,7 +28988,7 @@
   {
     "name": "Cursed Effigy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29010,7 +29010,7 @@
   {
     "name": "Elaborate Talisman Esoterica",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29028,7 +29028,7 @@
   {
     "name": "Cackle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29045,7 +29045,7 @@
   {
     "name": "Cauldron",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29062,7 +29062,7 @@
   {
     "name": "Witch's Armaments",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29079,7 +29079,7 @@
   {
     "name": "Double, Double",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29097,7 +29097,7 @@
   {
     "name": "Major Lesson",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29115,7 +29115,7 @@
   {
     "name": "Witch's Communion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29133,7 +29133,7 @@
   {
     "name": "Coven Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29153,7 +29153,7 @@
   {
     "name": "Hex Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29171,7 +29171,7 @@
   {
     "name": "Witch's Broom",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29189,7 +29189,7 @@
   {
     "name": "Patron's Presence",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29207,7 +29207,7 @@
   {
     "name": "Rites of Transfiguration",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29225,7 +29225,7 @@
   {
     "name": "Siphon Power",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29243,7 +29243,7 @@
   {
     "name": "Patron's Claim",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29261,7 +29261,7 @@
   {
     "name": "Split Hex",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29283,7 +29283,7 @@
   {
     "name": "Basic Lesson",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29301,7 +29301,7 @@
   {
     "name": "Familiar's Language",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29319,7 +29319,7 @@
   {
     "name": "Scatter Swarm",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29339,7 +29339,7 @@
   {
     "name": "Hex Master",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29357,7 +29357,7 @@
   {
     "name": "Patron's Truth",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29375,7 +29375,7 @@
   {
     "name": "Witch's Hut",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29393,7 +29393,7 @@
   {
     "name": "Portents of the Haruspex",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29415,7 +29415,7 @@
   {
     "name": "Rites of Convocation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29433,7 +29433,7 @@
   {
     "name": "Sympathetic Strike",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29451,7 +29451,7 @@
   {
     "name": "Ceremonial Knife",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29469,7 +29469,7 @@
   {
     "name": "Greater Lesson",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29487,7 +29487,7 @@
   {
     "name": "Wild Witch's Armaments",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29505,7 +29505,7 @@
   {
     "name": "Witch's Charge",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29525,7 +29525,7 @@
   {
     "name": "Murksight",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29543,7 +29543,7 @@
   {
     "name": "Spirit Familiar (Witch)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29561,7 +29561,7 @@
   {
     "name": "Stitched Familiar",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29579,7 +29579,7 @@
   {
     "name": "Witch's Bottle",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29597,7 +29597,7 @@
   {
     "name": "Spellbook Prodigy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29615,7 +29615,7 @@
   {
     "name": "Scroll Adept",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29633,7 +29633,7 @@
   {
     "name": "Clever Counterspell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29651,7 +29651,7 @@
   {
     "name": "Forcible Energy",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29673,7 +29673,7 @@
   {
     "name": "Keen Magical Detection",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29693,7 +29693,7 @@
   {
     "name": "Bonded Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29711,7 +29711,7 @@
   {
     "name": "Secondary Detonation Array",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29733,7 +29733,7 @@
   {
     "name": "Superior Bond",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29751,7 +29751,7 @@
   {
     "name": "Spell Tinker",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29771,7 +29771,7 @@
   {
     "name": "Infinite Possibilities",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29789,7 +29789,7 @@
   {
     "name": "Reprepare Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29807,7 +29807,7 @@
   {
     "name": "Second Thoughts",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29829,7 +29829,7 @@
   {
     "name": "Energy Ablation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29849,7 +29849,7 @@
   {
     "name": "Nonlethal Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29871,7 +29871,7 @@
   {
     "name": "Archwizard's Might",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29889,7 +29889,7 @@
   {
     "name": "Spell Combination",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29907,7 +29907,7 @@
   {
     "name": "Spell Mastery",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29925,7 +29925,7 @@
   {
     "name": "Call Wizardly Tools",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29947,7 +29947,7 @@
   {
     "name": "Linked Focus",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29965,7 +29965,7 @@
   {
     "name": "Spell Protection Array",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29987,7 +29987,7 @@
   {
     "name": "Convincing Illusion",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30005,7 +30005,7 @@
   {
     "name": "Explosive Arrival",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30029,7 +30029,7 @@
   {
     "name": "Irresistible Magic",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30047,7 +30047,7 @@
   {
     "name": "Split Slot",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30065,7 +30065,7 @@
   {
     "name": "Advanced School Spell",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30083,7 +30083,7 @@
   {
     "name": "Bond Conservation",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30105,7 +30105,7 @@
   {
     "name": "Form Retention",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30123,7 +30123,7 @@
   {
     "name": "Knowledge is Power (Wizard)",
     "rule_type": "Class Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/classes.json
+++ b/db/seeds/pf2e/classes.json
@@ -2,7 +2,7 @@
   {
     "name": "Alchemist",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15,7 +15,7 @@
   {
     "name": "Animist",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28,7 +28,7 @@
   {
     "name": "Barbarian",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41,7 +41,7 @@
   {
     "name": "Bard",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -54,7 +54,7 @@
   {
     "name": "Champion",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -67,7 +67,7 @@
   {
     "name": "Cleric",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -80,7 +80,7 @@
   {
     "name": "Commander",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -93,7 +93,7 @@
   {
     "name": "Druid",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -106,7 +106,7 @@
   {
     "name": "Exemplar",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -119,7 +119,7 @@
   {
     "name": "Fighter",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -132,7 +132,7 @@
   {
     "name": "Guardian",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -145,7 +145,7 @@
   {
     "name": "Gunslinger",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -158,7 +158,7 @@
   {
     "name": "Inventor",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -171,7 +171,7 @@
   {
     "name": "Investigator",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -184,7 +184,7 @@
   {
     "name": "Kineticist",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -197,7 +197,7 @@
   {
     "name": "Monk",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -210,7 +210,7 @@
   {
     "name": "Oracle",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -223,7 +223,7 @@
   {
     "name": "Psychic",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -236,7 +236,7 @@
   {
     "name": "Ranger",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -249,7 +249,7 @@
   {
     "name": "Rogue",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -262,7 +262,7 @@
   {
     "name": "Sorcerer",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -275,7 +275,7 @@
   {
     "name": "Swashbuckler",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -288,7 +288,7 @@
   {
     "name": "Thaumaturge",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -301,7 +301,7 @@
   {
     "name": "Witch",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -314,7 +314,7 @@
   {
     "name": "Wizard",
     "rule_type": "Class",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/conditions.json
+++ b/db/seeds/pf2e/conditions.json
@@ -2,7 +2,7 @@
   {
     "name": "Blinded",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15,7 +15,7 @@
   {
     "name": "Broken",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28,7 +28,7 @@
   {
     "name": "Clumsy",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41,7 +41,7 @@
   {
     "name": "Concealed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -54,7 +54,7 @@
   {
     "name": "Confused",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -67,7 +67,7 @@
   {
     "name": "Controlled",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -80,7 +80,7 @@
   {
     "name": "Cursebound",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -93,7 +93,7 @@
   {
     "name": "Dazzled",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -106,7 +106,7 @@
   {
     "name": "Deafened",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -119,7 +119,7 @@
   {
     "name": "Doomed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -132,7 +132,7 @@
   {
     "name": "Drained",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -145,7 +145,7 @@
   {
     "name": "Dying",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -158,7 +158,7 @@
   {
     "name": "Encumbered",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -171,7 +171,7 @@
   {
     "name": "Enfeebled",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -184,7 +184,7 @@
   {
     "name": "Fascinated",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -197,7 +197,7 @@
   {
     "name": "Fatigued",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -210,7 +210,7 @@
   {
     "name": "Fleeing",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -223,7 +223,7 @@
   {
     "name": "Friendly",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -236,7 +236,7 @@
   {
     "name": "Frightened",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -249,7 +249,7 @@
   {
     "name": "Grabbed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -262,7 +262,7 @@
   {
     "name": "Helpful",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -275,7 +275,7 @@
   {
     "name": "Hidden",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -288,7 +288,7 @@
   {
     "name": "Hostile",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -301,7 +301,7 @@
   {
     "name": "Immobilized",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -314,7 +314,7 @@
   {
     "name": "Indifferent",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -327,7 +327,7 @@
   {
     "name": "Invisible",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -340,7 +340,7 @@
   {
     "name": "Observed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -353,7 +353,7 @@
   {
     "name": "Off-Guard",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -366,7 +366,7 @@
   {
     "name": "Paralyzed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -379,7 +379,7 @@
   {
     "name": "Persistent Damage",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -392,7 +392,7 @@
   {
     "name": "Petrified",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -405,7 +405,7 @@
   {
     "name": "Prone",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -418,7 +418,7 @@
   {
     "name": "Quickened",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -431,7 +431,7 @@
   {
     "name": "Restrained",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -444,7 +444,7 @@
   {
     "name": "Sickened",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -457,7 +457,7 @@
   {
     "name": "Slowed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -470,7 +470,7 @@
   {
     "name": "Stunned",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -483,7 +483,7 @@
   {
     "name": "Stupefied",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -496,7 +496,7 @@
   {
     "name": "Unconscious",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -509,7 +509,7 @@
   {
     "name": "Undetected",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -522,7 +522,7 @@
   {
     "name": "Unfriendly",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -535,7 +535,7 @@
   {
     "name": "Unnoticed",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -548,7 +548,7 @@
   {
     "name": "Wounded",
     "rule_type": "Condition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/creatures-sample.json
+++ b/db/seeds/pf2e/creatures-sample.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Animated Broom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -100,7 +100,7 @@
   },
   {
     "name": "Air Scamp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -199,7 +199,7 @@
   },
   {
     "name": "Aapoph Serpentfolk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -310,7 +310,7 @@
   },
   {
     "name": "Army Ant Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -402,7 +402,7 @@
   },
   {
     "name": "Aesra",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -507,7 +507,7 @@
   },
   {
     "name": "Brontosaurus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -612,7 +612,7 @@
   },
   {
     "name": "Aeolaeka",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -711,7 +711,7 @@
   },
   {
     "name": "Benthic Worm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -822,7 +822,7 @@
   },
   {
     "name": "Adamantine Dragon (Ancient, Spellcaster)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -939,7 +939,7 @@
   },
   {
     "name": "Diabolic Dragon (Ancient, Spellcaster)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/deities.json
+++ b/db/seeds/pf2e/deities.json
@@ -2,7 +2,7 @@
   {
     "name": "Apep",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15,7 +15,7 @@
   {
     "name": "Bastet",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28,7 +28,7 @@
   {
     "name": "Bes",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41,7 +41,7 @@
   {
     "name": "Hathor",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -54,7 +54,7 @@
   {
     "name": "Khepri",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -67,7 +67,7 @@
   {
     "name": "Neith",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -80,7 +80,7 @@
   {
     "name": "Nephthys",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -93,7 +93,7 @@
   {
     "name": "Ptah",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -106,7 +106,7 @@
   {
     "name": "Sekhmet",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -119,7 +119,7 @@
   {
     "name": "Selket",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -132,7 +132,7 @@
   {
     "name": "Set",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -145,7 +145,7 @@
   {
     "name": "Sobek",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -158,7 +158,7 @@
   {
     "name": "Wadjet",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -171,7 +171,7 @@
   {
     "name": "Anras",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -184,7 +184,7 @@
   {
     "name": "Apollyon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -197,7 +197,7 @@
   {
     "name": "Charon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -210,7 +210,7 @@
   {
     "name": "Szuriel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -223,7 +223,7 @@
   {
     "name": "Trelmarixian",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -236,7 +236,7 @@
   {
     "name": "Baalzebul",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -249,7 +249,7 @@
   {
     "name": "Barbatos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -262,7 +262,7 @@
   {
     "name": "Belial",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -275,7 +275,7 @@
   {
     "name": "Dispater",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -288,7 +288,7 @@
   {
     "name": "Geryon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -301,7 +301,7 @@
   {
     "name": "Mammon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -314,7 +314,7 @@
   {
     "name": "Mephistopheles",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -327,7 +327,7 @@
   {
     "name": "Moloch",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -340,7 +340,7 @@
   {
     "name": "Acavna",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -353,7 +353,7 @@
   {
     "name": "Aesocar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -366,7 +366,7 @@
   {
     "name": "Amaznen",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -379,7 +379,7 @@
   {
     "name": "Elion",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -392,7 +392,7 @@
   {
     "name": "Jaidi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -405,7 +405,7 @@
   {
     "name": "Lissala (The Order of Virtue)",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -418,7 +418,7 @@
   {
     "name": "Myr",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -431,7 +431,7 @@
   {
     "name": "Onos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -444,7 +444,7 @@
   {
     "name": "Scal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -457,7 +457,7 @@
   {
     "name": "Sicva",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -470,7 +470,7 @@
   {
     "name": "Ulon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -483,7 +483,7 @@
   {
     "name": "Belech",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -496,7 +496,7 @@
   {
     "name": "Cihua Coatl",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -509,7 +509,7 @@
   {
     "name": "Pahti Coatl",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -522,7 +522,7 @@
   {
     "name": "Tolte Coatl",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -535,7 +535,7 @@
   {
     "name": "Abadar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -548,7 +548,7 @@
   {
     "name": "Arazni",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -561,7 +561,7 @@
   {
     "name": "Asmodeus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -574,7 +574,7 @@
   {
     "name": "Calistria",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -587,7 +587,7 @@
   {
     "name": "Cayden Cailean",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -600,7 +600,7 @@
   {
     "name": "Desna",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -613,7 +613,7 @@
   {
     "name": "Erastil",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -626,7 +626,7 @@
   {
     "name": "Gozreh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -639,7 +639,7 @@
   {
     "name": "Iomedae",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -652,7 +652,7 @@
   {
     "name": "Irori",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -665,7 +665,7 @@
   {
     "name": "Lamashtu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -678,7 +678,7 @@
   {
     "name": "Nethys",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -691,7 +691,7 @@
   {
     "name": "Norgorber",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -704,7 +704,7 @@
   {
     "name": "Pharasma",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -717,7 +717,7 @@
   {
     "name": "Rovagug",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -730,7 +730,7 @@
   {
     "name": "Sarenrae",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -743,7 +743,7 @@
   {
     "name": "Shelyn",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -756,7 +756,7 @@
   {
     "name": "Torag",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -769,7 +769,7 @@
   {
     "name": "Urgathoa",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -782,7 +782,7 @@
   {
     "name": "Zon-Kuthon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -795,7 +795,7 @@
   {
     "name": "Cormion",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -808,7 +808,7 @@
   {
     "name": "Blooms of the Spreading Weald",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -821,7 +821,7 @@
   {
     "name": "Breath of the Endless Sky",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -834,7 +834,7 @@
   {
     "name": "Esoteric Order of the Palatine Eye",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -847,7 +847,7 @@
   {
     "name": "Faith in the Fallen",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -860,7 +860,7 @@
   {
     "name": "Good Neighbors",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -873,7 +873,7 @@
   {
     "name": "Green Faith",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -886,7 +886,7 @@
   {
     "name": "Immaculate Growth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -899,7 +899,7 @@
   {
     "name": "Light of the Everlasting Flame",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -912,7 +912,7 @@
   {
     "name": "Rivethun",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -925,7 +925,7 @@
   {
     "name": "Shadow Cabinet",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -938,7 +938,7 @@
   {
     "name": "Shapes of the Fading Luster",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -951,7 +951,7 @@
   {
     "name": "The Pandemonia",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -964,7 +964,7 @@
   {
     "name": "The Readied Strike",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -977,7 +977,7 @@
   {
     "name": "The Spirit Wall",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -990,7 +990,7 @@
   {
     "name": "The Tides of Chaos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1003,7 +1003,7 @@
   {
     "name": "Treasures of the Eternal Delve",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1016,7 +1016,7 @@
   {
     "name": "Waves of the Boundless Sea",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1029,7 +1029,7 @@
   {
     "name": "Anogetz",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1042,7 +1042,7 @@
   {
     "name": "Cixyron",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1055,7 +1055,7 @@
   {
     "name": "Corosbel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1068,7 +1068,7 @@
   {
     "name": "Laivatiniel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1081,7 +1081,7 @@
   {
     "name": "Pavnuri",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1094,7 +1094,7 @@
   {
     "name": "Tresmalvos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1107,7 +1107,7 @@
   {
     "name": "Vorasha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1120,7 +1120,7 @@
   {
     "name": "Xsistaid",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1133,7 +1133,7 @@
   {
     "name": "Zelishkar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1146,7 +1146,7 @@
   {
     "name": "Abraxas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1159,7 +1159,7 @@
   {
     "name": "Angazhan",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1172,7 +1172,7 @@
   {
     "name": "Areshkagal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1185,7 +1185,7 @@
   {
     "name": "Baphomet",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1198,7 +1198,7 @@
   {
     "name": "Cyth-V'sug",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1211,7 +1211,7 @@
   {
     "name": "Dagon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1224,7 +1224,7 @@
   {
     "name": "Gogunta",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1237,7 +1237,7 @@
   {
     "name": "Haagenti",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1250,7 +1250,7 @@
   {
     "name": "Jezelda",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1263,7 +1263,7 @@
   {
     "name": "Kabriri",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1276,7 +1276,7 @@
   {
     "name": "Nurgal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1289,7 +1289,7 @@
   {
     "name": "Pazuzu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1302,7 +1302,7 @@
   {
     "name": "Shax",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1315,7 +1315,7 @@
   {
     "name": "Shivaska",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1328,7 +1328,7 @@
   {
     "name": "Sifkesh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1341,7 +1341,7 @@
   {
     "name": "Sithhud",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1354,7 +1354,7 @@
   {
     "name": "Vulot",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1367,7 +1367,7 @@
   {
     "name": "Xoveron",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1380,7 +1380,7 @@
   {
     "name": "Yhidothrus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1393,7 +1393,7 @@
   {
     "name": "Zevgavizeb",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1406,7 +1406,7 @@
   {
     "name": "Zura",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1419,7 +1419,7 @@
   {
     "name": "Deshto",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1432,7 +1432,7 @@
   {
     "name": "Brixori",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1445,7 +1445,7 @@
   {
     "name": "Gaasham",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1458,7 +1458,7 @@
   {
     "name": "Garhaazh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1471,7 +1471,7 @@
   {
     "name": "Otilaz",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1484,7 +1484,7 @@
   {
     "name": "Sarshallatu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1497,7 +1497,7 @@
   {
     "name": "Turvu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1510,7 +1510,7 @@
   {
     "name": "Yluma",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1523,7 +1523,7 @@
   {
     "name": "Angradd",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1536,7 +1536,7 @@
   {
     "name": "Bolka",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1549,7 +1549,7 @@
   {
     "name": "Dranngvit",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1562,7 +1562,7 @@
   {
     "name": "Droskar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1575,7 +1575,7 @@
   {
     "name": "Folgrit",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1588,7 +1588,7 @@
   {
     "name": "Kols",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1601,7 +1601,7 @@
   {
     "name": "Magrim",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1614,7 +1614,7 @@
   {
     "name": "Trudd",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1627,7 +1627,7 @@
   {
     "name": "Count Ranalc",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1640,7 +1640,7 @@
   {
     "name": "Imbrex",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1653,7 +1653,7 @@
   {
     "name": "Magdh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1666,7 +1666,7 @@
   {
     "name": "Ng",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1679,7 +1679,7 @@
   {
     "name": "Ragadahn",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1692,7 +1692,7 @@
   {
     "name": "Shyka",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1705,7 +1705,7 @@
   {
     "name": "The Green Mother",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1718,7 +1718,7 @@
   {
     "name": "The Lantern King",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1731,7 +1731,7 @@
   {
     "name": "The Lost Prince",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1744,7 +1744,7 @@
   {
     "name": "Atreia",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1757,7 +1757,7 @@
   {
     "name": "Ayrzul",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1770,7 +1770,7 @@
   {
     "name": "Ferrumnestra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1783,7 +1783,7 @@
   {
     "name": "Hshurha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1796,7 +1796,7 @@
   {
     "name": "Kelizandri",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1809,7 +1809,7 @@
   {
     "name": "Laudinmio",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1822,7 +1822,7 @@
   {
     "name": "Lysianassa",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1835,7 +1835,7 @@
   {
     "name": "Ranginori",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1848,7 +1848,7 @@
   {
     "name": "Sairazul",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1861,7 +1861,7 @@
   {
     "name": "Shumunue",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1874,7 +1874,7 @@
   {
     "name": "Verilorn",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1887,7 +1887,7 @@
   {
     "name": "Ymeri",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1900,7 +1900,7 @@
   {
     "name": "Findeladlara",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1913,7 +1913,7 @@
   {
     "name": "Ketephys",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1926,7 +1926,7 @@
   {
     "name": "Yuelral",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1939,7 +1939,7 @@
   {
     "name": "Andoletta",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1952,7 +1952,7 @@
   {
     "name": "Arqueros",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1965,7 +1965,7 @@
   {
     "name": "Arshea",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1978,7 +1978,7 @@
   {
     "name": "Ashava",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1991,7 +1991,7 @@
   {
     "name": "Bharnarol",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2004,7 +2004,7 @@
   {
     "name": "Black Butterfly",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2017,7 +2017,7 @@
   {
     "name": "Dalenydra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2030,7 +2030,7 @@
   {
     "name": "Dammerich",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2043,7 +2043,7 @@
   {
     "name": "Eritrice",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2056,7 +2056,7 @@
   {
     "name": "Falayna",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2069,7 +2069,7 @@
   {
     "name": "Halcamora",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2082,7 +2082,7 @@
   {
     "name": "Irez",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2095,7 +2095,7 @@
   {
     "name": "Jaidz",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2108,7 +2108,7 @@
   {
     "name": "Kelinahat",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2121,7 +2121,7 @@
   {
     "name": "Keltheald",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2134,7 +2134,7 @@
   {
     "name": "Korada",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2147,7 +2147,7 @@
   {
     "name": "Lalaci",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2160,7 +2160,7 @@
   {
     "name": "Lorris",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2173,7 +2173,7 @@
   {
     "name": "Lymnieris",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2186,7 +2186,7 @@
   {
     "name": "Marishi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2199,7 +2199,7 @@
   {
     "name": "Neshen",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2212,7 +2212,7 @@
   {
     "name": "Olheon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2225,7 +2225,7 @@
   {
     "name": "Picoperi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2238,7 +2238,7 @@
   {
     "name": "Pulura",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2251,7 +2251,7 @@
   {
     "name": "Ragathiel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2264,7 +2264,7 @@
   {
     "name": "Reymenda",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2277,7 +2277,7 @@
   {
     "name": "Rowdrosh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2290,7 +2290,7 @@
   {
     "name": "Seramaydiel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2303,7 +2303,7 @@
   {
     "name": "Shei",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2316,7 +2316,7 @@
   {
     "name": "Soralyon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2329,7 +2329,7 @@
   {
     "name": "Tanagaar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2342,7 +2342,7 @@
   {
     "name": "Thisamet",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2355,7 +2355,7 @@
   {
     "name": "Uskyeria",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2368,7 +2368,7 @@
   {
     "name": "Valani",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2381,7 +2381,7 @@
   {
     "name": "Vildeis",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2394,7 +2394,7 @@
   {
     "name": "Winlas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2407,7 +2407,7 @@
   {
     "name": "Ylimancha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2420,7 +2420,7 @@
   {
     "name": "Zohls",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2433,7 +2433,7 @@
   {
     "name": "Aegirran",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2446,7 +2446,7 @@
   {
     "name": "Bergelmir",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2459,7 +2459,7 @@
   {
     "name": "Fandarra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2472,7 +2472,7 @@
   {
     "name": "Haggakal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2485,7 +2485,7 @@
   {
     "name": "Minderhal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2498,7 +2498,7 @@
   {
     "name": "Skode",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2511,7 +2511,7 @@
   {
     "name": "Skrymir",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2524,7 +2524,7 @@
   {
     "name": "Thremyr",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2537,7 +2537,7 @@
   {
     "name": "Tjasse",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2550,7 +2550,7 @@
   {
     "name": "Urazra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2563,7 +2563,7 @@
   {
     "name": "Yrmidar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2576,7 +2576,7 @@
   {
     "name": "Zursvaater",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2589,7 +2589,7 @@
   {
     "name": "Cong",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2602,7 +2602,7 @@
   {
     "name": "Hadregash",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2615,7 +2615,7 @@
   {
     "name": "Lurlup",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2628,7 +2628,7 @@
   {
     "name": "Teki Stronggut",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2641,7 +2641,7 @@
   {
     "name": "Venkelvore",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2654,7 +2654,7 @@
   {
     "name": "Zarongel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2667,7 +2667,7 @@
   {
     "name": "Zogmugot",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2680,7 +2680,7 @@
   {
     "name": "Zugero",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2693,7 +2693,7 @@
   {
     "name": "Aminara",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2706,7 +2706,7 @@
   {
     "name": "Granduncle Taproot",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2719,7 +2719,7 @@
   {
     "name": "Green Man",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2732,7 +2732,7 @@
   {
     "name": "Kzininn",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2745,7 +2745,7 @@
   {
     "name": "Telvrys",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2758,7 +2758,7 @@
   {
     "name": "Zibik",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2771,7 +2771,7 @@
   {
     "name": "Aerekostes",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2784,7 +2784,7 @@
   {
     "name": "Chinostes",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2797,7 +2797,7 @@
   {
     "name": "Drokalion",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2810,7 +2810,7 @@
   {
     "name": "Iapholi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2823,7 +2823,7 @@
   {
     "name": "Ongalte",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2836,7 +2836,7 @@
   {
     "name": "Pharimia",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2849,7 +2849,7 @@
   {
     "name": "Upion and Warrik",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2862,7 +2862,7 @@
   {
     "name": "Ytildos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2875,7 +2875,7 @@
   {
     "name": "Zeaki",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2888,7 +2888,7 @@
   {
     "name": "Alazhra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2901,7 +2901,7 @@
   {
     "name": "Anubis",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2914,7 +2914,7 @@
   {
     "name": "Aroden",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2927,7 +2927,7 @@
   {
     "name": "Cernunnos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2940,7 +2940,7 @@
   {
     "name": "Cormigus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2953,7 +2953,7 @@
   {
     "name": "Gorum",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2966,7 +2966,7 @@
   {
     "name": "Grundinnar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2979,7 +2979,7 @@
   {
     "name": "Gyronna",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2992,7 +2992,7 @@
   {
     "name": "Horus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3005,7 +3005,7 @@
   {
     "name": "Isis",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3018,7 +3018,7 @@
   {
     "name": "Lorthact",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3031,7 +3031,7 @@
   {
     "name": "Ma'at",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3044,7 +3044,7 @@
   {
     "name": "Mestama",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3057,7 +3057,7 @@
   {
     "name": "Osiris",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3070,7 +3070,7 @@
   {
     "name": "Ra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3083,7 +3083,7 @@
   {
     "name": "Smiad",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3096,7 +3096,7 @@
   {
     "name": "Sturovenen",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3109,7 +3109,7 @@
   {
     "name": "Thoth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3122,7 +3122,7 @@
   {
     "name": "Ydersius",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3135,7 +3135,7 @@
   {
     "name": "Bifrons",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3148,7 +3148,7 @@
   {
     "name": "Furcas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3161,7 +3161,7 @@
   {
     "name": "Haborym",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3174,7 +3174,7 @@
   {
     "name": "Malthus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3187,7 +3187,7 @@
   {
     "name": "Nergal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3200,7 +3200,7 @@
   {
     "name": "Titivilus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3213,7 +3213,7 @@
   {
     "name": "Ussharassim",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3226,7 +3226,7 @@
   {
     "name": "Vapula",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3239,7 +3239,7 @@
   {
     "name": "Atropos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3252,7 +3252,7 @@
   {
     "name": "Barzahk",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3265,7 +3265,7 @@
   {
     "name": "Ceyannan",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3278,7 +3278,7 @@
   {
     "name": "Dammar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3291,7 +3291,7 @@
   {
     "name": "Dramindyr",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3304,7 +3304,7 @@
   {
     "name": "Il'Surrish",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3317,7 +3317,7 @@
   {
     "name": "Imot",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3330,7 +3330,7 @@
   {
     "name": "Inna",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3343,7 +3343,7 @@
   {
     "name": "Liisglan",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3356,7 +3356,7 @@
   {
     "name": "Monad",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3369,7 +3369,7 @@
   {
     "name": "Mother Vulture",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3382,7 +3382,7 @@
   {
     "name": "Mrtyu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3395,7 +3395,7 @@
   {
     "name": "Narakaas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3408,7 +3408,7 @@
   {
     "name": "Narriseminek",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3421,7 +3421,7 @@
   {
     "name": "Phlegyas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3434,7 +3434,7 @@
   {
     "name": "Saloc",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3447,7 +3447,7 @@
   {
     "name": "Ssila'meshnik",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3460,7 +3460,7 @@
   {
     "name": "Telastmar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3473,7 +3473,7 @@
   {
     "name": "Teshallas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3486,7 +3486,7 @@
   {
     "name": "The Pale Horse",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3499,7 +3499,7 @@
   {
     "name": "Vale",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3512,7 +3512,7 @@
   {
     "name": "Vavaalrav",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3525,7 +3525,7 @@
   {
     "name": "Vonymos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3538,7 +3538,7 @@
   {
     "name": "Ydajisk",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3551,7 +3551,7 @@
   {
     "name": "Adanye",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3564,7 +3564,7 @@
   {
     "name": "Balumbdar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3577,7 +3577,7 @@
   {
     "name": "Chohar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3590,7 +3590,7 @@
   {
     "name": "Kalekot",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3603,7 +3603,7 @@
   {
     "name": "Kitumu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3616,7 +3616,7 @@
   {
     "name": "Lubaiko",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3629,7 +3629,7 @@
   {
     "name": "Luhar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3642,7 +3642,7 @@
   {
     "name": "Mazludeh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3655,7 +3655,7 @@
   {
     "name": "Tlehar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3668,7 +3668,7 @@
   {
     "name": "Uvuko",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3681,7 +3681,7 @@
   {
     "name": "Walkena",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3694,7 +3694,7 @@
   {
     "name": "Oathos",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3707,7 +3707,7 @@
   {
     "name": "Grask Uldeth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3720,7 +3720,7 @@
   {
     "name": "Jukha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3733,7 +3733,7 @@
   {
     "name": "Mahja Firehair",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3746,7 +3746,7 @@
   {
     "name": "Nulgreth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3759,7 +3759,7 @@
   {
     "name": "Rull",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3772,7 +3772,7 @@
   {
     "name": "Uirch",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3785,7 +3785,7 @@
   {
     "name": "Varg",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3798,7 +3798,7 @@
   {
     "name": "Wulgren",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3811,7 +3811,7 @@
   {
     "name": "Aakriti",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3824,7 +3824,7 @@
   {
     "name": "Achaekek",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3837,7 +3837,7 @@
   {
     "name": "Ah Pook",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3850,7 +3850,7 @@
   {
     "name": "Ahriman",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3863,7 +3863,7 @@
   {
     "name": "Aleth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3876,7 +3876,7 @@
   {
     "name": "Alseta",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3889,7 +3889,7 @@
   {
     "name": "Apsu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3902,7 +3902,7 @@
   {
     "name": "Atrogine",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3915,7 +3915,7 @@
   {
     "name": "Besmara",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3928,7 +3928,7 @@
   {
     "name": "Brigh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3941,7 +3941,7 @@
   {
     "name": "Camazotz",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3954,7 +3954,7 @@
   {
     "name": "Casandalee",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3967,7 +3967,7 @@
   {
     "name": "Chaldira",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3980,7 +3980,7 @@
   {
     "name": "Dahak",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3993,7 +3993,7 @@
   {
     "name": "Dajermube",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4006,7 +4006,7 @@
   {
     "name": "Embaral",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4019,7 +4019,7 @@
   {
     "name": "Emmeton Galardaria",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4032,7 +4032,7 @@
   {
     "name": "Erecura",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4045,7 +4045,7 @@
   {
     "name": "Etaris",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4058,7 +4058,7 @@
   {
     "name": "Gendowyn",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4071,7 +4071,7 @@
   {
     "name": "Genzaeri",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4084,7 +4084,7 @@
   {
     "name": "Ghlaunder",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4097,7 +4097,7 @@
   {
     "name": "Grandmother Spider",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4110,7 +4110,7 @@
   {
     "name": "Groetus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4123,7 +4123,7 @@
   {
     "name": "Gruhastha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4136,7 +4136,7 @@
   {
     "name": "Hanspur",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4149,7 +4149,7 @@
   {
     "name": "Hei Feng",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4162,7 +4162,7 @@
   {
     "name": "Immonhiel",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4175,7 +4175,7 @@
   {
     "name": "Izuyaku",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4188,7 +4188,7 @@
   {
     "name": "Kaldemash",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4201,7 +4201,7 @@
   {
     "name": "Kazutal",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4214,7 +4214,7 @@
   {
     "name": "Kurgess",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4227,7 +4227,7 @@
   {
     "name": "Lissala",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4240,7 +4240,7 @@
   {
     "name": "Milani",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4253,7 +4253,7 @@
   {
     "name": "Naderi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4266,7 +4266,7 @@
   {
     "name": "Nin",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4279,7 +4279,7 @@
   {
     "name": "Nivi Rhombodazzle",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4292,7 +4292,7 @@
   {
     "name": "Nocticula",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4305,7 +4305,7 @@
   {
     "name": "Norns",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4318,7 +4318,7 @@
   {
     "name": "Obari",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4331,7 +4331,7 @@
   {
     "name": "Rokoga Gin",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4344,7 +4344,7 @@
   {
     "name": "Shizuru",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4357,7 +4357,7 @@
   {
     "name": "Sivanah",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4370,7 +4370,7 @@
   {
     "name": "Thamir",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4383,7 +4383,7 @@
   {
     "name": "The Devourer",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4396,7 +4396,7 @@
   {
     "name": "Treerazer",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4409,7 +4409,7 @@
   {
     "name": "Tsukiyo",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4422,7 +4422,7 @@
   {
     "name": "Vudravati",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4435,7 +4435,7 @@
   {
     "name": "Yelayne",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4448,7 +4448,7 @@
   {
     "name": "Zjar-Tovan",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4461,7 +4461,7 @@
   {
     "name": "Zyphus",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4474,7 +4474,7 @@
   {
     "name": "Azathoth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4487,7 +4487,7 @@
   {
     "name": "Bokrug",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4500,7 +4500,7 @@
   {
     "name": "Cthulhu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4513,7 +4513,7 @@
   {
     "name": "Hastur",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4526,7 +4526,7 @@
   {
     "name": "Mhar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4539,7 +4539,7 @@
   {
     "name": "Nhimbaloth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4552,7 +4552,7 @@
   {
     "name": "Nyarlathotep (Haunter in the Dark)",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4565,7 +4565,7 @@
   {
     "name": "Nyarlathotep (The Crawling Chaos)",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4578,7 +4578,7 @@
   {
     "name": "Nyarlathotep (The Faceless Sphinx)",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4591,7 +4591,7 @@
   {
     "name": "Nyarlathotep (The Veiled Voice)",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4604,7 +4604,7 @@
   {
     "name": "Orgesh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4617,7 +4617,7 @@
   {
     "name": "Rhan-Tegoth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4630,7 +4630,7 @@
   {
     "name": "Xhamen-Dor",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4643,7 +4643,7 @@
   {
     "name": "Yig",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4656,7 +4656,7 @@
   {
     "name": "Yog-Sothoth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4669,7 +4669,7 @@
   {
     "name": "Children of the Night",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4682,7 +4682,7 @@
   {
     "name": "Cosmic Caravan",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4695,7 +4695,7 @@
   {
     "name": "Essence Dancers",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4708,7 +4708,7 @@
   {
     "name": "Fortune's Fate",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4721,7 +4721,7 @@
   {
     "name": "Guardians of the Sacred Self",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4734,7 +4734,7 @@
   {
     "name": "Radiant Prism",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4747,7 +4747,7 @@
   {
     "name": "Sovyrian Conclave",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4760,7 +4760,7 @@
   {
     "name": "Stone's Blood",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4773,7 +4773,7 @@
   {
     "name": "Talons of the Godclaw",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4786,7 +4786,7 @@
   {
     "name": "The Anointing of Kings",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4799,7 +4799,7 @@
   {
     "name": "The Curtain Call",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4812,7 +4812,7 @@
   {
     "name": "Weight of the World",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4825,7 +4825,7 @@
   {
     "name": "Wheels of Innovation",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4838,7 +4838,7 @@
   {
     "name": "Atheists and Free Agents",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4851,7 +4851,7 @@
   {
     "name": "Laws of Mortality",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4864,7 +4864,7 @@
   {
     "name": "Prophecies of Kalistrade",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4877,7 +4877,7 @@
   {
     "name": "Whispering Way",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4890,7 +4890,7 @@
   {
     "name": "Aonaurious",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4903,7 +4903,7 @@
   {
     "name": "Chavazvug",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4916,7 +4916,7 @@
   {
     "name": "Isph-Aun-Vuln",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4929,7 +4929,7 @@
   {
     "name": "Nyuo-Ogh",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4942,7 +4942,7 @@
   {
     "name": "Oaur-Ooung",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4955,7 +4955,7 @@
   {
     "name": "Thuskchoon",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4968,7 +4968,7 @@
   {
     "name": "Yamasoth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4981,7 +4981,7 @@
   {
     "name": "Ardad Lili",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4994,7 +4994,7 @@
   {
     "name": "Doloras",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5007,7 +5007,7 @@
   {
     "name": "Eiseth",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5020,7 +5020,7 @@
   {
     "name": "Mahathallah",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5033,7 +5033,7 @@
   {
     "name": "Razmir",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5046,7 +5046,7 @@
   {
     "name": "Ananshea",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5059,7 +5059,7 @@
   {
     "name": "Chamiaholom",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5072,7 +5072,7 @@
   {
     "name": "Charg",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5085,7 +5085,7 @@
   {
     "name": "Dachzerul",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5098,7 +5098,7 @@
   {
     "name": "Hataam",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5111,7 +5111,7 @@
   {
     "name": "Iggeret",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5124,7 +5124,7 @@
   {
     "name": "Nameless",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5137,7 +5137,7 @@
   {
     "name": "Ozranvial",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5150,7 +5150,7 @@
   {
     "name": "Shawnari",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5163,7 +5163,7 @@
   {
     "name": "Velgaas",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5176,7 +5176,7 @@
   {
     "name": "Vermilion Mother",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5189,7 +5189,7 @@
   {
     "name": "Xiquiripat",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5202,7 +5202,7 @@
   {
     "name": "Zipacna",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5215,7 +5215,7 @@
   {
     "name": "Alglenweis",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5228,7 +5228,7 @@
   {
     "name": "Dolok Darkfur",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5241,7 +5241,7 @@
   {
     "name": "Kagia",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5254,7 +5254,7 @@
   {
     "name": "Ristrentho",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5267,7 +5267,7 @@
   {
     "name": "Stag Mother of the Forest of Stones",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5280,7 +5280,7 @@
   {
     "name": "Enkaar",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5293,7 +5293,7 @@
   {
     "name": "Eyes That Watch",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5306,7 +5306,7 @@
   {
     "name": "Grasping Iovett",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5319,7 +5319,7 @@
   {
     "name": "Husk",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5332,7 +5332,7 @@
   {
     "name": "Lady Razor",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5345,7 +5345,7 @@
   {
     "name": "Reshmit of the Heavy Voice",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5358,7 +5358,7 @@
   {
     "name": "Thalaphyrr",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5371,7 +5371,7 @@
   {
     "name": "Baekho",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5384,7 +5384,7 @@
   {
     "name": "Daikitsu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5397,7 +5397,7 @@
   {
     "name": "Fumeiyoshi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5410,7 +5410,7 @@
   {
     "name": "General Susumu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5423,7 +5423,7 @@
   {
     "name": "Jin Li",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5436,7 +5436,7 @@
   {
     "name": "Kofusachi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5449,7 +5449,7 @@
   {
     "name": "Lady Jingxi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5462,7 +5462,7 @@
   {
     "name": "Lady Nanbyo",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5475,7 +5475,7 @@
   {
     "name": "Lao Shu Po",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5488,7 +5488,7 @@
   {
     "name": "Mugura and Nrithu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5501,7 +5501,7 @@
   {
     "name": "Nalinivati",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5514,7 +5514,7 @@
   {
     "name": "Phi Deva",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5527,7 +5527,7 @@
   {
     "name": "Qi Zhong",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5540,7 +5540,7 @@
   {
     "name": "Srikalis, Sritaming, and Sribaril",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5553,7 +5553,7 @@
   {
     "name": "Sun Wukong",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5566,7 +5566,7 @@
   {
     "name": "The Lady of the North Star",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5579,7 +5579,7 @@
   {
     "name": "Yaezhing",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5592,7 +5592,7 @@
   {
     "name": "Yamatsumi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5605,7 +5605,7 @@
   {
     "name": "Umarik",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5618,7 +5618,7 @@
   {
     "name": "Arundhat",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5631,7 +5631,7 @@
   {
     "name": "Ashukharma",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5644,7 +5644,7 @@
   {
     "name": "Chamidu",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5657,7 +5657,7 @@
   {
     "name": "Dhalavei",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5670,7 +5670,7 @@
   {
     "name": "Diomazul",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5683,7 +5683,7 @@
   {
     "name": "Lahkgya",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5696,7 +5696,7 @@
   {
     "name": "Likha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5709,7 +5709,7 @@
   {
     "name": "Matravash",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5722,7 +5722,7 @@
   {
     "name": "Ragdya",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5735,7 +5735,7 @@
   {
     "name": "Raumya",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5748,7 +5748,7 @@
   {
     "name": "Ravithra",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5761,7 +5761,7 @@
   {
     "name": "Suyuddha",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5774,7 +5774,7 @@
   {
     "name": "Vineshvakhi",
     "rule_type": "Deity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/general-feats.json
+++ b/db/seeds/pf2e/general-feats.json
@@ -2,7 +2,7 @@
   {
     "name": "Adopted Ancestry",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19,7 +19,7 @@
   {
     "name": "Armor Proficiency",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36,7 +36,7 @@
   {
     "name": "Breath Control",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -53,7 +53,7 @@
   {
     "name": "Canny Acumen",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -70,7 +70,7 @@
   {
     "name": "Diehard",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -87,7 +87,7 @@
   {
     "name": "Fast Recovery",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -105,7 +105,7 @@
   {
     "name": "Feather Step",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -123,7 +123,7 @@
   {
     "name": "Fleet",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -140,7 +140,7 @@
   {
     "name": "Incredible Initiative",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -157,7 +157,7 @@
   {
     "name": "Pet",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -174,7 +174,7 @@
   {
     "name": "Ride",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -191,7 +191,7 @@
   {
     "name": "Shield Block",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -208,7 +208,7 @@
   {
     "name": "Speedrun Strats",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -221,7 +221,7 @@
   {
     "name": "Toughness",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -238,7 +238,7 @@
   {
     "name": "Weapon Proficiency",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -255,7 +255,7 @@
   {
     "name": "A Home in Every Port",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -275,7 +275,7 @@
   {
     "name": "Caravan Leader",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -293,7 +293,7 @@
   {
     "name": "Incredible Investiture",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -311,7 +311,7 @@
   {
     "name": "Incredible Scout",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -331,7 +331,7 @@
   {
     "name": "Sanguine Tenacity",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -345,7 +345,7 @@
   {
     "name": "True Perception",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -365,7 +365,7 @@
   {
     "name": "Ancestral Paragon",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -383,7 +383,7 @@
   {
     "name": "Improvised Repair",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -401,7 +401,7 @@
   {
     "name": "Keen Follower",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -419,7 +419,7 @@
   {
     "name": "Pick up the Pace",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -437,7 +437,7 @@
   {
     "name": "Prescient Planner",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -455,7 +455,7 @@
   {
     "name": "Robust Health",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -473,7 +473,7 @@
   {
     "name": "Thorough Search",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -491,7 +491,7 @@
   {
     "name": "Untrained Improvisation",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -509,7 +509,7 @@
   {
     "name": "Bloodsense",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -523,7 +523,7 @@
   {
     "name": "Expeditious Search",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -541,7 +541,7 @@
   {
     "name": "Numb to Death",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -559,7 +559,7 @@
   {
     "name": "Prescient Consumable",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -577,7 +577,7 @@
   {
     "name": "Supertaster",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -595,7 +595,7 @@
   {
     "name": "Devil's Eye",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -615,7 +615,7 @@
   {
     "name": "Dormant Eruption",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -637,7 +637,7 @@
   {
     "name": "Echo of the Fallen",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -655,7 +655,7 @@
   {
     "name": "Elysium's Cadence",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -675,7 +675,7 @@
   {
     "name": "Fey Life",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -697,7 +697,7 @@
   {
     "name": "Gift of the Hoard",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -717,7 +717,7 @@
   {
     "name": "Jelly Body",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -737,7 +737,7 @@
   {
     "name": "Lingering Chill",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -759,7 +759,7 @@
   {
     "name": "Petrified Skin",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -779,7 +779,7 @@
   {
     "name": "Sink and Swim",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -801,7 +801,7 @@
   {
     "name": "Siphon Life",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -825,7 +825,7 @@
   {
     "name": "Walk on the Wind",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -847,7 +847,7 @@
   {
     "name": "Awakened Power",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -865,7 +865,7 @@
   {
     "name": "Blasting Beams",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -887,7 +887,7 @@
   {
     "name": "Bone Spikes",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -907,7 +907,7 @@
   {
     "name": "Borrowed Ability",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -929,7 +929,7 @@
   {
     "name": "Consume Energy",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -949,7 +949,7 @@
   {
     "name": "Defensive Growth",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -973,7 +973,7 @@
   {
     "name": "Disperse Into Petals",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -997,7 +997,7 @@
   {
     "name": "Distant Wandering",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1017,7 +1017,7 @@
   {
     "name": "Draining Touch",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1041,7 +1041,7 @@
   {
     "name": "Eerie Flicker",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1061,7 +1061,7 @@
   {
     "name": "Enervating Wail",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1083,7 +1083,7 @@
   {
     "name": "Feed the Void",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1109,7 +1109,7 @@
   {
     "name": "Ghostly Grasp (Deviant)",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1129,7 +1129,7 @@
   {
     "name": "Greater Awakened Power",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1147,7 +1147,7 @@
   {
     "name": "High-Speed Regeneration",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1169,7 +1169,7 @@
   {
     "name": "Irradiate",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1191,7 +1191,7 @@
   {
     "name": "Kinetic Dampening",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1211,7 +1211,7 @@
   {
     "name": "Lightspeed Assault",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1231,7 +1231,7 @@
   {
     "name": "Overclock Senses",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1251,7 +1251,7 @@
   {
     "name": "Propulsive Leap",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1271,7 +1271,7 @@
   {
     "name": "Release Spores",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1295,7 +1295,7 @@
   {
     "name": "Rotten Slurry",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1317,7 +1317,7 @@
   {
     "name": "Sonic Dash",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1337,7 +1337,7 @@
   {
     "name": "Sprout Fruit",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1361,7 +1361,7 @@
   {
     "name": "Storming Breath",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1381,7 +1381,7 @@
   {
     "name": "Tectonic Stomp",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1401,7 +1401,7 @@
   {
     "name": "Titan Swing",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1421,7 +1421,7 @@
   {
     "name": "Unleash the Blight",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1443,7 +1443,7 @@
   {
     "name": "Unstable Gearshift",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1463,7 +1463,7 @@
   {
     "name": "Vine Lash",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1487,7 +1487,7 @@
   {
     "name": "Animal Soul Siblings",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1505,7 +1505,7 @@
   {
     "name": "Boneyard Acquaintance",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1525,7 +1525,7 @@
   {
     "name": "Clinging to Life",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1543,7 +1543,7 @@
   {
     "name": "Empathy Incarnate",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1561,7 +1561,7 @@
   {
     "name": "I Sense Malevolence",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1579,7 +1579,7 @@
   {
     "name": "Indomitable Spirit",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1599,7 +1599,7 @@
   {
     "name": "I've Had Many Jobs",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1619,7 +1619,7 @@
   {
     "name": "Let's Try That Again",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1638,7 +1638,7 @@
   {
     "name": "Like a Roach",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1657,7 +1657,7 @@
   {
     "name": "Lingering Echoes",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1675,7 +1675,7 @@
   {
     "name": "Linguistic Revival",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1693,7 +1693,7 @@
   {
     "name": "Pain is Temporary",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1713,7 +1713,7 @@
   {
     "name": "Plant Soul Siblings",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1731,7 +1731,7 @@
   {
     "name": "Rapid Retraining",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1751,7 +1751,7 @@
   {
     "name": "Reincarnated Ridiculer",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1769,7 +1769,7 @@
   {
     "name": "Release the Light",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1791,7 +1791,7 @@
   {
     "name": "See You in Hell",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1809,7 +1809,7 @@
   {
     "name": "Sleep of the Reborn",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1827,7 +1827,7 @@
   {
     "name": "Stone Soul Siblings",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1845,7 +1845,7 @@
   {
     "name": "This is What it's Like to Die",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1863,7 +1863,7 @@
   {
     "name": "Unbreakable Resolve",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1883,7 +1883,7 @@
   {
     "name": "Weight of Experience",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1900,7 +1900,7 @@
   {
     "name": "Wisdom from Another Life",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1917,7 +1917,7 @@
   {
     "name": "You Seem Somewhat Familiar",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1935,7 +1935,7 @@
   {
     "name": "Arc of Destruction",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1953,7 +1953,7 @@
   {
     "name": "Arms That Cut the Waves",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1971,7 +1971,7 @@
   {
     "name": "Avenger of Envy",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1989,7 +1989,7 @@
   {
     "name": "Avenger of Gluttony",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2007,7 +2007,7 @@
   {
     "name": "Avenger of Greed",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2025,7 +2025,7 @@
   {
     "name": "Avenger of Lust",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2043,7 +2043,7 @@
   {
     "name": "Avenger of Sloth",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2061,7 +2061,7 @@
   {
     "name": "Avenger of Wrath",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2079,7 +2079,7 @@
   {
     "name": "Become Destiny",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2099,7 +2099,7 @@
   {
     "name": "Become Shadow",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2117,7 +2117,7 @@
   {
     "name": "Binds That Tie",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2135,7 +2135,7 @@
   {
     "name": "Call From Death's Door",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2153,7 +2153,7 @@
   {
     "name": "Correct the Story",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2173,7 +2173,7 @@
   {
     "name": "Cutting Rebuke",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2191,7 +2191,7 @@
   {
     "name": "Divert Destiny",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2209,7 +2209,7 @@
   {
     "name": "Ears That Hear the Truth",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2227,7 +2227,7 @@
   {
     "name": "Eyes That See Eternity",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2247,7 +2247,7 @@
   {
     "name": "Feet That Stride the Sky",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2265,7 +2265,7 @@
   {
     "name": "Fiery Rebirth",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2287,7 +2287,7 @@
   {
     "name": "Fling Into Action",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2305,7 +2305,7 @@
   {
     "name": "Fool's Fleeting Plan",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2323,7 +2323,7 @@
   {
     "name": "Godspeed",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2341,7 +2341,7 @@
   {
     "name": "Hands That Unweave Disaster",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2359,7 +2359,7 @@
   {
     "name": "Hydra's Bond",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2377,7 +2377,7 @@
   {
     "name": "Mythic Allies",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2395,7 +2395,7 @@
   {
     "name": "Mythic Casting",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2415,7 +2415,7 @@
   {
     "name": "Mythic Containment",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2433,7 +2433,7 @@
   {
     "name": "Mythic Counterspell",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2451,7 +2451,7 @@
   {
     "name": "Mythic Magic",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2469,7 +2469,7 @@
   {
     "name": "Mythic Refocus",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2487,7 +2487,7 @@
   {
     "name": "Mythic Strike",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2505,7 +2505,7 @@
   {
     "name": "Prescience",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2523,7 +2523,7 @@
   {
     "name": "Read the Wind",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2541,7 +2541,7 @@
   {
     "name": "Repel Assault",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2559,7 +2559,7 @@
   {
     "name": "Sovereign's Blade",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2579,7 +2579,7 @@
   {
     "name": "Stages of Fate",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2597,7 +2597,7 @@
   {
     "name": "Steal Magic",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2615,7 +2615,7 @@
   {
     "name": "Storied Companion",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2635,7 +2635,7 @@
   {
     "name": "Summon Mythic Power",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2653,7 +2653,7 @@
   {
     "name": "Unbelievable Interception",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2671,7 +2671,7 @@
   {
     "name": "Unbelievably Believable",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2689,7 +2689,7 @@
   {
     "name": "Unbreaking Castle",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2707,7 +2707,7 @@
   {
     "name": "Unending Subsistence",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2725,7 +2725,7 @@
   {
     "name": "Unrivaled Retort",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2743,7 +2743,7 @@
   {
     "name": "We've Met Before",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2761,7 +2761,7 @@
   {
     "name": "Windborne Shove",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2779,7 +2779,7 @@
   {
     "name": "You Can't Hide From Us",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2797,7 +2797,7 @@
   {
     "name": "You Can't Keep Us Down",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2817,7 +2817,7 @@
   {
     "name": "You Can't Kill an Idea",
     "rule_type": "General Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/heritages.json
+++ b/db/seeds/pf2e/heritages.json
@@ -2,7 +2,7 @@
   {
     "name": "Coral Athamaru",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16,7 +16,7 @@
   {
     "name": "Hopeful Athamaru",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30,7 +30,7 @@
   {
     "name": "Kaleidoscopic Athamaru",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44,7 +44,7 @@
   {
     "name": "Quilled Athamaru",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -58,7 +58,7 @@
   {
     "name": "Hunter Automaton",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -72,7 +72,7 @@
   {
     "name": "Mage Automaton",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -86,7 +86,7 @@
   {
     "name": "Sharpshooter Automaton",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -100,7 +100,7 @@
   {
     "name": "Warrior Automaton",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -114,7 +114,7 @@
   {
     "name": "Climbing Animal",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -128,7 +128,7 @@
   {
     "name": "Flying Animal",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -142,7 +142,7 @@
   {
     "name": "Running Animal",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -156,7 +156,7 @@
   {
     "name": "Swimming Animal",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -170,7 +170,7 @@
   {
     "name": "Clawed Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -184,7 +184,7 @@
   {
     "name": "Hunting Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -198,7 +198,7 @@
   {
     "name": "Jungle Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -212,7 +212,7 @@
   {
     "name": "Liminal Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -226,7 +226,7 @@
   {
     "name": "Nine Lives Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -240,7 +240,7 @@
   {
     "name": "Sharp-Eared Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -254,7 +254,7 @@
   {
     "name": "Winter Catfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -268,7 +268,7 @@
   {
     "name": "Budding Speaker Centaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -282,7 +282,7 @@
   {
     "name": "Fleetwind Centaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -296,7 +296,7 @@
   {
     "name": "Ironhoof Centaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -310,7 +310,7 @@
   {
     "name": "Mottle-Coat Centaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -324,7 +324,7 @@
   {
     "name": "Ponygait Centaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -338,7 +338,7 @@
   {
     "name": "Stoutheart Centaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -352,7 +352,7 @@
   {
     "name": "Fey Dragonet",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -370,7 +370,7 @@
   {
     "name": "Homing Drake",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -384,7 +384,7 @@
   {
     "name": "House Drake",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -398,7 +398,7 @@
   {
     "name": "Pearl Dragonet",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -412,7 +412,7 @@
   {
     "name": "Tidepool Dragonet",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -430,7 +430,7 @@
   {
     "name": "Ancient-Blooded Dwarf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -444,7 +444,7 @@
   {
     "name": "Death Warden Dwarf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -458,7 +458,7 @@
   {
     "name": "Forge Dwarf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -472,7 +472,7 @@
   {
     "name": "Rock Dwarf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -486,7 +486,7 @@
   {
     "name": "Strong-Blooded Dwarf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -500,7 +500,7 @@
   {
     "name": "Ancient Elf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -514,7 +514,7 @@
   {
     "name": "Arctic Elf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -528,7 +528,7 @@
   {
     "name": "Cavern Elf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -542,7 +542,7 @@
   {
     "name": "Seer Elf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -556,7 +556,7 @@
   {
     "name": "Whisper Elf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -570,7 +570,7 @@
   {
     "name": "Woodland Elf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -584,7 +584,7 @@
   {
     "name": "Chameleon Gnome",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -598,7 +598,7 @@
   {
     "name": "Fey-Touched Gnome",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -612,7 +612,7 @@
   {
     "name": "Kijimuna Gnome",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -630,7 +630,7 @@
   {
     "name": "Sensate Gnome",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -644,7 +644,7 @@
   {
     "name": "Umbral Gnome",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -658,7 +658,7 @@
   {
     "name": "Wellspring Gnome",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -672,7 +672,7 @@
   {
     "name": "Charhide Goblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -686,7 +686,7 @@
   {
     "name": "Dokkaebi Goblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -704,7 +704,7 @@
   {
     "name": "Irongut Goblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -718,7 +718,7 @@
   {
     "name": "Razortooth Goblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -732,7 +732,7 @@
   {
     "name": "Snow Goblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -746,7 +746,7 @@
   {
     "name": "Unbreakable Goblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -760,7 +760,7 @@
   {
     "name": "Gutsy Halfling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -774,7 +774,7 @@
   {
     "name": "Hillock Halfling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -788,7 +788,7 @@
   {
     "name": "Jinxed Halfling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -802,7 +802,7 @@
   {
     "name": "Nomadic Halfling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -816,7 +816,7 @@
   {
     "name": "Twilight Halfling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -830,7 +830,7 @@
   {
     "name": "Wildwood Halfling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -844,7 +844,7 @@
   {
     "name": "Elfbane Hobgoblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -858,7 +858,7 @@
   {
     "name": "Runtboss Hobgoblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -872,7 +872,7 @@
   {
     "name": "Shortshanks Hobgoblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -886,7 +886,7 @@
   {
     "name": "Smokeworker Hobgoblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -900,7 +900,7 @@
   {
     "name": "Warmarch Hobgoblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -914,7 +914,7 @@
   {
     "name": "Warrenbred Hobgoblin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -928,7 +928,7 @@
   {
     "name": "Ambitious Human",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -942,7 +942,7 @@
   {
     "name": "Battle-Trained Human (BB)",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -956,7 +956,7 @@
   {
     "name": "Skilled Human",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -970,7 +970,7 @@
   {
     "name": "Versatile Human",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -984,7 +984,7 @@
   {
     "name": "Keeper Jotunborn",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -998,7 +998,7 @@
   {
     "name": "Plane-Hopper Jotunborn",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1012,7 +1012,7 @@
   {
     "name": "Sage Jotunborn",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1026,7 +1026,7 @@
   {
     "name": "Warrior Jotunborn",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1040,7 +1040,7 @@
   {
     "name": "Weaver Jotunborn",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1054,7 +1054,7 @@
   {
     "name": "Ant Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1068,7 +1068,7 @@
   {
     "name": "Cave Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1082,7 +1082,7 @@
   {
     "name": "Dog Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1096,7 +1096,7 @@
   {
     "name": "Great Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1110,7 +1110,7 @@
   {
     "name": "Sweetbreath Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1124,7 +1124,7 @@
   {
     "name": "Winter Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1138,7 +1138,7 @@
   {
     "name": "Witch Kholo",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1152,7 +1152,7 @@
   {
     "name": "Palace Echoes Kitsune",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1170,7 +1170,7 @@
   {
     "name": "Cavernstalker Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1184,7 +1184,7 @@
   {
     "name": "Dragonscaled Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1198,7 +1198,7 @@
   {
     "name": "Elementheart Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1212,7 +1212,7 @@
   {
     "name": "Heavenscribe Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1230,7 +1230,7 @@
   {
     "name": "Mightyfall Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1248,7 +1248,7 @@
   {
     "name": "Spellhorn Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1262,7 +1262,7 @@
   {
     "name": "Strongjaw Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1276,7 +1276,7 @@
   {
     "name": "Tunnelflood Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1290,7 +1290,7 @@
   {
     "name": "Venomtail Kobold",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1304,7 +1304,7 @@
   {
     "name": "Cactus Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1318,7 +1318,7 @@
   {
     "name": "Chrysanthemum Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1336,7 +1336,7 @@
   {
     "name": "Fruit Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1350,7 +1350,7 @@
   {
     "name": "Fungus Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1364,7 +1364,7 @@
   {
     "name": "Gourd Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1378,7 +1378,7 @@
   {
     "name": "Leaf Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1392,7 +1392,7 @@
   {
     "name": "Lotus Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1406,7 +1406,7 @@
   {
     "name": "Peachchild Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1424,7 +1424,7 @@
   {
     "name": "Root Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1438,7 +1438,7 @@
   {
     "name": "Seaweed Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1452,7 +1452,7 @@
   {
     "name": "Vine Leshy",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1466,7 +1466,7 @@
   {
     "name": "Bakuwa Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1484,7 +1484,7 @@
   {
     "name": "Cliffscale Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1498,7 +1498,7 @@
   {
     "name": "Cloudleaper Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1512,7 +1512,7 @@
   {
     "name": "Frilled Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1526,7 +1526,7 @@
   {
     "name": "Makari Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1544,7 +1544,7 @@
   {
     "name": "Sandstrider Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1558,7 +1558,7 @@
   {
     "name": "Unseen Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1572,7 +1572,7 @@
   {
     "name": "Wetlander Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1586,7 +1586,7 @@
   {
     "name": "Woodstalker Lizardfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1600,7 +1600,7 @@
   {
     "name": "Abyssal Merfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1614,7 +1614,7 @@
   {
     "name": "Carcharodon Merfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1628,7 +1628,7 @@
   {
     "name": "Pelagic Merfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1642,7 +1642,7 @@
   {
     "name": "Reef Merfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1656,7 +1656,7 @@
   {
     "name": "Sailfish Merfolk",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1670,7 +1670,7 @@
   {
     "name": "Ghost Bull Minotaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1684,7 +1684,7 @@
   {
     "name": "Glacier Cavern Minotaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1698,7 +1698,7 @@
   {
     "name": "Littlehorn Minotaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1712,7 +1712,7 @@
   {
     "name": "Roaming Minotaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1726,7 +1726,7 @@
   {
     "name": "Slabsoul Minotaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1740,7 +1740,7 @@
   {
     "name": "Stalker Minotaur",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1754,7 +1754,7 @@
   {
     "name": "Shimmertongue Nagaji",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1772,7 +1772,7 @@
   {
     "name": "Badlands Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1786,7 +1786,7 @@
   {
     "name": "Battle-Ready Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1800,7 +1800,7 @@
   {
     "name": "Deep Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1814,7 +1814,7 @@
   {
     "name": "Grave Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1828,7 +1828,7 @@
   {
     "name": "Hold-Scarred Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1842,7 +1842,7 @@
   {
     "name": "Rainfall Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1856,7 +1856,7 @@
   {
     "name": "Winter Orc",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1870,7 +1870,7 @@
   {
     "name": "Tsukumogami Poppet",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1888,7 +1888,7 @@
   {
     "name": "Deep Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1902,7 +1902,7 @@
   {
     "name": "Desert Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1916,7 +1916,7 @@
   {
     "name": "Longsnout Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1930,7 +1930,7 @@
   {
     "name": "Sewer Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1944,7 +1944,7 @@
   {
     "name": "Shadow Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1958,7 +1958,7 @@
   {
     "name": "Snow Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1972,7 +1972,7 @@
   {
     "name": "Tunnel Rat",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1986,7 +1986,7 @@
   {
     "name": "Healer Samsaran",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2004,7 +2004,7 @@
   {
     "name": "Mountaineer Samsaran",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2022,7 +2022,7 @@
   {
     "name": "Oracular Samsaran",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2040,7 +2040,7 @@
   {
     "name": "Sanctuary Samsaran",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2058,7 +2058,7 @@
   {
     "name": "Wilderness Samsaran",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2076,7 +2076,7 @@
   {
     "name": "Full Moon Sarangay",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2094,7 +2094,7 @@
   {
     "name": "Half Moon Sarangay",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2112,7 +2112,7 @@
   {
     "name": "New Moon Sarangay",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2130,7 +2130,7 @@
   {
     "name": "Waning Moon Sarangay",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2148,7 +2148,7 @@
   {
     "name": "Waxing Moon Sarangay",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2166,7 +2166,7 @@
   {
     "name": "Dijiang",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2184,7 +2184,7 @@
   {
     "name": "Gandharva",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2202,7 +2202,7 @@
   {
     "name": "Kanchil",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2220,7 +2220,7 @@
   {
     "name": "Leungli",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2238,7 +2238,7 @@
   {
     "name": "Breaker Surki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2252,7 +2252,7 @@
   {
     "name": "Elytron Surki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2266,7 +2266,7 @@
   {
     "name": "Hardshell Surki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2280,7 +2280,7 @@
   {
     "name": "Lantern Surki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2294,7 +2294,7 @@
   {
     "name": "Ascetic Tanuki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2312,7 +2312,7 @@
   {
     "name": "Courageous Tanuki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2330,7 +2330,7 @@
   {
     "name": "Even-Tempered Tanuki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2348,7 +2348,7 @@
   {
     "name": "Steadfast Tanuki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2366,7 +2366,7 @@
   {
     "name": "Virtuous Tanuki",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2384,7 +2384,7 @@
   {
     "name": "Dogtooth Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2398,7 +2398,7 @@
   {
     "name": "Jinxed Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2412,7 +2412,7 @@
   {
     "name": "Mountainkeeper Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2426,7 +2426,7 @@
   {
     "name": "Skyborn Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2440,7 +2440,7 @@
   {
     "name": "Stormtossed Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2454,7 +2454,7 @@
   {
     "name": "Taloned Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2468,7 +2468,7 @@
   {
     "name": "Wavediver Tengu",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2482,7 +2482,7 @@
   {
     "name": "Poisonhide Tripkee",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2496,7 +2496,7 @@
   {
     "name": "Riverside Tripkee",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2510,7 +2510,7 @@
   {
     "name": "Snaptongue Tripkee",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2524,7 +2524,7 @@
   {
     "name": "Stickytoe Tripkee",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2538,7 +2538,7 @@
   {
     "name": "Thickskin Tripkee",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2552,7 +2552,7 @@
   {
     "name": "Windweb Tripkee",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2566,7 +2566,7 @@
   {
     "name": "Aiuvarin",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2584,7 +2584,7 @@
   {
     "name": "Ardande",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2602,7 +2602,7 @@
   {
     "name": "Changeling",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2620,7 +2620,7 @@
   {
     "name": "Dhampir",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2638,7 +2638,7 @@
   {
     "name": "Dragonblood",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2656,7 +2656,7 @@
   {
     "name": "Dromaar",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2674,7 +2674,7 @@
   {
     "name": "Duskwalker",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2692,7 +2692,7 @@
   {
     "name": "Hungerseed",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2710,7 +2710,7 @@
   {
     "name": "Nephilim",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2728,7 +2728,7 @@
   {
     "name": "Reflection",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2746,7 +2746,7 @@
   {
     "name": "Talos",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2764,7 +2764,7 @@
   {
     "name": "Shadow of the Courtier",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2782,7 +2782,7 @@
   {
     "name": "Shadow of the Hermit",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2800,7 +2800,7 @@
   {
     "name": "Shadow of the Sailor",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2818,7 +2818,7 @@
   {
     "name": "Shadow of the Smith",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2836,7 +2836,7 @@
   {
     "name": "Shadow of the Wanderer",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2854,7 +2854,7 @@
   {
     "name": "Deny Lady Nanbyo's Charity",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2872,7 +2872,7 @@
   {
     "name": "Deny the Firstborn Pursuit",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2890,7 +2890,7 @@
   {
     "name": "Deny the Traitor's Rebirth",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2908,7 +2908,7 @@
   {
     "name": "Respite of a Thousand Roofs",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2926,7 +2926,7 @@
   {
     "name": "Respite of Cloudless Paths",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2944,7 +2944,7 @@
   {
     "name": "Respite of Loam and Leaf",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2964,7 +2964,7 @@
   {
     "name": "Born of Animal",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2982,7 +2982,7 @@
   {
     "name": "Born of Celestial",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3000,7 +3000,7 @@
   {
     "name": "Born of Elements",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3018,7 +3018,7 @@
   {
     "name": "Born of Item",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3036,7 +3036,7 @@
   {
     "name": "Born of Vegetation",
     "rule_type": "Heritage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/skill-feats.json
+++ b/db/seeds/pf2e/skill-feats.json
@@ -2,7 +2,7 @@
   {
     "name": "Acrobatic Performer",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22,7 +22,7 @@
   {
     "name": "Acupuncturist",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42,7 +42,7 @@
   {
     "name": "Additional Lore",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -61,7 +61,7 @@
   {
     "name": "Alchemical Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -81,7 +81,7 @@
   {
     "name": "Arcane Sense",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -101,7 +101,7 @@
   {
     "name": "Armor Assist",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -121,7 +121,7 @@
   {
     "name": "Assurance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -143,7 +143,7 @@
   {
     "name": "Bargain Hunter",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -163,7 +163,7 @@
   {
     "name": "Battle Medicine",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -187,7 +187,7 @@
   {
     "name": "Bon Mot",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -217,7 +217,7 @@
   {
     "name": "Cat Fall",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -237,7 +237,7 @@
   {
     "name": "Charming Liar",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -257,7 +257,7 @@
   {
     "name": "Combat Climber",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -277,7 +277,7 @@
   {
     "name": "Concealing Legerdemain",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -297,7 +297,7 @@
   {
     "name": "Courtly Graces",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -317,7 +317,7 @@
   {
     "name": "Crafter's Appraisal",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -337,7 +337,7 @@
   {
     "name": "Crystal Healing",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -361,7 +361,7 @@
   {
     "name": "Deceptive Worship",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -381,7 +381,7 @@
   {
     "name": "Dirty Trick",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -405,7 +405,7 @@
   {
     "name": "Dubious Knowledge",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -425,7 +425,7 @@
   {
     "name": "Experienced Professional",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -445,7 +445,7 @@
   {
     "name": "Experienced Smuggler",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -465,7 +465,7 @@
   {
     "name": "Experienced Tracker",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -485,7 +485,7 @@
   {
     "name": "Express Rider",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -507,7 +507,7 @@
   {
     "name": "Fascinating Performance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -527,7 +527,7 @@
   {
     "name": "Forager",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -547,7 +547,7 @@
   {
     "name": "Forensic Acumen",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -567,7 +567,7 @@
   {
     "name": "Glean Contents",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -587,7 +587,7 @@
   {
     "name": "Group Coercion",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -607,7 +607,7 @@
   {
     "name": "Group Impression",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -627,7 +627,7 @@
   {
     "name": "Hefty Hauler",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -647,7 +647,7 @@
   {
     "name": "Hobnobber",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -667,7 +667,7 @@
   {
     "name": "Impressive Performance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -687,7 +687,7 @@
   {
     "name": "Improvise Tool",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -707,7 +707,7 @@
   {
     "name": "Inoculation",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -729,7 +729,7 @@
   {
     "name": "Intimidating Glare",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -749,7 +749,7 @@
   {
     "name": "Lengthy Diversion",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -769,7 +769,7 @@
   {
     "name": "Lie to Me",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -789,7 +789,7 @@
   {
     "name": "Multilingual",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -809,7 +809,7 @@
   {
     "name": "Myth Hunter",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -823,7 +823,7 @@
   {
     "name": "Natural Medicine",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -843,7 +843,7 @@
   {
     "name": "No Cause for Alarm",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -873,7 +873,7 @@
   {
     "name": "Oddity Identification",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -893,7 +893,7 @@
   {
     "name": "Pickpocket",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -913,7 +913,7 @@
   {
     "name": "Pilgrim's Token",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -933,7 +933,7 @@
   {
     "name": "Prepare Elemental Medicine",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -955,7 +955,7 @@
   {
     "name": "Quick Coercion",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -975,7 +975,7 @@
   {
     "name": "Quick Identification",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -995,7 +995,7 @@
   {
     "name": "Quick Jump",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1015,7 +1015,7 @@
   {
     "name": "Quick Repair",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1035,7 +1035,7 @@
   {
     "name": "Quick Squeeze",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1055,7 +1055,7 @@
   {
     "name": "Read Lips",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1075,7 +1075,7 @@
   {
     "name": "Read Psychometric Resonance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1105,7 +1105,7 @@
   {
     "name": "Recognize Spell",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1127,7 +1127,7 @@
   {
     "name": "Risky Surgery",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1147,7 +1147,7 @@
   {
     "name": "Root Magic",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1167,7 +1167,7 @@
   {
     "name": "Schooled in Secrets",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1187,7 +1187,7 @@
   {
     "name": "Seasoned",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1207,7 +1207,7 @@
   {
     "name": "Sign Language",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1227,7 +1227,7 @@
   {
     "name": "Skill Training",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1247,7 +1247,7 @@
   {
     "name": "Snare Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1267,7 +1267,7 @@
   {
     "name": "Specialty Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1287,7 +1287,7 @@
   {
     "name": "Steady Balance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1307,7 +1307,7 @@
   {
     "name": "Stifle Flames",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1327,7 +1327,7 @@
   {
     "name": "Streetwise",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1347,7 +1347,7 @@
   {
     "name": "Student of the Canon",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1367,7 +1367,7 @@
   {
     "name": "Subtle Theft",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1387,7 +1387,7 @@
   {
     "name": "Survey Wildlife",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1407,7 +1407,7 @@
   {
     "name": "Terrain Expertise",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1427,7 +1427,7 @@
   {
     "name": "Terrain Stalker",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1447,7 +1447,7 @@
   {
     "name": "Titan Wrestler",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1467,7 +1467,7 @@
   {
     "name": "Train Animal",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1491,7 +1491,7 @@
   {
     "name": "Trick Magic Item",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1513,7 +1513,7 @@
   {
     "name": "Underwater Marauder",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1533,7 +1533,7 @@
   {
     "name": "Virtuosic Performer",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1553,7 +1553,7 @@
   {
     "name": "Comforting Presence",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1579,7 +1579,7 @@
   {
     "name": "Cloud Jump",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1599,7 +1599,7 @@
   {
     "name": "Craft Anything",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1619,7 +1619,7 @@
   {
     "name": "Divine Guidance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1639,7 +1639,7 @@
   {
     "name": "Legendary Codebreaker",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1659,7 +1659,7 @@
   {
     "name": "Legendary Guide",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1679,7 +1679,7 @@
   {
     "name": "Legendary Linguist",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1699,7 +1699,7 @@
   {
     "name": "Legendary Medic",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1719,7 +1719,7 @@
   {
     "name": "Legendary Negotiation",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1739,7 +1739,7 @@
   {
     "name": "Legendary Performer",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1759,7 +1759,7 @@
   {
     "name": "Legendary Professional",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1779,7 +1779,7 @@
   {
     "name": "Legendary Sneak",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1799,7 +1799,7 @@
   {
     "name": "Legendary Survivalist",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1819,7 +1819,7 @@
   {
     "name": "Legendary Tattoo Artist",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1839,7 +1839,7 @@
   {
     "name": "Legendary Thief",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1859,7 +1859,7 @@
   {
     "name": "Scare to Death",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1885,7 +1885,7 @@
   {
     "name": "Unified Theory",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1905,7 +1905,7 @@
   {
     "name": "Armored Stealth",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1925,7 +1925,7 @@
   {
     "name": "Assured Identification",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1945,7 +1945,7 @@
   {
     "name": "Aura Sight",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1971,7 +1971,7 @@
   {
     "name": "Automatic Knowledge",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1991,7 +1991,7 @@
   {
     "name": "Automatic Writing",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2017,7 +2017,7 @@
   {
     "name": "Backup Disguise",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2037,7 +2037,7 @@
   {
     "name": "Battle Planner",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2057,7 +2057,7 @@
   {
     "name": "Bonded Animal",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2079,7 +2079,7 @@
   {
     "name": "Chromotherapy",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2103,7 +2103,7 @@
   {
     "name": "Communal Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2123,7 +2123,7 @@
   {
     "name": "Confabulator",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2143,7 +2143,7 @@
   {
     "name": "Continual Recovery",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2163,7 +2163,7 @@
   {
     "name": "Discreet Inquiry",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2183,7 +2183,7 @@
   {
     "name": "Distracting Performance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2203,7 +2203,7 @@
   {
     "name": "Energy Fortification",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2217,7 +2217,7 @@
   {
     "name": "Exhort the Faithful",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2237,7 +2237,7 @@
   {
     "name": "Eyes of the City",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2257,7 +2257,7 @@
   {
     "name": "Glad-Hand",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2277,7 +2277,7 @@
   {
     "name": "Godless Healing",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2291,7 +2291,7 @@
   {
     "name": "Intimidating Prowess",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2311,7 +2311,7 @@
   {
     "name": "Inventor",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2333,7 +2333,7 @@
   {
     "name": "Lasting Coercion",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2353,7 +2353,7 @@
   {
     "name": "Lead Climber",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2373,7 +2373,7 @@
   {
     "name": "Leverage Connections",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2393,7 +2393,7 @@
   {
     "name": "Magical Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2413,7 +2413,7 @@
   {
     "name": "Magical Shorthand",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2433,7 +2433,7 @@
   {
     "name": "Mortal Healing",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2453,7 +2453,7 @@
   {
     "name": "Nimble Crawl",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2473,7 +2473,7 @@
   {
     "name": "Pei Zing Adept",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2487,7 +2487,7 @@
   {
     "name": "Performer's Treatment",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2507,7 +2507,7 @@
   {
     "name": "Powerful Leap",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2527,7 +2527,7 @@
   {
     "name": "Quick Disguise",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2547,7 +2547,7 @@
   {
     "name": "Quiet Allies",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2567,7 +2567,7 @@
   {
     "name": "Rapid Mantel",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2587,7 +2587,7 @@
   {
     "name": "Robust Recovery",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2607,7 +2607,7 @@
   {
     "name": "Rolling Landing",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2627,7 +2627,7 @@
   {
     "name": "Sanctify Water",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2647,7 +2647,7 @@
   {
     "name": "Shadow Mark",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2667,7 +2667,7 @@
   {
     "name": "Slippery Prey",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2687,7 +2687,7 @@
   {
     "name": "Sow Rumor",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2709,7 +2709,7 @@
   {
     "name": "Tattoo Artist",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2729,7 +2729,7 @@
   {
     "name": "Terrifying Resistance",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2749,7 +2749,7 @@
   {
     "name": "Tumbling Teamwork",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2769,7 +2769,7 @@
   {
     "name": "Underground Network",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2789,7 +2789,7 @@
   {
     "name": "Unmistakable Lore",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2809,7 +2809,7 @@
   {
     "name": "Unusual Treatment",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2829,7 +2829,7 @@
   {
     "name": "Vasodilation",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2843,7 +2843,7 @@
   {
     "name": "Ward Medic",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2863,7 +2863,7 @@
   {
     "name": "Wary Disarmament",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2883,7 +2883,7 @@
   {
     "name": "Aurochs-Headed",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2901,7 +2901,7 @@
   {
     "name": "Folk Dowsing",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2921,7 +2921,7 @@
   {
     "name": "Graft Technician",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2941,7 +2941,7 @@
   {
     "name": "Advanced First Aid",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2965,7 +2965,7 @@
   {
     "name": "Aerobatics Mastery",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2985,7 +2985,7 @@
   {
     "name": "Battle Cry",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3005,7 +3005,7 @@
   {
     "name": "Biographical Eye",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3027,7 +3027,7 @@
   {
     "name": "Bizarre Magic",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3047,7 +3047,7 @@
   {
     "name": "Break Curse",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3071,7 +3071,7 @@
   {
     "name": "Consult the Spirits",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3093,7 +3093,7 @@
   {
     "name": "Disturbing Knowledge",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3119,7 +3119,7 @@
   {
     "name": "Doublespeak",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3139,7 +3139,7 @@
   {
     "name": "Environmental Guide",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3159,7 +3159,7 @@
   {
     "name": "Evangelize",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3185,7 +3185,7 @@
   {
     "name": "Foil Senses",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3205,7 +3205,7 @@
   {
     "name": "Go with the Flow",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3227,7 +3227,7 @@
   {
     "name": "Impeccable Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3247,7 +3247,7 @@
   {
     "name": "Inflame Crowd",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3267,7 +3267,7 @@
   {
     "name": "Influence Nature",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3289,7 +3289,7 @@
   {
     "name": "Kip Up",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3309,7 +3309,7 @@
   {
     "name": "Monster Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3327,7 +3327,7 @@
   {
     "name": "Morphic Manipulation",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3353,7 +3353,7 @@
   {
     "name": "Paragon Battle Medicine",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3373,7 +3373,7 @@
   {
     "name": "Planar Survival",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3393,7 +3393,7 @@
   {
     "name": "Quick Climb",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3413,7 +3413,7 @@
   {
     "name": "Quick Recognition",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3433,7 +3433,7 @@
   {
     "name": "Quick Setup",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3453,7 +3453,7 @@
   {
     "name": "Quick Swim",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3473,7 +3473,7 @@
   {
     "name": "Quick Unlock",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3493,7 +3493,7 @@
   {
     "name": "Rapid Affixture",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3513,7 +3513,7 @@
   {
     "name": "Shameless Request",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3533,7 +3533,7 @@
   {
     "name": "Signature Crafting",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3553,7 +3553,7 @@
   {
     "name": "Skeptic's Defense",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3573,7 +3573,7 @@
   {
     "name": "Slippery Secrets",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3593,7 +3593,7 @@
   {
     "name": "Swift Sneak",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3613,7 +3613,7 @@
   {
     "name": "Talent Envy",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3633,7 +3633,7 @@
   {
     "name": "Temperature Adjustment",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3647,7 +3647,7 @@
   {
     "name": "Terrified Retreat",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3667,7 +3667,7 @@
   {
     "name": "Tumbling Theft",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3687,7 +3687,7 @@
   {
     "name": "Vanish Into the Land",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3707,7 +3707,7 @@
   {
     "name": "Wall Jump",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3727,7 +3727,7 @@
   {
     "name": "Water Sprint",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3747,7 +3747,7 @@
   {
     "name": "Calm and Centered",
     "rule_type": "Skill Feat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/spells.json
+++ b/db/seeds/pf2e/spells.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Aberrant Whispers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27,7 +27,7 @@
   },
   {
     "name": "Accelerated Decomposition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -53,7 +53,7 @@
   },
   {
     "name": "Access Lore",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -78,7 +78,7 @@
   },
   {
     "name": "Achaekek's Clutch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -104,7 +104,7 @@
   },
   {
     "name": "Adapt Self",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -130,7 +130,7 @@
   },
   {
     "name": "Adaptive Ablation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -154,7 +154,7 @@
   },
   {
     "name": "Agile Feet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -178,7 +178,7 @@
   },
   {
     "name": "All-Encompassing Hunger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -204,7 +204,7 @@
   },
   {
     "name": "Allegro",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -231,7 +231,7 @@
   },
   {
     "name": "Ancestral Defense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -257,7 +257,7 @@
   },
   {
     "name": "Ancestral Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -282,7 +282,7 @@
   },
   {
     "name": "Ancestral Memories",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -306,7 +306,7 @@
   },
   {
     "name": "Ancestral Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -333,7 +333,7 @@
   },
   {
     "name": "Angelic Halo",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -359,7 +359,7 @@
   },
   {
     "name": "Angelic Wings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -385,7 +385,7 @@
   },
   {
     "name": "Animal Feature",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -411,7 +411,7 @@
   },
   {
     "name": "Appearance of Wealth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -437,7 +437,7 @@
   },
   {
     "name": "Arcane Countermeasure",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -461,7 +461,7 @@
   },
   {
     "name": "Arcane Explosion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -487,7 +487,7 @@
   },
   {
     "name": "Armor of Bones",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -511,7 +511,7 @@
   },
   {
     "name": "Arms of Nature",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -537,7 +537,7 @@
   },
   {
     "name": "Artistic Flourish",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -562,7 +562,7 @@
   },
   {
     "name": "Ashen Wind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -587,7 +587,7 @@
   },
   {
     "name": "Asterism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -613,7 +613,7 @@
   },
   {
     "name": "Astral Rain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -639,7 +639,7 @@
   },
   {
     "name": "Athletic Rush",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -663,7 +663,7 @@
   },
   {
     "name": "Augmented Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -688,7 +688,7 @@
   },
   {
     "name": "Barbed Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -714,7 +714,7 @@
   },
   {
     "name": "Battlefield Persistence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -738,7 +738,7 @@
   },
   {
     "name": "Bit of Luck",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -764,7 +764,7 @@
   },
   {
     "name": "Blood in the Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -791,7 +791,7 @@
   },
   {
     "name": "Blood Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -816,7 +816,7 @@
   },
   {
     "name": "Bottle the Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -841,7 +841,7 @@
   },
   {
     "name": "Brain Drain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -867,7 +867,7 @@
   },
   {
     "name": "Buzzing Bites",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -892,7 +892,7 @@
   },
   {
     "name": "Cackle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -917,7 +917,7 @@
   },
   {
     "name": "Call the Ten",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -941,7 +941,7 @@
   },
   {
     "name": "Canopy Crawler",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -967,7 +967,7 @@
   },
   {
     "name": "Capital Dividend",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -991,7 +991,7 @@
   },
   {
     "name": "Captivating Adoration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1020,7 +1020,7 @@
   },
   {
     "name": "Celestial Brand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1045,7 +1045,7 @@
   },
   {
     "name": "Censure Falsehoods",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1072,7 +1072,7 @@
   },
   {
     "name": "Champion's Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1096,7 +1096,7 @@
   },
   {
     "name": "Charged Javelin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1123,7 +1123,7 @@
   },
   {
     "name": "Charming Push",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1149,7 +1149,7 @@
   },
   {
     "name": "Charming Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1177,7 +1177,7 @@
   },
   {
     "name": "Chastising Retort",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1202,7 +1202,7 @@
   },
   {
     "name": "Chthonian Wrath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1227,7 +1227,7 @@
   },
   {
     "name": "Cinder Gaze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1253,7 +1253,7 @@
   },
   {
     "name": "Claim Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1279,7 +1279,7 @@
   },
   {
     "name": "Clinging Ice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1305,7 +1305,7 @@
   },
   {
     "name": "Clinging Shadows Stance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1331,7 +1331,7 @@
   },
   {
     "name": "Cloak of Shadow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1358,7 +1358,7 @@
   },
   {
     "name": "Clouded Focus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1383,7 +1383,7 @@
   },
   {
     "name": "Combustion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1408,7 +1408,7 @@
   },
   {
     "name": "Commanding Lash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1435,7 +1435,7 @@
   },
   {
     "name": "Community Restoration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1460,7 +1460,7 @@
   },
   {
     "name": "Competitive Edge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1486,7 +1486,7 @@
   },
   {
     "name": "Confront Selves",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1512,7 +1512,7 @@
   },
   {
     "name": "Conjured Clockwork",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1537,7 +1537,7 @@
   },
   {
     "name": "Contagious Idea",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1564,7 +1564,7 @@
   },
   {
     "name": "Cornucopia",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1592,7 +1592,7 @@
   },
   {
     "name": "Counter Performance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1620,7 +1620,7 @@
   },
   {
     "name": "Courageous Anthem",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1647,7 +1647,7 @@
   },
   {
     "name": "Creative Splash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1674,7 +1674,7 @@
   },
   {
     "name": "Crescent Scepter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1702,7 +1702,7 @@
   },
   {
     "name": "Crown of Prophets",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1726,7 +1726,7 @@
   },
   {
     "name": "Crushing Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1751,7 +1751,7 @@
   },
   {
     "name": "Cry of Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1777,7 +1777,7 @@
   },
   {
     "name": "Curse of Death",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1806,7 +1806,7 @@
   },
   {
     "name": "Cutting Eye",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1830,7 +1830,7 @@
   },
   {
     "name": "Dancing Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1855,7 +1855,7 @@
   },
   {
     "name": "Darkened Forest Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1879,7 +1879,7 @@
   },
   {
     "name": "Darkened Sight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1905,7 +1905,7 @@
   },
   {
     "name": "Dazzling Flash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1932,7 +1932,7 @@
   },
   {
     "name": "Death's Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1956,7 +1956,7 @@
   },
   {
     "name": "Debilitating Terror",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1983,7 +1983,7 @@
   },
   {
     "name": "Deceiver's Cloak",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2010,7 +2010,7 @@
   },
   {
     "name": "Delay Affliction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2037,7 +2037,7 @@
   },
   {
     "name": "Delay Consequence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2061,7 +2061,7 @@
   },
   {
     "name": "Delusional Pride",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2088,7 +2088,7 @@
   },
   {
     "name": "Destructive Aura",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2114,7 +2114,7 @@
   },
   {
     "name": "Devouring Dark Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2138,7 +2138,7 @@
   },
   {
     "name": "Diabolic Edict",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2162,7 +2162,7 @@
   },
   {
     "name": "Diamond Dust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2189,7 +2189,7 @@
   },
   {
     "name": "Dirge of Doom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2217,7 +2217,7 @@
   },
   {
     "name": "Discern Secrets",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2242,7 +2242,7 @@
   },
   {
     "name": "Discomfiting Whispers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2268,7 +2268,7 @@
   },
   {
     "name": "Disperse into Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2294,7 +2294,7 @@
   },
   {
     "name": "Distortion Lens",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2318,7 +2318,7 @@
   },
   {
     "name": "Distracting Decoy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2343,7 +2343,7 @@
   },
   {
     "name": "Divine Plagues",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2369,7 +2369,7 @@
   },
   {
     "name": "Door to Beyond",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2394,7 +2394,7 @@
   },
   {
     "name": "Downpour",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2420,7 +2420,7 @@
   },
   {
     "name": "Draconic Barrage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2445,7 +2445,7 @@
   },
   {
     "name": "Dragon Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2470,7 +2470,7 @@
   },
   {
     "name": "Dragon Wings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2496,7 +2496,7 @@
   },
   {
     "name": "Drain Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2521,7 +2521,7 @@
   },
   {
     "name": "Dread Secret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2549,7 +2549,7 @@
   },
   {
     "name": "Dreamer's Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2577,7 +2577,7 @@
   },
   {
     "name": "Dust Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2604,7 +2604,7 @@
   },
   {
     "name": "Dutiful Challenge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2629,7 +2629,7 @@
   },
   {
     "name": "Earth's Bile",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2654,7 +2654,7 @@
   },
   {
     "name": "Earthworks",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2680,7 +2680,7 @@
   },
   {
     "name": "Ectoplasmic Interstice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2705,7 +2705,7 @@
   },
   {
     "name": "Eject Soul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2731,7 +2731,7 @@
   },
   {
     "name": "Elemental Betrayal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2756,7 +2756,7 @@
   },
   {
     "name": "Elemental Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2781,7 +2781,7 @@
   },
   {
     "name": "Elemental Motion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2806,7 +2806,7 @@
   },
   {
     "name": "Elemental Sheath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2830,7 +2830,7 @@
   },
   {
     "name": "Elemental Toss",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2855,7 +2855,7 @@
   },
   {
     "name": "Embodiment of Battle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2878,7 +2878,7 @@
   },
   {
     "name": "Embrace Nothingness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2903,7 +2903,7 @@
   },
   {
     "name": "Embrace the Pit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2928,7 +2928,7 @@
   },
   {
     "name": "Empty Inside",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2953,7 +2953,7 @@
   },
   {
     "name": "Enduring Might",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2977,7 +2977,7 @@
   },
   {
     "name": "Energy Absorption",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3000,7 +3000,7 @@
   },
   {
     "name": "Enlarge Companion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3026,7 +3026,7 @@
   },
   {
     "name": "Entreat Spirit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3050,7 +3050,7 @@
   },
   {
     "name": "Entreat the Many",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3074,7 +3074,7 @@
   },
   {
     "name": "Entropic Wheel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3100,7 +3100,7 @@
   },
   {
     "name": "Ephemeral Hazards",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3128,7 +3128,7 @@
   },
   {
     "name": "Ephemeral Tracking",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3153,7 +3153,7 @@
   },
   {
     "name": "Eradicate Undeath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3179,7 +3179,7 @@
   },
   {
     "name": "Euphoric Renewal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3204,7 +3204,7 @@
   },
   {
     "name": "Evil Eye",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3230,7 +3230,7 @@
   },
   {
     "name": "Extend Blood Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3255,7 +3255,7 @@
   },
   {
     "name": "Face in the Crowd",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3280,7 +3280,7 @@
   },
   {
     "name": "Faerie Dust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3306,7 +3306,7 @@
   },
   {
     "name": "Fallow Field",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3332,7 +3332,7 @@
   },
   {
     "name": "Fatal Aria",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3360,7 +3360,7 @@
   },
   {
     "name": "Fearful Feast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3386,7 +3386,7 @@
   },
   {
     "name": "Fey Disappearance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3410,7 +3410,7 @@
   },
   {
     "name": "Fey Glamour",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3436,7 +3436,7 @@
   },
   {
     "name": "Fire Ray",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3463,7 +3463,7 @@
   },
   {
     "name": "Flame Barrier",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3487,7 +3487,7 @@
   },
   {
     "name": "Flaming Fusillade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3513,7 +3513,7 @@
   },
   {
     "name": "Flurry of Claws",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3539,7 +3539,7 @@
   },
   {
     "name": "Font of Serenity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3566,7 +3566,7 @@
   },
   {
     "name": "Forbidden Thought",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3592,7 +3592,7 @@
   },
   {
     "name": "Force Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3617,7 +3617,7 @@
   },
   {
     "name": "Foresee the Path",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3641,7 +3641,7 @@
   },
   {
     "name": "Fortify Summoning",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3665,7 +3665,7 @@
   },
   {
     "name": "Fortissimo Composition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3690,7 +3690,7 @@
   },
   {
     "name": "Foul Miasma",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3716,7 +3716,7 @@
   },
   {
     "name": "Frenzied Revelry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3743,7 +3743,7 @@
   },
   {
     "name": "Friendly Push",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3768,7 +3768,7 @@
   },
   {
     "name": "Fungal Exhalation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3794,7 +3794,7 @@
   },
   {
     "name": "Garden of Healing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3821,7 +3821,7 @@
   },
   {
     "name": "Ghostly Shift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3845,7 +3845,7 @@
   },
   {
     "name": "Ghostly Transcription",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3871,7 +3871,7 @@
   },
   {
     "name": "Gift of the Anemos",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3896,7 +3896,7 @@
   },
   {
     "name": "Glimpse the Truth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3922,7 +3922,7 @@
   },
   {
     "name": "Glimpse Weakness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3946,7 +3946,7 @@
   },
   {
     "name": "Gluttonous Growth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3972,7 +3972,7 @@
   },
   {
     "name": "Glutton's Jaws",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3998,7 +3998,7 @@
   },
   {
     "name": "Grasping Grave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4023,7 +4023,7 @@
   },
   {
     "name": "Grasping Vine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4050,7 +4050,7 @@
   },
   {
     "name": "Gravity Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4073,7 +4073,7 @@
   },
   {
     "name": "Guided Introspection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4099,7 +4099,7 @@
   },
   {
     "name": "Halcyon Mists",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4124,7 +4124,7 @@
   },
   {
     "name": "Hand of the Apprentice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4149,7 +4149,7 @@
   },
   {
     "name": "Harmonize Self",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4175,7 +4175,7 @@
   },
   {
     "name": "Heal Animal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4201,7 +4201,7 @@
   },
   {
     "name": "Heal Companion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4226,7 +4226,7 @@
   },
   {
     "name": "Healer's Blessing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4250,7 +4250,7 @@
   },
   {
     "name": "Heart's Hook",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4277,7 +4277,7 @@
   },
   {
     "name": "Hedge Prison",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4302,7 +4302,7 @@
   },
   {
     "name": "Hellfire Plume",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4329,7 +4329,7 @@
   },
   {
     "name": "Hero's Defiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4355,7 +4355,7 @@
   },
   {
     "name": "Hollow Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4383,7 +4383,7 @@
   },
   {
     "name": "Hologram Cage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4410,7 +4410,7 @@
   },
   {
     "name": "Home Among Mulberry Leaves",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4434,7 +4434,7 @@
   },
   {
     "name": "Horrific Visage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4464,7 +4464,7 @@
   },
   {
     "name": "House of Imaginary Walls",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4491,7 +4491,7 @@
   },
   {
     "name": "Hunter's Luck",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4516,7 +4516,7 @@
   },
   {
     "name": "Hunter's Vision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4540,7 +4540,7 @@
   },
   {
     "name": "Hurtling Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4566,7 +4566,7 @@
   },
   {
     "name": "Hymn of Healing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4593,7 +4593,7 @@
   },
   {
     "name": "Ignite Ambition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4620,7 +4620,7 @@
   },
   {
     "name": "Imaginary Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4647,7 +4647,7 @@
   },
   {
     "name": "Imitate Fauna",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4673,7 +4673,7 @@
   },
   {
     "name": "Impaling Briars",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4700,7 +4700,7 @@
   },
   {
     "name": "Incendiary Ashes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4726,7 +4726,7 @@
   },
   {
     "name": "Incendiary Aura",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4753,7 +4753,7 @@
   },
   {
     "name": "Inevitable Destination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4778,7 +4778,7 @@
   },
   {
     "name": "Information Overload",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4804,7 +4804,7 @@
   },
   {
     "name": "Inner Upheaval",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4828,7 +4828,7 @@
   },
   {
     "name": "Interdisciplinary Incantation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4852,7 +4852,7 @@
   },
   {
     "name": "Interstellar Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4878,7 +4878,7 @@
   },
   {
     "name": "Invisibility Cloak",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4903,7 +4903,7 @@
   },
   {
     "name": "Isolation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4929,7 +4929,7 @@
   },
   {
     "name": "Jealous Hex",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4954,7 +4954,7 @@
   },
   {
     "name": "Keen Smell",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4980,7 +4980,7 @@
   },
   {
     "name": "Know the Enemy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5005,7 +5005,7 @@
   },
   {
     "name": "Lament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5033,7 +5033,7 @@
   },
   {
     "name": "Lay on Hands",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5059,7 +5059,7 @@
   },
   {
     "name": "Let Not the Fallen Rest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5085,7 +5085,7 @@
   },
   {
     "name": "Life Boost",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5112,7 +5112,7 @@
   },
   {
     "name": "Life-Giving Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5140,7 +5140,7 @@
   },
   {
     "name": "Life Link",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5166,7 +5166,7 @@
   },
   {
     "name": "Lift Nature's Caul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5193,7 +5193,7 @@
   },
   {
     "name": "Lingering Composition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5218,7 +5218,7 @@
   },
   {
     "name": "Localized Quake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5244,7 +5244,7 @@
   },
   {
     "name": "Loremaster's Etude",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5270,7 +5270,7 @@
   },
   {
     "name": "Lucky Break",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5295,7 +5295,7 @@
   },
   {
     "name": "Luminous Stardust Healing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5321,7 +5321,7 @@
   },
   {
     "name": "Magic Hide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5345,7 +5345,7 @@
   },
   {
     "name": "Magic's Vessel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5369,7 +5369,7 @@
   },
   {
     "name": "Malicious Shadow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5397,7 +5397,7 @@
   },
   {
     "name": "Malignant Sustenance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5423,7 +5423,7 @@
   },
   {
     "name": "Manifest Will",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5449,7 +5449,7 @@
   },
   {
     "name": "Manifold Lives",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5476,7 +5476,7 @@
   },
   {
     "name": "Mantis Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5501,7 +5501,7 @@
   },
   {
     "name": "Medusa's Wrath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5526,7 +5526,7 @@
   },
   {
     "name": "Menacing Lament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5552,7 +5552,7 @@
   },
   {
     "name": "Moonbeam",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5580,7 +5580,7 @@
   },
   {
     "name": "Moonlight Bridge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5606,7 +5606,7 @@
   },
   {
     "name": "Murmuration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5632,7 +5632,7 @@
   },
   {
     "name": "Mushroom Patch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5657,7 +5657,7 @@
   },
   {
     "name": "Mycological Malady",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5684,7 +5684,7 @@
   },
   {
     "name": "Mystic Beacon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5708,7 +5708,7 @@
   },
   {
     "name": "Nature's Bounty",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5734,7 +5734,7 @@
   },
   {
     "name": "Needle of Vengeance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5760,7 +5760,7 @@
   },
   {
     "name": "Nudge Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5785,7 +5785,7 @@
   },
   {
     "name": "Nymph's Grace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5813,7 +5813,7 @@
   },
   {
     "name": "Object Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5838,7 +5838,7 @@
   },
   {
     "name": "Ode to Ouroboros",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5863,7 +5863,7 @@
   },
   {
     "name": "Omnidirectional Scan",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5888,7 +5888,7 @@
   },
   {
     "name": "Over the Coals",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5915,7 +5915,7 @@
   },
   {
     "name": "Overflowing Sorrow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5944,7 +5944,7 @@
   },
   {
     "name": "Overstuff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5969,7 +5969,7 @@
   },
   {
     "name": "Pack Breaker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5995,7 +5995,7 @@
   },
   {
     "name": "Pact Broker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6023,7 +6023,7 @@
   },
   {
     "name": "Parch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6049,7 +6049,7 @@
   },
   {
     "name": "Path of Least Resistance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6072,7 +6072,7 @@
   },
   {
     "name": "Patron's Puppet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6096,7 +6096,7 @@
   },
   {
     "name": "Perfected Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6120,7 +6120,7 @@
   },
   {
     "name": "Perfected Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6144,7 +6144,7 @@
   },
   {
     "name": "Personal Blizzard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6169,7 +6169,7 @@
   },
   {
     "name": "Personal Runewell",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6194,7 +6194,7 @@
   },
   {
     "name": "Phase Familiar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6219,7 +6219,7 @@
   },
   {
     "name": "Pied Piping",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6247,7 +6247,7 @@
   },
   {
     "name": "Powerful Inhalation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6272,7 +6272,7 @@
   },
   {
     "name": "Practice Makes Perfect",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6296,7 +6296,7 @@
   },
   {
     "name": "Precious Gleam",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6322,7 +6322,7 @@
   },
   {
     "name": "Precious Metals",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6347,7 +6347,7 @@
   },
   {
     "name": "Primal Summons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6371,7 +6371,7 @@
   },
   {
     "name": "Protective Wards",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6396,7 +6396,7 @@
   },
   {
     "name": "Protector's Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6420,7 +6420,7 @@
   },
   {
     "name": "Protector's Sphere",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6446,7 +6446,7 @@
   },
   {
     "name": "Pulse of Civilization",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6472,7 +6472,7 @@
   },
   {
     "name": "Pulverizing Cascade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6497,7 +6497,7 @@
   },
   {
     "name": "Pulverizing Wake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6524,7 +6524,7 @@
   },
   {
     "name": "Purging Toxins",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6550,7 +6550,7 @@
   },
   {
     "name": "Purifying Veil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6578,7 +6578,7 @@
   },
   {
     "name": "Pushing Gust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6604,7 +6604,7 @@
   },
   {
     "name": "Qi Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6630,7 +6630,7 @@
   },
   {
     "name": "Qi Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6655,7 +6655,7 @@
   },
   {
     "name": "Qi Rush",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6679,7 +6679,7 @@
   },
   {
     "name": "Rallying Anthem",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6706,7 +6706,7 @@
   },
   {
     "name": "Ranger's Bramble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6732,7 +6732,7 @@
   },
   {
     "name": "Rapid Retreat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6756,7 +6756,7 @@
   },
   {
     "name": "Read Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6782,7 +6782,7 @@
   },
   {
     "name": "Rebuke Death",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6808,7 +6808,7 @@
   },
   {
     "name": "Reclined Apport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6834,7 +6834,7 @@
   },
   {
     "name": "Redact",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6859,7 +6859,7 @@
   },
   {
     "name": "Redistribute Potential",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6886,7 +6886,7 @@
   },
   {
     "name": "Remember the Lost",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6912,7 +6912,7 @@
   },
   {
     "name": "Repel Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6938,7 +6938,7 @@
   },
   {
     "name": "Restorative Moment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6964,7 +6964,7 @@
   },
   {
     "name": "Retributive Pain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6990,7 +6990,7 @@
   },
   {
     "name": "Return the Favor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7015,7 +7015,7 @@
   },
   {
     "name": "Revel in Retribution",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7041,7 +7041,7 @@
   },
   {
     "name": "Rising Surf",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7066,7 +7066,7 @@
   },
   {
     "name": "River Carving Mountains",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7090,7 +7090,7 @@
   },
   {
     "name": "Roar of the Dragon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7118,7 +7118,7 @@
   },
   {
     "name": "Rune of Observation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7142,7 +7142,7 @@
   },
   {
     "name": "Safeguard Secret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7168,7 +7168,7 @@
   },
   {
     "name": "Savor the Sting",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7194,7 +7194,7 @@
   },
   {
     "name": "Scholarly Recollection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7219,7 +7219,7 @@
   },
   {
     "name": "Scramble Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7244,7 +7244,7 @@
   },
   {
     "name": "Scrounger's Glee",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7272,7 +7272,7 @@
   },
   {
     "name": "Serrate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7297,7 +7297,7 @@
   },
   {
     "name": "Shadow's Web",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7322,7 +7322,7 @@
   },
   {
     "name": "Shaken Confidence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7349,7 +7349,7 @@
   },
   {
     "name": "Share Burden",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7374,7 +7374,7 @@
   },
   {
     "name": "Share Vision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7399,7 +7399,7 @@
   },
   {
     "name": "Shared Nightmare",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7427,7 +7427,7 @@
   },
   {
     "name": "Shatter Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7453,7 +7453,7 @@
   },
   {
     "name": "Sheltering Wings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7478,7 +7478,7 @@
   },
   {
     "name": "Shielding Formation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7504,7 +7504,7 @@
   },
   {
     "name": "Shields of the Spirit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7530,7 +7530,7 @@
   },
   {
     "name": "Shifting Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7555,7 +7555,7 @@
   },
   {
     "name": "Shining Starlight Attack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7579,7 +7579,7 @@
   },
   {
     "name": "Show the Path",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7605,7 +7605,7 @@
   },
   {
     "name": "Shrink the Span",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7630,7 +7630,7 @@
   },
   {
     "name": "Shroud of Night",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7656,7 +7656,7 @@
   },
   {
     "name": "Shroud of the Mantis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7681,7 +7681,7 @@
   },
   {
     "name": "Sky Laughs at Waves",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7705,7 +7705,7 @@
   },
   {
     "name": "Slime Spit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7731,7 +7731,7 @@
   },
   {
     "name": "Song of Marching",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7757,7 +7757,7 @@
   },
   {
     "name": "Song of Strength",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7784,7 +7784,7 @@
   },
   {
     "name": "Songbird's Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7810,7 +7810,7 @@
   },
   {
     "name": "Soothing Ballad",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7839,7 +7839,7 @@
   },
   {
     "name": "Soothing Mist",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7866,7 +7866,7 @@
   },
   {
     "name": "Soothing Words",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7892,7 +7892,7 @@
   },
   {
     "name": "Soul Siphon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7917,7 +7917,7 @@
   },
   {
     "name": "Spectral Advance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7943,7 +7943,7 @@
   },
   {
     "name": "Spellsurge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7967,7 +7967,7 @@
   },
   {
     "name": "Spiral of Horrors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7996,7 +7996,7 @@
   },
   {
     "name": "Spirit Object",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8021,7 +8021,7 @@
   },
   {
     "name": "Spirit of the Beast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8045,7 +8045,7 @@
   },
   {
     "name": "Spray of Stars",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8072,7 +8072,7 @@
   },
   {
     "name": "Stasis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8098,7 +8098,7 @@
   },
   {
     "name": "Sting of the Sea",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8123,7 +8123,7 @@
   },
   {
     "name": "Stoke the Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8149,7 +8149,7 @@
   },
   {
     "name": "Stone Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8175,7 +8175,7 @@
   },
   {
     "name": "Store Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8198,7 +8198,7 @@
   },
   {
     "name": "Storm Lord",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8225,7 +8225,7 @@
   },
   {
     "name": "Stormwind Flight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8251,7 +8251,7 @@
   },
   {
     "name": "String of Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8276,7 +8276,7 @@
   },
   {
     "name": "Sudden Shift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8300,7 +8300,7 @@
   },
   {
     "name": "Swamp of Sloth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8326,7 +8326,7 @@
   },
   {
     "name": "Swarm Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8352,7 +8352,7 @@
   },
   {
     "name": "Swarmsense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8377,7 +8377,7 @@
   },
   {
     "name": "Swear Oath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8401,7 +8401,7 @@
   },
   {
     "name": "Sweet Dream",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8430,7 +8430,7 @@
   },
   {
     "name": "Symphony of the Unfettered Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8456,7 +8456,7 @@
   },
   {
     "name": "Take its Course",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8481,7 +8481,7 @@
   },
   {
     "name": "Telekinetic Rend",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8506,7 +8506,7 @@
   },
   {
     "name": "Tempest Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8532,7 +8532,7 @@
   },
   {
     "name": "Tempest Surge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8559,7 +8559,7 @@
   },
   {
     "name": "Tempest Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8585,7 +8585,7 @@
   },
   {
     "name": "Temporal Distortion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8609,7 +8609,7 @@
   },
   {
     "name": "Tempt Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8634,7 +8634,7 @@
   },
   {
     "name": "Tentacular Limbs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8659,7 +8659,7 @@
   },
   {
     "name": "Terrain Transposition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8685,7 +8685,7 @@
   },
   {
     "name": "Tesseract Tunnel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8711,7 +8711,7 @@
   },
   {
     "name": "Thermal Stasis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8735,7 +8735,7 @@
   },
   {
     "name": "Threatening Mimicry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8764,7 +8764,7 @@
   },
   {
     "name": "Thunderburst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8791,7 +8791,7 @@
   },
   {
     "name": "Tidal Surge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8816,7 +8816,7 @@
   },
   {
     "name": "Time Skip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8840,7 +8840,7 @@
   },
   {
     "name": "Tireless Worker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8866,7 +8866,7 @@
   },
   {
     "name": "Touch of Death",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8892,7 +8892,7 @@
   },
   {
     "name": "Touch of Obedience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8917,7 +8917,7 @@
   },
   {
     "name": "Touch of the Moon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8942,7 +8942,7 @@
   },
   {
     "name": "Touch of the Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8967,7 +8967,7 @@
   },
   {
     "name": "Touch of Undeath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8992,7 +8992,7 @@
   },
   {
     "name": "Trade Death for Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9018,7 +9018,7 @@
   },
   {
     "name": "Traveler's Transit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9043,7 +9043,7 @@
   },
   {
     "name": "Traveling Workshop",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9067,7 +9067,7 @@
   },
   {
     "name": "Trickster's Mirrors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9093,7 +9093,7 @@
   },
   {
     "name": "Trickster's Twin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9120,7 +9120,7 @@
   },
   {
     "name": "Triple Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9147,7 +9147,7 @@
   },
   {
     "name": "Turbulent Tide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9172,7 +9172,7 @@
   },
   {
     "name": "Ulcerous Canker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9199,7 +9199,7 @@
   },
   {
     "name": "Undeath's Blessing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9224,7 +9224,7 @@
   },
   {
     "name": "Unexpected Windfall",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9250,7 +9250,7 @@
   },
   {
     "name": "Unimpeded Stride",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9274,7 +9274,7 @@
   },
   {
     "name": "Unity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9299,7 +9299,7 @@
   },
   {
     "name": "Unravel Knowledge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9326,7 +9326,7 @@
   },
   {
     "name": "Unsettling Knowledge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9352,7 +9352,7 @@
   },
   {
     "name": "Untamed Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9378,7 +9378,7 @@
   },
   {
     "name": "Untamed Shift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9404,7 +9404,7 @@
   },
   {
     "name": "Unusual Anatomy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9429,7 +9429,7 @@
   },
   {
     "name": "Updraft",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9454,7 +9454,7 @@
   },
   {
     "name": "Uplifting Overture",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9481,7 +9481,7 @@
   },
   {
     "name": "Valiant Anthem",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9507,7 +9507,7 @@
   },
   {
     "name": "Vector Screen",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9532,7 +9532,7 @@
   },
   {
     "name": "Veil of Confidence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9557,7 +9557,7 @@
   },
   {
     "name": "Veil of Dreams",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9583,7 +9583,7 @@
   },
   {
     "name": "Vengeful Glare",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9607,7 +9607,7 @@
   },
   {
     "name": "Vibrant Thorns",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9634,7 +9634,7 @@
   },
   {
     "name": "Vicious Howl",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9657,7 +9657,7 @@
   },
   {
     "name": "Victory Cry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9682,7 +9682,7 @@
   },
   {
     "name": "Vindicator's Judgment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9705,7 +9705,7 @@
   },
   {
     "name": "Vindicator's Mark",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9730,7 +9730,7 @@
   },
   {
     "name": "Waking Dream",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9755,7 +9755,7 @@
   },
   {
     "name": "Waking Nightmare",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9783,7 +9783,7 @@
   },
   {
     "name": "Warning Stripes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9809,7 +9809,7 @@
   },
   {
     "name": "Weapon Surge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9834,7 +9834,7 @@
   },
   {
     "name": "Weapon Trance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9858,7 +9858,7 @@
   },
   {
     "name": "Weaponize Secret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9884,7 +9884,7 @@
   },
   {
     "name": "Whirling Flames",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9910,7 +9910,7 @@
   },
   {
     "name": "Whispering Quiet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9935,7 +9935,7 @@
   },
   {
     "name": "Wild Winds Stance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9961,7 +9961,7 @@
   },
   {
     "name": "Wildfire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9986,7 +9986,7 @@
   },
   {
     "name": "Wilding Word",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10011,7 +10011,7 @@
   },
   {
     "name": "Wind Jump",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10036,7 +10036,7 @@
   },
   {
     "name": "Wind Whispers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10063,7 +10063,7 @@
   },
   {
     "name": "Wings of the Valkyrie",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10088,7 +10088,7 @@
   },
   {
     "name": "Winter Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10115,7 +10115,7 @@
   },
   {
     "name": "Withering Grasp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10142,7 +10142,7 @@
   },
   {
     "name": "Wood Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10168,7 +10168,7 @@
   },
   {
     "name": "Word of Freedom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10193,7 +10193,7 @@
   },
   {
     "name": "Word of Truth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10217,7 +10217,7 @@
   },
   {
     "name": "Wordsmith",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10242,7 +10242,7 @@
   },
   {
     "name": "You're Mine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10270,7 +10270,7 @@
   },
   {
     "name": "Zeal for Battle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10297,7 +10297,7 @@
   },
   {
     "name": "Zenith Star",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10323,7 +10323,7 @@
   },
   {
     "name": "Angelic Messenger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10343,7 +10343,7 @@
   },
   {
     "name": "Animate Object",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10363,7 +10363,7 @@
   },
   {
     "name": "Antimagic Artifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10383,7 +10383,7 @@
   },
   {
     "name": "Army of Shadows",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10405,7 +10405,7 @@
   },
   {
     "name": "Ash-Strewn Ending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10428,7 +10428,7 @@
   },
   {
     "name": "Astral Projection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10448,7 +10448,7 @@
   },
   {
     "name": "Atone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10468,7 +10468,7 @@
   },
   {
     "name": "Awaken Animal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10490,7 +10490,7 @@
   },
   {
     "name": "Awaken Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10512,7 +10512,7 @@
   },
   {
     "name": "Bacchanalia",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10535,7 +10535,7 @@
   },
   {
     "name": "Bacchanalia",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10558,7 +10558,7 @@
   },
   {
     "name": "Band of Heroes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10580,7 +10580,7 @@
   },
   {
     "name": "Binding Circle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10600,7 +10600,7 @@
   },
   {
     "name": "Blight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10623,7 +10623,7 @@
   },
   {
     "name": "Bonding Meal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10643,7 +10643,7 @@
   },
   {
     "name": "Bountiful Oasis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10665,7 +10665,7 @@
   },
   {
     "name": "Butterfly Bender",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10685,7 +10685,7 @@
   },
   {
     "name": "Call Spirit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10705,7 +10705,7 @@
   },
   {
     "name": "City of Sin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10729,7 +10729,7 @@
   },
   {
     "name": "Clone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10749,7 +10749,7 @@
   },
   {
     "name": "Collective Memories",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10769,7 +10769,7 @@
   },
   {
     "name": "Commune with Corazal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10789,7 +10789,7 @@
   },
   {
     "name": "Commune",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10811,7 +10811,7 @@
   },
   {
     "name": "Consecrate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10833,7 +10833,7 @@
   },
   {
     "name": "Construct Mindscape",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10855,7 +10855,7 @@
   },
   {
     "name": "Contact Friends",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10875,7 +10875,7 @@
   },
   {
     "name": "Control Weather",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10895,7 +10895,7 @@
   },
   {
     "name": "Create Demiplane",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10918,7 +10918,7 @@
   },
   {
     "name": "Create Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10940,7 +10940,7 @@
   },
   {
     "name": "Curse of Calamity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10964,7 +10964,7 @@
   },
   {
     "name": "Demonic Pact",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10986,7 +10986,7 @@
   },
   {
     "name": "Destroy Mindscape",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11006,7 +11006,7 @@
   },
   {
     "name": "Diabolic Pact",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11028,7 +11028,7 @@
   },
   {
     "name": "Div Pact",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11048,7 +11048,7 @@
   },
   {
     "name": "Divine Keystone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11071,7 +11071,7 @@
   },
   {
     "name": "Drain Planar Connection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11091,7 +11091,7 @@
   },
   {
     "name": "Elemental Servitor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11111,7 +11111,7 @@
   },
   {
     "name": "Embodied Font",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11131,7 +11131,7 @@
   },
   {
     "name": "Encroaching Woods",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11153,7 +11153,7 @@
   },
   {
     "name": "Entreat Thunderbird",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11173,7 +11173,7 @@
   },
   {
     "name": "Fantastic Facade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11195,7 +11195,7 @@
   },
   {
     "name": "Feast of Supplication",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11215,7 +11215,7 @@
   },
   {
     "name": "Footholds and Foothills",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11237,7 +11237,7 @@
   },
   {
     "name": "Fortifying Brew",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11257,7 +11257,7 @@
   },
   {
     "name": "Freedom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11279,7 +11279,7 @@
   },
   {
     "name": "Gathering Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11301,7 +11301,7 @@
   },
   {
     "name": "Geas",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11324,7 +11324,7 @@
   },
   {
     "name": "Gnaw at the Moon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11344,7 +11344,7 @@
   },
   {
     "name": "Halt Death",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11366,7 +11366,7 @@
   },
   {
     "name": "Heartbond",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11386,7 +11386,7 @@
   },
   {
     "name": "Imprisonment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11408,7 +11408,7 @@
   },
   {
     "name": "Inveigle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11430,7 +11430,7 @@
   },
   {
     "name": "Kaiju Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11452,7 +11452,7 @@
   },
   {
     "name": "Labyrinthine Prison",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11475,7 +11475,7 @@
   },
   {
     "name": "Last Night's Vigil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11497,7 +11497,7 @@
   },
   {
     "name": "Mindscape Door",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11519,7 +11519,7 @@
   },
   {
     "name": "Mindscape Shift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11541,7 +11541,7 @@
   },
   {
     "name": "Oblivious Expulsion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11563,7 +11563,7 @@
   },
   {
     "name": "Ocean's Roar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11586,7 +11586,7 @@
   },
   {
     "name": "Oil-Slicked Walls",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11606,7 +11606,7 @@
   },
   {
     "name": "Open the Wall of Ghosts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11628,7 +11628,7 @@
   },
   {
     "name": "Owb Pact",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11648,7 +11648,7 @@
   },
   {
     "name": "Perfection of Essence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11670,7 +11670,7 @@
   },
   {
     "name": "Phantasmal Custodians",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11690,7 +11690,7 @@
   },
   {
     "name": "Phantom Ship",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11712,7 +11712,7 @@
   },
   {
     "name": "Plague Shot",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11734,7 +11734,7 @@
   },
   {
     "name": "Planar Displacement",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11756,7 +11756,7 @@
   },
   {
     "name": "Planar Servitor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11776,7 +11776,7 @@
   },
   {
     "name": "Plant Growth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11800,7 +11800,7 @@
   },
   {
     "name": "Power of the Beasts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11822,7 +11822,7 @@
   },
   {
     "name": "Primal Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11842,7 +11842,7 @@
   },
   {
     "name": "Purify Tanglebriar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11864,7 +11864,7 @@
   },
   {
     "name": "Raise Runelord",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11888,7 +11888,7 @@
   },
   {
     "name": "Ransack the Night",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11910,7 +11910,7 @@
   },
   {
     "name": "Recall Past Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11930,7 +11930,7 @@
   },
   {
     "name": "Regale the Lost Ones",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11950,7 +11950,7 @@
   },
   {
     "name": "Reincarnate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11970,7 +11970,7 @@
   },
   {
     "name": "Reinforced Rations",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11990,7 +11990,7 @@
   },
   {
     "name": "Rest Eternal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12010,7 +12010,7 @@
   },
   {
     "name": "Resurrect",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12032,7 +12032,7 @@
   },
   {
     "name": "Retreat Among the Rains",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12055,7 +12055,7 @@
   },
   {
     "name": "Rite of Cleansing Flame",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12078,7 +12078,7 @@
   },
   {
     "name": "Rune Trap",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12098,7 +12098,7 @@
   },
   {
     "name": "Secure Siege Weapons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12118,7 +12118,7 @@
   },
   {
     "name": "Seed of Mercy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12140,7 +12140,7 @@
   },
   {
     "name": "Shadow Double",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12162,7 +12162,7 @@
   },
   {
     "name": "Sky Signs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12186,7 +12186,7 @@
   },
   {
     "name": "Sleepless Season",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12209,7 +12209,7 @@
   },
   {
     "name": "Song of Silver",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12229,7 +12229,7 @@
   },
   {
     "name": "Sprawling Tunnels",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12251,7 +12251,7 @@
   },
   {
     "name": "Supreme Connection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12271,7 +12271,7 @@
   },
   {
     "name": "Sweetest Solstice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12291,7 +12291,7 @@
   },
   {
     "name": "Teleportation Circle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12313,7 +12313,7 @@
   },
   {
     "name": "The Unseeing Blade Master",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12335,7 +12335,7 @@
   },
   {
     "name": "Transmigrate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12357,7 +12357,7 @@
   },
   {
     "name": "Unbearable Cacophony",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12380,7 +12380,7 @@
   },
   {
     "name": "Vital Singularity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12400,7 +12400,7 @@
   },
   {
     "name": "Void Harvest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12424,7 +12424,7 @@
   },
   {
     "name": "Ward Domain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12444,7 +12444,7 @@
   },
   {
     "name": "Wild Allegiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12466,7 +12466,7 @@
   },
   {
     "name": "Wild Feast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12488,7 +12488,7 @@
   },
   {
     "name": "Winter's Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12508,7 +12508,7 @@
   },
   {
     "name": "Wish",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12528,7 +12528,7 @@
   },
   {
     "name": "World in Shadow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12551,7 +12551,7 @@
   },
   {
     "name": "Bramble Bush",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12577,7 +12577,7 @@
   },
   {
     "name": "Bramble Bush",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12603,7 +12603,7 @@
   },
   {
     "name": "Bullhorn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12629,7 +12629,7 @@
   },
   {
     "name": "Bullhorn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12655,7 +12655,7 @@
   },
   {
     "name": "Bullhorn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12681,7 +12681,7 @@
   },
   {
     "name": "Caustic Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12706,7 +12706,7 @@
   },
   {
     "name": "Caustic Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12731,7 +12731,7 @@
   },
   {
     "name": "Daze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12757,7 +12757,7 @@
   },
   {
     "name": "Daze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12783,7 +12783,7 @@
   },
   {
     "name": "Daze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12809,7 +12809,7 @@
   },
   {
     "name": "Deep Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12833,7 +12833,7 @@
   },
   {
     "name": "Deep Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12857,7 +12857,7 @@
   },
   {
     "name": "Detect Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12882,7 +12882,7 @@
   },
   {
     "name": "Detect Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12907,7 +12907,7 @@
   },
   {
     "name": "Detect Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12932,7 +12932,7 @@
   },
   {
     "name": "Detect Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12957,7 +12957,7 @@
   },
   {
     "name": "Detect Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -12983,7 +12983,7 @@
   },
   {
     "name": "Detect Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13009,7 +13009,7 @@
   },
   {
     "name": "Detect Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13035,7 +13035,7 @@
   },
   {
     "name": "Detect Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13061,7 +13061,7 @@
   },
   {
     "name": "Divine Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13088,7 +13088,7 @@
   },
   {
     "name": "Draw Moisture",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13113,7 +13113,7 @@
   },
   {
     "name": "Draw Moisture",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13138,7 +13138,7 @@
   },
   {
     "name": "Draw Moisture",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13163,7 +13163,7 @@
   },
   {
     "name": "Eat Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13187,7 +13187,7 @@
   },
   {
     "name": "Eat Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13211,7 +13211,7 @@
   },
   {
     "name": "Eat Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13235,7 +13235,7 @@
   },
   {
     "name": "Electric Arc",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13260,7 +13260,7 @@
   },
   {
     "name": "Electric Arc",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13285,7 +13285,7 @@
   },
   {
     "name": "Elemental Counter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13308,7 +13308,7 @@
   },
   {
     "name": "Elemental Counter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13331,7 +13331,7 @@
   },
   {
     "name": "Figment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13357,7 +13357,7 @@
   },
   {
     "name": "Figment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13383,7 +13383,7 @@
   },
   {
     "name": "Forbidding Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13407,7 +13407,7 @@
   },
   {
     "name": "Forbidding Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13431,7 +13431,7 @@
   },
   {
     "name": "Frostbite",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13456,7 +13456,7 @@
   },
   {
     "name": "Frostbite",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13481,7 +13481,7 @@
   },
   {
     "name": "Frost's Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13505,7 +13505,7 @@
   },
   {
     "name": "Gale Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13530,7 +13530,7 @@
   },
   {
     "name": "Gale Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13555,7 +13555,7 @@
   },
   {
     "name": "Glamorize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13579,7 +13579,7 @@
   },
   {
     "name": "Glamorize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13603,7 +13603,7 @@
   },
   {
     "name": "Glamorize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13627,7 +13627,7 @@
   },
   {
     "name": "Glamorize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13651,7 +13651,7 @@
   },
   {
     "name": "Glass Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13675,7 +13675,7 @@
   },
   {
     "name": "Glass Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13699,7 +13699,7 @@
   },
   {
     "name": "Gouging Claw",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13725,7 +13725,7 @@
   },
   {
     "name": "Gouging Claw",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13751,7 +13751,7 @@
   },
   {
     "name": "Guidance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13774,7 +13774,7 @@
   },
   {
     "name": "Guidance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13797,7 +13797,7 @@
   },
   {
     "name": "Guidance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13820,7 +13820,7 @@
   },
   {
     "name": "Haunting Hymn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13846,7 +13846,7 @@
   },
   {
     "name": "Haunting Hymn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13872,7 +13872,7 @@
   },
   {
     "name": "Ignition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13898,7 +13898,7 @@
   },
   {
     "name": "Ignition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13924,7 +13924,7 @@
   },
   {
     "name": "Illuminate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13948,7 +13948,7 @@
   },
   {
     "name": "Illuminate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13972,7 +13972,7 @@
   },
   {
     "name": "Illuminate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -13996,7 +13996,7 @@
   },
   {
     "name": "Illuminate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14020,7 +14020,7 @@
   },
   {
     "name": "Know the Way",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14045,7 +14045,7 @@
   },
   {
     "name": "Know the Way",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14070,7 +14070,7 @@
   },
   {
     "name": "Know the Way",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14095,7 +14095,7 @@
   },
   {
     "name": "Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14120,7 +14120,7 @@
   },
   {
     "name": "Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14145,7 +14145,7 @@
   },
   {
     "name": "Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14170,7 +14170,7 @@
   },
   {
     "name": "Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14195,7 +14195,7 @@
   },
   {
     "name": "Live Wire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14222,7 +14222,7 @@
   },
   {
     "name": "Live Wire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14249,7 +14249,7 @@
   },
   {
     "name": "Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14277,7 +14277,7 @@
   },
   {
     "name": "Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14305,7 +14305,7 @@
   },
   {
     "name": "Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14333,7 +14333,7 @@
   },
   {
     "name": "Needle Darts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14359,7 +14359,7 @@
   },
   {
     "name": "Needle Darts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14385,7 +14385,7 @@
   },
   {
     "name": "Needle Darts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14411,7 +14411,7 @@
   },
   {
     "name": "Needle Darts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14437,7 +14437,7 @@
   },
   {
     "name": "Phase Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14462,7 +14462,7 @@
   },
   {
     "name": "Phase Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14487,7 +14487,7 @@
   },
   {
     "name": "Prestidigitation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14511,7 +14511,7 @@
   },
   {
     "name": "Prestidigitation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14535,7 +14535,7 @@
   },
   {
     "name": "Prestidigitation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14559,7 +14559,7 @@
   },
   {
     "name": "Prestidigitation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14583,7 +14583,7 @@
   },
   {
     "name": "Puff of Poison",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14608,7 +14608,7 @@
   },
   {
     "name": "Puff of Poison",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14633,7 +14633,7 @@
   },
   {
     "name": "Read Aura",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14658,7 +14658,7 @@
   },
   {
     "name": "Read Aura",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14683,7 +14683,7 @@
   },
   {
     "name": "Read Aura",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14708,7 +14708,7 @@
   },
   {
     "name": "Read Aura",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14733,7 +14733,7 @@
   },
   {
     "name": "Root Reading",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14758,7 +14758,7 @@
   },
   {
     "name": "Root Reading",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14783,7 +14783,7 @@
   },
   {
     "name": "Rousing Splash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14808,7 +14808,7 @@
   },
   {
     "name": "Rousing Splash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14833,7 +14833,7 @@
   },
   {
     "name": "Scatter Scree",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14858,7 +14858,7 @@
   },
   {
     "name": "Scatter Scree",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14883,7 +14883,7 @@
   },
   {
     "name": "Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14907,7 +14907,7 @@
   },
   {
     "name": "Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14931,7 +14931,7 @@
   },
   {
     "name": "Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14955,7 +14955,7 @@
   },
   {
     "name": "Sigil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -14979,7 +14979,7 @@
   },
   {
     "name": "Sigil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15003,7 +15003,7 @@
   },
   {
     "name": "Sigil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15027,7 +15027,7 @@
   },
   {
     "name": "Sigil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15051,7 +15051,7 @@
   },
   {
     "name": "Slashing Gust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15077,7 +15077,7 @@
   },
   {
     "name": "Slashing Gust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15103,7 +15103,7 @@
   },
   {
     "name": "Spout",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15128,7 +15128,7 @@
   },
   {
     "name": "Spout",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15153,7 +15153,7 @@
   },
   {
     "name": "Stabilize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15179,7 +15179,7 @@
   },
   {
     "name": "Stabilize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15205,7 +15205,7 @@
   },
   {
     "name": "Summon Instrument",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15229,7 +15229,7 @@
   },
   {
     "name": "Summon Instrument",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15253,7 +15253,7 @@
   },
   {
     "name": "Summon Instrument",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15277,7 +15277,7 @@
   },
   {
     "name": "Take Root",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15302,7 +15302,7 @@
   },
   {
     "name": "Take Root",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15327,7 +15327,7 @@
   },
   {
     "name": "Tangle Vine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15354,7 +15354,7 @@
   },
   {
     "name": "Tangle Vine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15381,7 +15381,7 @@
   },
   {
     "name": "Telekinetic Hand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15405,7 +15405,7 @@
   },
   {
     "name": "Telekinetic Hand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15429,7 +15429,7 @@
   },
   {
     "name": "Telekinetic Projectile",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15454,7 +15454,7 @@
   },
   {
     "name": "Telekinetic Projectile",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15479,7 +15479,7 @@
   },
   {
     "name": "Timber",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15504,7 +15504,7 @@
   },
   {
     "name": "Timber",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15529,7 +15529,7 @@
   },
   {
     "name": "Time Sense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15552,7 +15552,7 @@
   },
   {
     "name": "Time Sense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15575,7 +15575,7 @@
   },
   {
     "name": "Tremor Signs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15600,7 +15600,7 @@
   },
   {
     "name": "Tremor Signs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15625,7 +15625,7 @@
   },
   {
     "name": "Tremor Signs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15650,7 +15650,7 @@
   },
   {
     "name": "Tremor Signs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15675,7 +15675,7 @@
   },
   {
     "name": "Vitality Lash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15700,7 +15700,7 @@
   },
   {
     "name": "Vitality Lash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15725,7 +15725,7 @@
   },
   {
     "name": "Void Warp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15750,7 +15750,7 @@
   },
   {
     "name": "Void Warp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15775,7 +15775,7 @@
   },
   {
     "name": "Void Warp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15800,7 +15800,7 @@
   },
   {
     "name": "Warp Step",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15824,7 +15824,7 @@
   },
   {
     "name": "Warp Step",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15848,7 +15848,7 @@
   },
   {
     "name": "500 Toads",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15871,7 +15871,7 @@
   },
   {
     "name": "500 Toads",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15894,7 +15894,7 @@
   },
   {
     "name": "Acidic Burst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15918,7 +15918,7 @@
   },
   {
     "name": "Acidic Burst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15942,7 +15942,7 @@
   },
   {
     "name": "Agitate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15967,7 +15967,7 @@
   },
   {
     "name": "Agitate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -15992,7 +15992,7 @@
   },
   {
     "name": "Air Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16015,7 +16015,7 @@
   },
   {
     "name": "Air Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16038,7 +16038,7 @@
   },
   {
     "name": "Air Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16061,7 +16061,7 @@
   },
   {
     "name": "Alarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16084,7 +16084,7 @@
   },
   {
     "name": "Alarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16107,7 +16107,7 @@
   },
   {
     "name": "Alarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16130,7 +16130,7 @@
   },
   {
     "name": "Alarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16153,7 +16153,7 @@
   },
   {
     "name": "Ant Haul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16176,7 +16176,7 @@
   },
   {
     "name": "Ant Haul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16199,7 +16199,7 @@
   },
   {
     "name": "Anticipate Peril",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16222,7 +16222,7 @@
   },
   {
     "name": "Anticipate Peril",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16245,7 +16245,7 @@
   },
   {
     "name": "Armor of Thorn and Claw",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16269,7 +16269,7 @@
   },
   {
     "name": "Bane",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16294,7 +16294,7 @@
   },
   {
     "name": "Bane",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16319,7 +16319,7 @@
   },
   {
     "name": "Befuddle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16344,7 +16344,7 @@
   },
   {
     "name": "Befuddle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16369,7 +16369,7 @@
   },
   {
     "name": "Benediction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16394,7 +16394,7 @@
   },
   {
     "name": "Beseech the Sphinx",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16417,7 +16417,7 @@
   },
   {
     "name": "Beseech the Sphinx",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16440,7 +16440,7 @@
   },
   {
     "name": "Bless",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16465,7 +16465,7 @@
   },
   {
     "name": "Bless",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16490,7 +16490,7 @@
   },
   {
     "name": "Breathe Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16514,7 +16514,7 @@
   },
   {
     "name": "Breathe Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16538,7 +16538,7 @@
   },
   {
     "name": "Briny Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16563,7 +16563,7 @@
   },
   {
     "name": "Briny Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16588,7 +16588,7 @@
   },
   {
     "name": "Buoyant Bubbles",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16611,7 +16611,7 @@
   },
   {
     "name": "Buoyant Bubbles",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16634,7 +16634,7 @@
   },
   {
     "name": "Camel Spit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16660,7 +16660,7 @@
   },
   {
     "name": "Camel Spit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16686,7 +16686,7 @@
   },
   {
     "name": "Carryall",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16710,7 +16710,7 @@
   },
   {
     "name": "Carryall",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16734,7 +16734,7 @@
   },
   {
     "name": "Charm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16761,7 +16761,7 @@
   },
   {
     "name": "Charm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16788,7 +16788,7 @@
   },
   {
     "name": "Charm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16815,7 +16815,7 @@
   },
   {
     "name": "Chilling Spray",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16839,7 +16839,7 @@
   },
   {
     "name": "Chilling Spray",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16863,7 +16863,7 @@
   },
   {
     "name": "Cleanse Cuisine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16886,7 +16886,7 @@
   },
   {
     "name": "Cleanse Cuisine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16909,7 +16909,7 @@
   },
   {
     "name": "Command",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16935,7 +16935,7 @@
   },
   {
     "name": "Command",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16961,7 +16961,7 @@
   },
   {
     "name": "Command",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -16987,7 +16987,7 @@
   },
   {
     "name": "Concordant Choir",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17010,7 +17010,7 @@
   },
   {
     "name": "Concordant Choir",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17033,7 +17033,7 @@
   },
   {
     "name": "Conductive Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17058,7 +17058,7 @@
   },
   {
     "name": "Conductive Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17083,7 +17083,7 @@
   },
   {
     "name": "Create Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17107,7 +17107,7 @@
   },
   {
     "name": "Create Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17131,7 +17131,7 @@
   },
   {
     "name": "Create Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17155,7 +17155,7 @@
   },
   {
     "name": "Curse of Recoil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17178,7 +17178,7 @@
   },
   {
     "name": "Curse of Recoil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17201,7 +17201,7 @@
   },
   {
     "name": "Cycle of Retribution",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17225,7 +17225,7 @@
   },
   {
     "name": "Cycle of Retribution",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17249,7 +17249,7 @@
   },
   {
     "name": "Defended by Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17273,7 +17273,7 @@
   },
   {
     "name": "Defended by Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17297,7 +17297,7 @@
   },
   {
     "name": "Dehydrate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17321,7 +17321,7 @@
   },
   {
     "name": "Dehydrate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17345,7 +17345,7 @@
   },
   {
     "name": "Detect Poison",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17369,7 +17369,7 @@
   },
   {
     "name": "Detect Poison",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17393,7 +17393,7 @@
   },
   {
     "name": "Disguise Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17417,7 +17417,7 @@
   },
   {
     "name": "Disguise Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17441,7 +17441,7 @@
   },
   {
     "name": "Dizzying Colors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17467,7 +17467,7 @@
   },
   {
     "name": "Dizzying Colors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17493,7 +17493,7 @@
   },
   {
     "name": "Déjà Vu",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17518,7 +17518,7 @@
   },
   {
     "name": "Déjà Vu",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17543,7 +17543,7 @@
   },
   {
     "name": "Endure",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17566,7 +17566,7 @@
   },
   {
     "name": "Endure",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17589,7 +17589,7 @@
   },
   {
     "name": "Enfeeble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17612,7 +17612,7 @@
   },
   {
     "name": "Enfeeble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17635,7 +17635,7 @@
   },
   {
     "name": "Enfeeble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17658,7 +17658,7 @@
   },
   {
     "name": "Equal Footing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17682,7 +17682,7 @@
   },
   {
     "name": "Equal Footing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17706,7 +17706,7 @@
   },
   {
     "name": "Equal Footing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17730,7 +17730,7 @@
   },
   {
     "name": "Fated Healing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17755,7 +17755,7 @@
   },
   {
     "name": "Fated Healing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17780,7 +17780,7 @@
   },
   {
     "name": "Fear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17806,7 +17806,7 @@
   },
   {
     "name": "Fear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17832,7 +17832,7 @@
   },
   {
     "name": "Fear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17858,7 +17858,7 @@
   },
   {
     "name": "Fear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17884,7 +17884,7 @@
   },
   {
     "name": "Fleet Step",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17907,7 +17907,7 @@
   },
   {
     "name": "Fleet Step",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17930,7 +17930,7 @@
   },
   {
     "name": "Flourishing Flora",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17955,7 +17955,7 @@
   },
   {
     "name": "Flourishing Flora",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17980,7 +17980,7 @@
   },
   {
     "name": "Fold Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18004,7 +18004,7 @@
   },
   {
     "name": "Foraging Friends",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18027,7 +18027,7 @@
   },
   {
     "name": "Force Barrage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18051,7 +18051,7 @@
   },
   {
     "name": "Force Barrage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18075,7 +18075,7 @@
   },
   {
     "name": "Forced Mercy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18100,7 +18100,7 @@
   },
   {
     "name": "Forced Mercy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18125,7 +18125,7 @@
   },
   {
     "name": "Gentle Landing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18148,7 +18148,7 @@
   },
   {
     "name": "Gentle Landing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18171,7 +18171,7 @@
   },
   {
     "name": "Goblin Pox",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18195,7 +18195,7 @@
   },
   {
     "name": "Goblin Pox",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18219,7 +18219,7 @@
   },
   {
     "name": "Grease",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18242,7 +18242,7 @@
   },
   {
     "name": "Grease",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18265,7 +18265,7 @@
   },
   {
     "name": "Grim Tendrils",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18289,7 +18289,7 @@
   },
   {
     "name": "Grim Tendrils",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18313,7 +18313,7 @@
   },
   {
     "name": "Gust of Wind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18337,7 +18337,7 @@
   },
   {
     "name": "Gust of Wind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18361,7 +18361,7 @@
   },
   {
     "name": "Harm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18384,7 +18384,7 @@
   },
   {
     "name": "Heal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18408,7 +18408,7 @@
   },
   {
     "name": "Heal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18432,7 +18432,7 @@
   },
   {
     "name": "Hippocampus Retreat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18457,7 +18457,7 @@
   },
   {
     "name": "Hippocampus Retreat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18482,7 +18482,7 @@
   },
   {
     "name": "Hydraulic Push",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18507,7 +18507,7 @@
   },
   {
     "name": "Hydraulic Push",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18532,7 +18532,7 @@
   },
   {
     "name": "Ill Omen",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18557,7 +18557,7 @@
   },
   {
     "name": "Illusory Disguise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18582,7 +18582,7 @@
   },
   {
     "name": "Illusory Disguise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18607,7 +18607,7 @@
   },
   {
     "name": "Illusory Object",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18632,7 +18632,7 @@
   },
   {
     "name": "Illusory Object",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18657,7 +18657,7 @@
   },
   {
     "name": "Imprint Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18680,7 +18680,7 @@
   },
   {
     "name": "Infuse Vitality",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18704,7 +18704,7 @@
   },
   {
     "name": "Instant Pottery",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18728,7 +18728,7 @@
   },
   {
     "name": "Instant Pottery",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18752,7 +18752,7 @@
   },
   {
     "name": "Interposing Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18775,7 +18775,7 @@
   },
   {
     "name": "Interposing Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18798,7 +18798,7 @@
   },
   {
     "name": "Invisible Item",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18822,7 +18822,7 @@
   },
   {
     "name": "Invisible Item",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18846,7 +18846,7 @@
   },
   {
     "name": "Item Facade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18871,7 +18871,7 @@
   },
   {
     "name": "Item Facade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18896,7 +18896,7 @@
   },
   {
     "name": "Jump",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18919,7 +18919,7 @@
   },
   {
     "name": "Jump",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18942,7 +18942,7 @@
   },
   {
     "name": "Kinetic Ram",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18965,7 +18965,7 @@
   },
   {
     "name": "Kinetic Ram",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -18988,7 +18988,7 @@
   },
   {
     "name": "Leaden Steps",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19013,7 +19013,7 @@
   },
   {
     "name": "Leaden Steps",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19038,7 +19038,7 @@
   },
   {
     "name": "Liberating Command",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19062,7 +19062,7 @@
   },
   {
     "name": "Lock",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19085,7 +19085,7 @@
   },
   {
     "name": "Lock",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19108,7 +19108,7 @@
   },
   {
     "name": "Lock",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19131,7 +19131,7 @@
   },
   {
     "name": "Malediction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19156,7 +19156,7 @@
   },
   {
     "name": "Mending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19179,7 +19179,7 @@
   },
   {
     "name": "Mending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19202,7 +19202,7 @@
   },
   {
     "name": "Mending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19225,7 +19225,7 @@
   },
   {
     "name": "Mending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19248,7 +19248,7 @@
   },
   {
     "name": "Message Rune",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19273,7 +19273,7 @@
   },
   {
     "name": "Message Rune",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19298,7 +19298,7 @@
   },
   {
     "name": "Mindlink",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19322,7 +19322,7 @@
   },
   {
     "name": "Mindlink",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19346,7 +19346,7 @@
   },
   {
     "name": "Mud Pit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19371,7 +19371,7 @@
   },
   {
     "name": "Mud Pit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19396,7 +19396,7 @@
   },
   {
     "name": "Mystic Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19419,7 +19419,7 @@
   },
   {
     "name": "Mystic Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19442,7 +19442,7 @@
   },
   {
     "name": "Mystic Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19465,7 +19465,7 @@
   },
   {
     "name": "Mystic Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19488,7 +19488,7 @@
   },
   {
     "name": "Noxious Vapors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19512,7 +19512,7 @@
   },
   {
     "name": "Noxious Vapors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19536,7 +19536,7 @@
   },
   {
     "name": "Object Reading",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19559,7 +19559,7 @@
   },
   {
     "name": "Penumbral Shroud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19584,7 +19584,7 @@
   },
   {
     "name": "Penumbral Shroud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19609,7 +19609,7 @@
   },
   {
     "name": "Pest Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19633,7 +19633,7 @@
   },
   {
     "name": "Pest Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19657,7 +19657,7 @@
   },
   {
     "name": "Pet Cache",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19680,7 +19680,7 @@
   },
   {
     "name": "Pet Cache",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19703,7 +19703,7 @@
   },
   {
     "name": "Pet Cache",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19726,7 +19726,7 @@
   },
   {
     "name": "Pet Cache",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19749,7 +19749,7 @@
   },
   {
     "name": "Phantasmal Minion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19773,7 +19773,7 @@
   },
   {
     "name": "Phantasmal Minion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19797,7 +19797,7 @@
   },
   {
     "name": "Phantom Pain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19823,7 +19823,7 @@
   },
   {
     "name": "Pocket Library",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19847,7 +19847,7 @@
   },
   {
     "name": "Pocket Library",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19871,7 +19871,7 @@
   },
   {
     "name": "Protection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19894,7 +19894,7 @@
   },
   {
     "name": "Protection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19917,7 +19917,7 @@
   },
   {
     "name": "Protector Tree",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19942,7 +19942,7 @@
   },
   {
     "name": "Pummeling Rubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19966,7 +19966,7 @@
   },
   {
     "name": "Pummeling Rubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -19990,7 +19990,7 @@
   },
   {
     "name": "Rainbow's End",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20016,7 +20016,7 @@
   },
   {
     "name": "Rainbow's End",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20042,7 +20042,7 @@
   },
   {
     "name": "Rainbow's End",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20068,7 +20068,7 @@
   },
   {
     "name": "Rainbow's End",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20094,7 +20094,7 @@
   },
   {
     "name": "Reed Whistle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20119,7 +20119,7 @@
   },
   {
     "name": "Reed Whistle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20144,7 +20144,7 @@
   },
   {
     "name": "Reed Whistle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20169,7 +20169,7 @@
   },
   {
     "name": "Runic Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20192,7 +20192,7 @@
   },
   {
     "name": "Runic Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20215,7 +20215,7 @@
   },
   {
     "name": "Runic Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20238,7 +20238,7 @@
   },
   {
     "name": "Runic Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20261,7 +20261,7 @@
   },
   {
     "name": "Runic Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20284,7 +20284,7 @@
   },
   {
     "name": "Runic Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20307,7 +20307,7 @@
   },
   {
     "name": "Runic Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20330,7 +20330,7 @@
   },
   {
     "name": "Runic Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20353,7 +20353,7 @@
   },
   {
     "name": "Sacred Beasts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20376,7 +20376,7 @@
   },
   {
     "name": "Sacred Beasts",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20399,7 +20399,7 @@
   },
   {
     "name": "Sanctuary",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20422,7 +20422,7 @@
   },
   {
     "name": "Sanctuary",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20445,7 +20445,7 @@
   },
   {
     "name": "Schadenfreude",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20469,7 +20469,7 @@
   },
   {
     "name": "Schadenfreude",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20493,7 +20493,7 @@
   },
   {
     "name": "Schadenfreude",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20517,7 +20517,7 @@
   },
   {
     "name": "Share Lore",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20541,7 +20541,7 @@
   },
   {
     "name": "Share Lore",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20565,7 +20565,7 @@
   },
   {
     "name": "Shattering Gem",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20589,7 +20589,7 @@
   },
   {
     "name": "Shattering Gem",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20613,7 +20613,7 @@
   },
   {
     "name": "Shielded Arm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20637,7 +20637,7 @@
   },
   {
     "name": "Shielded Arm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20661,7 +20661,7 @@
   },
   {
     "name": "Shielded Arm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20685,7 +20685,7 @@
   },
   {
     "name": "Shockwave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20709,7 +20709,7 @@
   },
   {
     "name": "Shockwave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20733,7 +20733,7 @@
   },
   {
     "name": "Signal Skyrocket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20758,7 +20758,7 @@
   },
   {
     "name": "Signal Skyrocket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20783,7 +20783,7 @@
   },
   {
     "name": "Signal Skyrocket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20808,7 +20808,7 @@
   },
   {
     "name": "Sleep",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20834,7 +20834,7 @@
   },
   {
     "name": "Sleep",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20860,7 +20860,7 @@
   },
   {
     "name": "Soothe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20886,7 +20886,7 @@
   },
   {
     "name": "Spider Sting",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20910,7 +20910,7 @@
   },
   {
     "name": "Spider Sting",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20934,7 +20934,7 @@
   },
   {
     "name": "Spirit Link",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20959,7 +20959,7 @@
   },
   {
     "name": "Spirit Link",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -20984,7 +20984,7 @@
   },
   {
     "name": "Spirit Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21006,7 +21006,7 @@
   },
   {
     "name": "Spirit Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21028,7 +21028,7 @@
   },
   {
     "name": "Summon Animal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21052,7 +21052,7 @@
   },
   {
     "name": "Summon Animal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21076,7 +21076,7 @@
   },
   {
     "name": "Summon Construct",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21100,7 +21100,7 @@
   },
   {
     "name": "Summon Fey",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21124,7 +21124,7 @@
   },
   {
     "name": "Summon Fey",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21148,7 +21148,7 @@
   },
   {
     "name": "Summon Lesser Servitor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21172,7 +21172,7 @@
   },
   {
     "name": "Summon Plant or Fungus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21196,7 +21196,7 @@
   },
   {
     "name": "Summon Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21220,7 +21220,7 @@
   },
   {
     "name": "Summon Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21244,7 +21244,7 @@
   },
   {
     "name": "Summon Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21268,7 +21268,7 @@
   },
   {
     "name": "Sure Strike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21291,7 +21291,7 @@
   },
   {
     "name": "Sure Strike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21314,7 +21314,7 @@
   },
   {
     "name": "Tailwind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21338,7 +21338,7 @@
   },
   {
     "name": "Tailwind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21362,7 +21362,7 @@
   },
   {
     "name": "Temporary Tool",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21384,7 +21384,7 @@
   },
   {
     "name": "Tether",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21407,7 +21407,7 @@
   },
   {
     "name": "Tether",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21430,7 +21430,7 @@
   },
   {
     "name": "Thoughtful Gift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21453,7 +21453,7 @@
   },
   {
     "name": "Thoughtful Gift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21476,7 +21476,7 @@
   },
   {
     "name": "Thoughtful Gift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21499,7 +21499,7 @@
   },
   {
     "name": "Threefold Limb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21525,7 +21525,7 @@
   },
   {
     "name": "Threefold Limb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21551,7 +21551,7 @@
   },
   {
     "name": "Thunderstrike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21576,7 +21576,7 @@
   },
   {
     "name": "Thunderstrike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21601,7 +21601,7 @@
   },
   {
     "name": "Unbroken Panoply",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21625,7 +21625,7 @@
   },
   {
     "name": "Unbroken Panoply",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21649,7 +21649,7 @@
   },
   {
     "name": "Vanishing Tracks",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21672,7 +21672,7 @@
   },
   {
     "name": "Ventriloquism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21697,7 +21697,7 @@
   },
   {
     "name": "Ventriloquism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21722,7 +21722,7 @@
   },
   {
     "name": "Ventriloquism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21747,7 +21747,7 @@
   },
   {
     "name": "Ventriloquism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21772,7 +21772,7 @@
   },
   {
     "name": "Wall of Shrubs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21797,7 +21797,7 @@
   },
   {
     "name": "Wall of Shrubs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21822,7 +21822,7 @@
   },
   {
     "name": "Weaken Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21846,7 +21846,7 @@
   },
   {
     "name": "Weaken Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21870,7 +21870,7 @@
   },
   {
     "name": "Weave Wood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21894,7 +21894,7 @@
   },
   {
     "name": "Weave Wood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21918,7 +21918,7 @@
   },
   {
     "name": "Wooden Fists",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21943,7 +21943,7 @@
   },
   {
     "name": "Wooden Fists",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21968,7 +21968,7 @@
   },
   {
     "name": "Avatar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -21992,7 +21992,7 @@
   },
   {
     "name": "Cataclysm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22022,7 +22022,7 @@
   },
   {
     "name": "Cataclysm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22052,7 +22052,7 @@
   },
   {
     "name": "Conquering Soldiers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22076,7 +22076,7 @@
   },
   {
     "name": "Conquering Soldiers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22100,7 +22100,7 @@
   },
   {
     "name": "Dragon Turret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22123,7 +22123,7 @@
   },
   {
     "name": "Dragon Turret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22146,7 +22146,7 @@
   },
   {
     "name": "Dragon Turret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22169,7 +22169,7 @@
   },
   {
     "name": "Dragon Turret",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22192,7 +22192,7 @@
   },
   {
     "name": "Element Embodied",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22216,7 +22216,7 @@
   },
   {
     "name": "Fabricated Truth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22241,7 +22241,7 @@
   },
   {
     "name": "Freeze Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22264,7 +22264,7 @@
   },
   {
     "name": "Freeze Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22287,7 +22287,7 @@
   },
   {
     "name": "Garden of the Green Man's Growth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22312,7 +22312,7 @@
   },
   {
     "name": "Garden of the Green Man's Growth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22337,7 +22337,7 @@
   },
   {
     "name": "Gate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22361,7 +22361,7 @@
   },
   {
     "name": "Gate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22385,7 +22385,7 @@
   },
   {
     "name": "Gate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22409,7 +22409,7 @@
   },
   {
     "name": "Indestructibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22432,7 +22432,7 @@
   },
   {
     "name": "Indestructibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22455,7 +22455,7 @@
   },
   {
     "name": "Indestructibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22478,7 +22478,7 @@
   },
   {
     "name": "Indestructibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22501,7 +22501,7 @@
   },
   {
     "name": "Jassim's Allegiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22525,7 +22525,7 @@
   },
   {
     "name": "Jassim's Allegiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22549,7 +22549,7 @@
   },
   {
     "name": "Manifestation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22572,7 +22572,7 @@
   },
   {
     "name": "Manifestation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22595,7 +22595,7 @@
   },
   {
     "name": "Manifestation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22618,7 +22618,7 @@
   },
   {
     "name": "Manifestation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22641,7 +22641,7 @@
   },
   {
     "name": "Nature Incarnate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22665,7 +22665,7 @@
   },
   {
     "name": "Primal Herd",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22689,7 +22689,7 @@
   },
   {
     "name": "Remake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22712,7 +22712,7 @@
   },
   {
     "name": "Remake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22735,7 +22735,7 @@
   },
   {
     "name": "Remake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22758,7 +22758,7 @@
   },
   {
     "name": "Remake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22781,7 +22781,7 @@
   },
   {
     "name": "Revival",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22806,7 +22806,7 @@
   },
   {
     "name": "Revival",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22831,7 +22831,7 @@
   },
   {
     "name": "Summon Oliphaunt of Jandelay",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22856,7 +22856,7 @@
   },
   {
     "name": "Summon Oliphaunt of Jandelay",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22881,7 +22881,7 @@
   },
   {
     "name": "Acid Grip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22905,7 +22905,7 @@
   },
   {
     "name": "Acid Grip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22929,7 +22929,7 @@
   },
   {
     "name": "Advanced Scurvy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22953,7 +22953,7 @@
   },
   {
     "name": "Advanced Scurvy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -22977,7 +22977,7 @@
   },
   {
     "name": "Albatross Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23001,7 +23001,7 @@
   },
   {
     "name": "Albatross Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23025,7 +23025,7 @@
   },
   {
     "name": "Animal Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23049,7 +23049,7 @@
   },
   {
     "name": "Animal Messenger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23073,7 +23073,7 @@
   },
   {
     "name": "Animated Assault",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23096,7 +23096,7 @@
   },
   {
     "name": "Animated Assault",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23119,7 +23119,7 @@
   },
   {
     "name": "Animus Mine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23143,7 +23143,7 @@
   },
   {
     "name": "Augury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23167,7 +23167,7 @@
   },
   {
     "name": "Augury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23191,7 +23191,7 @@
   },
   {
     "name": "Avenging Wildwood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23216,7 +23216,7 @@
   },
   {
     "name": "Banishing Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23241,7 +23241,7 @@
   },
   {
     "name": "Banishing Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23266,7 +23266,7 @@
   },
   {
     "name": "Banishing Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23291,7 +23291,7 @@
   },
   {
     "name": "Banishing Touch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23316,7 +23316,7 @@
   },
   {
     "name": "Bee-Man's Summons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23341,7 +23341,7 @@
   },
   {
     "name": "Bee-Man's Summons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23366,7 +23366,7 @@
   },
   {
     "name": "Bee-Man's Summons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23391,7 +23391,7 @@
   },
   {
     "name": "Blazing Armory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23415,7 +23415,7 @@
   },
   {
     "name": "Blazing Armory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23439,7 +23439,7 @@
   },
   {
     "name": "Blazing Armory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23463,7 +23463,7 @@
   },
   {
     "name": "Blazing Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23488,7 +23488,7 @@
   },
   {
     "name": "Blazing Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23513,7 +23513,7 @@
   },
   {
     "name": "Blistering Invective",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23540,7 +23540,7 @@
   },
   {
     "name": "Blood Vendetta",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23562,7 +23562,7 @@
   },
   {
     "name": "Blood Vendetta",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23584,7 +23584,7 @@
   },
   {
     "name": "Blood Vendetta",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23606,7 +23606,7 @@
   },
   {
     "name": "Blur",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23631,7 +23631,7 @@
   },
   {
     "name": "Blur",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23656,7 +23656,7 @@
   },
   {
     "name": "Brine Dragon Bile",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23681,7 +23681,7 @@
   },
   {
     "name": "Brine Dragon Bile",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23706,7 +23706,7 @@
   },
   {
     "name": "Burrow Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23730,7 +23730,7 @@
   },
   {
     "name": "Burrow Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23754,7 +23754,7 @@
   },
   {
     "name": "Buzzing Servants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23777,7 +23777,7 @@
   },
   {
     "name": "Buzzing Servants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23800,7 +23800,7 @@
   },
   {
     "name": "Buzzing Servants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23823,7 +23823,7 @@
   },
   {
     "name": "Calm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23849,7 +23849,7 @@
   },
   {
     "name": "Calm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23875,7 +23875,7 @@
   },
   {
     "name": "Cauterize Wounds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23900,7 +23900,7 @@
   },
   {
     "name": "Cauterize Wounds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23925,7 +23925,7 @@
   },
   {
     "name": "Cauterize Wounds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23950,7 +23950,7 @@
   },
   {
     "name": "Charitable Urge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -23975,7 +23975,7 @@
   },
   {
     "name": "Charitable Urge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24000,7 +24000,7 @@
   },
   {
     "name": "Charitable Urge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24025,7 +24025,7 @@
   },
   {
     "name": "Clad In Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24049,7 +24049,7 @@
   },
   {
     "name": "Clad In Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24073,7 +24073,7 @@
   },
   {
     "name": "Clad In Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24097,7 +24097,7 @@
   },
   {
     "name": "Claws of the Otter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24121,7 +24121,7 @@
   },
   {
     "name": "Claws of the Otter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24145,7 +24145,7 @@
   },
   {
     "name": "Cleanse Affliction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24169,7 +24169,7 @@
   },
   {
     "name": "Cleanse Affliction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24193,7 +24193,7 @@
   },
   {
     "name": "Cleanse Affliction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24217,7 +24217,7 @@
   },
   {
     "name": "Cleanse Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24241,7 +24241,7 @@
   },
   {
     "name": "Cleanse Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24265,7 +24265,7 @@
   },
   {
     "name": "Cleanse Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24289,7 +24289,7 @@
   },
   {
     "name": "Clear Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24314,7 +24314,7 @@
   },
   {
     "name": "Clear Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24339,7 +24339,7 @@
   },
   {
     "name": "Clear Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24364,7 +24364,7 @@
   },
   {
     "name": "Coiling Dance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24388,7 +24388,7 @@
   },
   {
     "name": "Coiling Dance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24412,7 +24412,7 @@
   },
   {
     "name": "Create Food",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24435,7 +24435,7 @@
   },
   {
     "name": "Create Food",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24458,7 +24458,7 @@
   },
   {
     "name": "Create Food",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24481,7 +24481,7 @@
   },
   {
     "name": "Dancing Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24504,7 +24504,7 @@
   },
   {
     "name": "Dancing Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24527,7 +24527,7 @@
   },
   {
     "name": "Dancing Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24550,7 +24550,7 @@
   },
   {
     "name": "Dancing Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24573,7 +24573,7 @@
   },
   {
     "name": "Darkness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24597,7 +24597,7 @@
   },
   {
     "name": "Darkness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24621,7 +24621,7 @@
   },
   {
     "name": "Darkness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24645,7 +24645,7 @@
   },
   {
     "name": "Darkness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24669,7 +24669,7 @@
   },
   {
     "name": "Darkvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24692,7 +24692,7 @@
   },
   {
     "name": "Darkvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24715,7 +24715,7 @@
   },
   {
     "name": "Darkvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24738,7 +24738,7 @@
   },
   {
     "name": "Darkvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24761,7 +24761,7 @@
   },
   {
     "name": "Deafness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24784,7 +24784,7 @@
   },
   {
     "name": "Deafness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24807,7 +24807,7 @@
   },
   {
     "name": "Deafness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24830,7 +24830,7 @@
   },
   {
     "name": "Deafness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24853,7 +24853,7 @@
   },
   {
     "name": "Dismantle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24876,7 +24876,7 @@
   },
   {
     "name": "Dismantle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24899,7 +24899,7 @@
   },
   {
     "name": "Dispel Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24922,7 +24922,7 @@
   },
   {
     "name": "Dispel Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24945,7 +24945,7 @@
   },
   {
     "name": "Dispel Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24968,7 +24968,7 @@
   },
   {
     "name": "Dispel Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -24991,7 +24991,7 @@
   },
   {
     "name": "Elemental Zone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25014,7 +25014,7 @@
   },
   {
     "name": "Elemental Zone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25037,7 +25037,7 @@
   },
   {
     "name": "Embed Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25061,7 +25061,7 @@
   },
   {
     "name": "Embed Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25085,7 +25085,7 @@
   },
   {
     "name": "Empty Pack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25109,7 +25109,7 @@
   },
   {
     "name": "Empty Pack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25133,7 +25133,7 @@
   },
   {
     "name": "Enlarge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25157,7 +25157,7 @@
   },
   {
     "name": "Enlarge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25181,7 +25181,7 @@
   },
   {
     "name": "Entangling Flora",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25206,7 +25206,7 @@
   },
   {
     "name": "Entangling Flora",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25231,7 +25231,7 @@
   },
   {
     "name": "Environmental Endurance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25254,7 +25254,7 @@
   },
   {
     "name": "Environmental Endurance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25277,7 +25277,7 @@
   },
   {
     "name": "Environmental Endurance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25300,7 +25300,7 @@
   },
   {
     "name": "Everlight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25324,7 +25324,7 @@
   },
   {
     "name": "Everlight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25348,7 +25348,7 @@
   },
   {
     "name": "Everlight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25372,7 +25372,7 @@
   },
   {
     "name": "Everlight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25396,7 +25396,7 @@
   },
   {
     "name": "Expeditious Excavation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25420,7 +25420,7 @@
   },
   {
     "name": "Expeditious Excavation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25444,7 +25444,7 @@
   },
   {
     "name": "Exploding Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25469,7 +25469,7 @@
   },
   {
     "name": "Exploding Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25494,7 +25494,7 @@
   },
   {
     "name": "False Vitality",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25517,7 +25517,7 @@
   },
   {
     "name": "False Vitality",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25540,7 +25540,7 @@
   },
   {
     "name": "Falsify Heat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25565,7 +25565,7 @@
   },
   {
     "name": "Falsify Heat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25590,7 +25590,7 @@
   },
   {
     "name": "Far-Flung Fetch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25614,7 +25614,7 @@
   },
   {
     "name": "Far-Flung Fetch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25638,7 +25638,7 @@
   },
   {
     "name": "Far-Flung Fetch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25662,7 +25662,7 @@
   },
   {
     "name": "Fear the Sun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25685,7 +25685,7 @@
   },
   {
     "name": "Fear the Sun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25708,7 +25708,7 @@
   },
   {
     "name": "Fear the Sun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25731,7 +25731,7 @@
   },
   {
     "name": "Fear the Sun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25754,7 +25754,7 @@
   },
   {
     "name": "Feast of Ashes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25778,7 +25778,7 @@
   },
   {
     "name": "Feast of Ashes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25802,7 +25802,7 @@
   },
   {
     "name": "Feast of Ashes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25826,7 +25826,7 @@
   },
   {
     "name": "Final Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25850,7 +25850,7 @@
   },
   {
     "name": "Final Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25874,7 +25874,7 @@
   },
   {
     "name": "Final Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25898,7 +25898,7 @@
   },
   {
     "name": "Final Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25922,7 +25922,7 @@
   },
   {
     "name": "Fireproof",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25946,7 +25946,7 @@
   },
   {
     "name": "Fireproof",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25970,7 +25970,7 @@
   },
   {
     "name": "Fireproof",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -25994,7 +25994,7 @@
   },
   {
     "name": "Floating Flame",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26018,7 +26018,7 @@
   },
   {
     "name": "Floating Flame",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26042,7 +26042,7 @@
   },
   {
     "name": "Frog Tongue",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26065,7 +26065,7 @@
   },
   {
     "name": "Funeral Flames",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26089,7 +26089,7 @@
   },
   {
     "name": "Funeral Flames",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26113,7 +26113,7 @@
   },
   {
     "name": "Fungal Hyphae",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26137,7 +26137,7 @@
   },
   {
     "name": "Fungal Infestation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26162,7 +26162,7 @@
   },
   {
     "name": "Gecko Grip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26185,7 +26185,7 @@
   },
   {
     "name": "Gecko Grip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26208,7 +26208,7 @@
   },
   {
     "name": "Gentle Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26234,7 +26234,7 @@
   },
   {
     "name": "Gentle Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26260,7 +26260,7 @@
   },
   {
     "name": "Gentle Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26286,7 +26286,7 @@
   },
   {
     "name": "Ghostly Carrier",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26309,7 +26309,7 @@
   },
   {
     "name": "Ghostly Carrier",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26332,7 +26332,7 @@
   },
   {
     "name": "Ghoulish Cravings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26357,7 +26357,7 @@
   },
   {
     "name": "Ghoulish Cravings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26382,7 +26382,7 @@
   },
   {
     "name": "Helpful Reload",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26405,7 +26405,7 @@
   },
   {
     "name": "Helpful Reload",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26428,7 +26428,7 @@
   },
   {
     "name": "Helpful Reload",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26451,7 +26451,7 @@
   },
   {
     "name": "Helpful Wood Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26475,7 +26475,7 @@
   },
   {
     "name": "Helpful Wood Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26499,7 +26499,7 @@
   },
   {
     "name": "Hidebound",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26522,7 +26522,7 @@
   },
   {
     "name": "Hidebound",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26545,7 +26545,7 @@
   },
   {
     "name": "Humanoid Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26569,7 +26569,7 @@
   },
   {
     "name": "Humanoid Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26593,7 +26593,7 @@
   },
   {
     "name": "Humanoid Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26617,7 +26617,7 @@
   },
   {
     "name": "Illusory Creature",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26644,7 +26644,7 @@
   },
   {
     "name": "Illusory Creature",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26671,7 +26671,7 @@
   },
   {
     "name": "Instant Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26697,7 +26697,7 @@
   },
   {
     "name": "Instant Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26723,7 +26723,7 @@
   },
   {
     "name": "Instant Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26749,7 +26749,7 @@
   },
   {
     "name": "Instant Armor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26775,7 +26775,7 @@
   },
   {
     "name": "Invisibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26799,7 +26799,7 @@
   },
   {
     "name": "Invisibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26823,7 +26823,7 @@
   },
   {
     "name": "Kgalaserke's Axes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26848,7 +26848,7 @@
   },
   {
     "name": "Kgalaserke's Axes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26873,7 +26873,7 @@
   },
   {
     "name": "Knock",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26896,7 +26896,7 @@
   },
   {
     "name": "Knock",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26919,7 +26919,7 @@
   },
   {
     "name": "Laughing Fit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26944,7 +26944,7 @@
   },
   {
     "name": "Laughing Fit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26969,7 +26969,7 @@
   },
   {
     "name": "Lock Item",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -26992,7 +26992,7 @@
   },
   {
     "name": "Lock Item",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27015,7 +27015,7 @@
   },
   {
     "name": "Loose Time's Arrow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27038,7 +27038,7 @@
   },
   {
     "name": "Loose Time's Arrow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27061,7 +27061,7 @@
   },
   {
     "name": "Loose Time's Arrow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27084,7 +27084,7 @@
   },
   {
     "name": "Magnetic Attraction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27108,7 +27108,7 @@
   },
   {
     "name": "Magnetic Attraction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27132,7 +27132,7 @@
   },
   {
     "name": "Magnetic Repulsion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27156,7 +27156,7 @@
   },
   {
     "name": "Magnetic Repulsion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27180,7 +27180,7 @@
   },
   {
     "name": "Manifestation of Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27204,7 +27204,7 @@
   },
   {
     "name": "Manifestation of Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27228,7 +27228,7 @@
   },
   {
     "name": "Mark of Blood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27251,7 +27251,7 @@
   },
   {
     "name": "Mark of Blood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27274,7 +27274,7 @@
   },
   {
     "name": "Mark of Blood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27297,7 +27297,7 @@
   },
   {
     "name": "Marvelous Mount",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27320,7 +27320,7 @@
   },
   {
     "name": "Marvelous Mount",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27343,7 +27343,7 @@
   },
   {
     "name": "Marvelous Mount",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27366,7 +27366,7 @@
   },
   {
     "name": "Marvelous Mount",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27389,7 +27389,7 @@
   },
   {
     "name": "Mental Map",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27412,7 +27412,7 @@
   },
   {
     "name": "Mental Map",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27435,7 +27435,7 @@
   },
   {
     "name": "Mist",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27459,7 +27459,7 @@
   },
   {
     "name": "Mist",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27483,7 +27483,7 @@
   },
   {
     "name": "Noise Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27507,7 +27507,7 @@
   },
   {
     "name": "Noise Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27531,7 +27531,7 @@
   },
   {
     "name": "Noise Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27555,7 +27555,7 @@
   },
   {
     "name": "Oaken Resilience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27580,7 +27580,7 @@
   },
   {
     "name": "Oaken Resilience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27605,7 +27605,7 @@
   },
   {
     "name": "One with Plants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27631,7 +27631,7 @@
   },
   {
     "name": "Paranoia",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27656,7 +27656,7 @@
   },
   {
     "name": "Pave Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27680,7 +27680,7 @@
   },
   {
     "name": "Pave Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27704,7 +27704,7 @@
   },
   {
     "name": "Peaceful Rest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27727,7 +27727,7 @@
   },
   {
     "name": "Peaceful Rest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27750,7 +27750,7 @@
   },
   {
     "name": "Peaceful Rest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27773,7 +27773,7 @@
   },
   {
     "name": "Peaceful Rest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27796,7 +27796,7 @@
   },
   {
     "name": "Penumbral Disguise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27821,7 +27821,7 @@
   },
   {
     "name": "Penumbral Disguise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27846,7 +27846,7 @@
   },
   {
     "name": "Phantasmal Treasure",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27872,7 +27872,7 @@
   },
   {
     "name": "Phantasmal Treasure",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27898,7 +27898,7 @@
   },
   {
     "name": "Propulsive Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27922,7 +27922,7 @@
   },
   {
     "name": "Propulsive Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27946,7 +27946,7 @@
   },
   {
     "name": "Pyrefowl Rebuke",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27970,7 +27970,7 @@
   },
   {
     "name": "Pyrefowl Rebuke",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -27994,7 +27994,7 @@
   },
   {
     "name": "Radiant Field",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28018,7 +28018,7 @@
   },
   {
     "name": "Radiant Field",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28042,7 +28042,7 @@
   },
   {
     "name": "Radiant Field",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28066,7 +28066,7 @@
   },
   {
     "name": "Radiant Field",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28090,7 +28090,7 @@
   },
   {
     "name": "Reaper's Lantern",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28116,7 +28116,7 @@
   },
   {
     "name": "Reaper's Lantern",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28142,7 +28142,7 @@
   },
   {
     "name": "Reaper's Lantern",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28168,7 +28168,7 @@
   },
   {
     "name": "Resist Energy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28191,7 +28191,7 @@
   },
   {
     "name": "Resist Energy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28214,7 +28214,7 @@
   },
   {
     "name": "Resist Energy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28237,7 +28237,7 @@
   },
   {
     "name": "Resist Energy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28260,7 +28260,7 @@
   },
   {
     "name": "Revealing Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28284,7 +28284,7 @@
   },
   {
     "name": "Revealing Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28308,7 +28308,7 @@
   },
   {
     "name": "Revealing Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28332,7 +28332,7 @@
   },
   {
     "name": "Revealing Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28356,7 +28356,7 @@
   },
   {
     "name": "Rubble Step",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28380,7 +28380,7 @@
   },
   {
     "name": "Rubble Step",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28404,7 +28404,7 @@
   },
   {
     "name": "See the Unseen",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28428,7 +28428,7 @@
   },
   {
     "name": "See the Unseen",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28452,7 +28452,7 @@
   },
   {
     "name": "See the Unseen",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28476,7 +28476,7 @@
   },
   {
     "name": "Shape Wood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28501,7 +28501,7 @@
   },
   {
     "name": "Shape Wood",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28526,7 +28526,7 @@
   },
   {
     "name": "Share Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28549,7 +28549,7 @@
   },
   {
     "name": "Shatter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28573,7 +28573,7 @@
   },
   {
     "name": "Shatter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28597,7 +28597,7 @@
   },
   {
     "name": "Shrink",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28621,7 +28621,7 @@
   },
   {
     "name": "Shrink",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28645,7 +28645,7 @@
   },
   {
     "name": "Silence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28669,7 +28669,7 @@
   },
   {
     "name": "Silence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28693,7 +28693,7 @@
   },
   {
     "name": "Slough Skin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28716,7 +28716,7 @@
   },
   {
     "name": "Slough Skin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28739,7 +28739,7 @@
   },
   {
     "name": "Sound Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28764,7 +28764,7 @@
   },
   {
     "name": "Sound Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28789,7 +28789,7 @@
   },
   {
     "name": "Sound Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28814,7 +28814,7 @@
   },
   {
     "name": "Speak with Animals",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28837,7 +28837,7 @@
   },
   {
     "name": "Spirit Sense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28862,7 +28862,7 @@
   },
   {
     "name": "Spirit Sense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28887,7 +28887,7 @@
   },
   {
     "name": "Spiritual Armament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28913,7 +28913,7 @@
   },
   {
     "name": "Spiritual Armament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28939,7 +28939,7 @@
   },
   {
     "name": "Splinter Volley",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28964,7 +28964,7 @@
   },
   {
     "name": "Splinter Volley",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -28989,7 +28989,7 @@
   },
   {
     "name": "Status",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29013,7 +29013,7 @@
   },
   {
     "name": "Status",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29037,7 +29037,7 @@
   },
   {
     "name": "Status",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29061,7 +29061,7 @@
   },
   {
     "name": "Steel Fortifications",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29085,7 +29085,7 @@
   },
   {
     "name": "Steel Fortifications",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29109,7 +29109,7 @@
   },
   {
     "name": "Sticky Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29134,7 +29134,7 @@
   },
   {
     "name": "Sticky Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29159,7 +29159,7 @@
   },
   {
     "name": "Stupefy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29183,7 +29183,7 @@
   },
   {
     "name": "Stupefy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29207,7 +29207,7 @@
   },
   {
     "name": "Sudden Blight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29231,7 +29231,7 @@
   },
   {
     "name": "Sudden Blight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29255,7 +29255,7 @@
   },
   {
     "name": "Summon Elemental",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29279,7 +29279,7 @@
   },
   {
     "name": "Summon Elemental",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29303,7 +29303,7 @@
   },
   {
     "name": "Sure Footing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29327,7 +29327,7 @@
   },
   {
     "name": "Sure Footing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29351,7 +29351,7 @@
   },
   {
     "name": "Sure Footing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29375,7 +29375,7 @@
   },
   {
     "name": "Telekinetic Maneuver",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29400,7 +29400,7 @@
   },
   {
     "name": "Telekinetic Maneuver",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29425,7 +29425,7 @@
   },
   {
     "name": "The Parrot's Whisper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29449,7 +29449,7 @@
   },
   {
     "name": "The Parrot's Whisper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29473,7 +29473,7 @@
   },
   {
     "name": "The Queen's Rainbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29498,7 +29498,7 @@
   },
   {
     "name": "The Queen's Rainbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29523,7 +29523,7 @@
   },
   {
     "name": "The Queen's Rainbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29548,7 +29548,7 @@
   },
   {
     "name": "Thermal Remedy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29572,7 +29572,7 @@
   },
   {
     "name": "Thermal Remedy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29596,7 +29596,7 @@
   },
   {
     "name": "Thermal Remedy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29620,7 +29620,7 @@
   },
   {
     "name": "Translate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29643,7 +29643,7 @@
   },
   {
     "name": "Translate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29666,7 +29666,7 @@
   },
   {
     "name": "Translate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29689,7 +29689,7 @@
   },
   {
     "name": "Tremorsense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29713,7 +29713,7 @@
   },
   {
     "name": "Tremorsense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29737,7 +29737,7 @@
   },
   {
     "name": "Tremorsense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29761,7 +29761,7 @@
   },
   {
     "name": "Veil of Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29785,7 +29785,7 @@
   },
   {
     "name": "Veil of Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29809,7 +29809,7 @@
   },
   {
     "name": "Veil of Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29833,7 +29833,7 @@
   },
   {
     "name": "Voice on the Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29857,7 +29857,7 @@
   },
   {
     "name": "Voice on the Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29881,7 +29881,7 @@
   },
   {
     "name": "Voice on the Breeze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29905,7 +29905,7 @@
   },
   {
     "name": "Vomit Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29928,7 +29928,7 @@
   },
   {
     "name": "Vomit Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29951,7 +29951,7 @@
   },
   {
     "name": "Vomit Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29974,7 +29974,7 @@
   },
   {
     "name": "Warping Pull",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -29998,7 +29998,7 @@
   },
   {
     "name": "Water Breathing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30022,7 +30022,7 @@
   },
   {
     "name": "Water Breathing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30046,7 +30046,7 @@
   },
   {
     "name": "Water Breathing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30070,7 +30070,7 @@
   },
   {
     "name": "Water Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30094,7 +30094,7 @@
   },
   {
     "name": "Water Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30118,7 +30118,7 @@
   },
   {
     "name": "Water Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30142,7 +30142,7 @@
   },
   {
     "name": "Waterproof",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30166,7 +30166,7 @@
   },
   {
     "name": "Waterproof",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30190,7 +30190,7 @@
   },
   {
     "name": "Web",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30213,7 +30213,7 @@
   },
   {
     "name": "Web",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30236,7 +30236,7 @@
   },
   {
     "name": "Animal Vision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30260,7 +30260,7 @@
   },
   {
     "name": "Annunciation of the Outer Gate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30284,7 +30284,7 @@
   },
   {
     "name": "Annunciation of the Outer Gate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30308,7 +30308,7 @@
   },
   {
     "name": "Anointed Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30332,7 +30332,7 @@
   },
   {
     "name": "Antlion Trap",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30356,7 +30356,7 @@
   },
   {
     "name": "Aqueous Orb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30380,7 +30380,7 @@
   },
   {
     "name": "Aqueous Orb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30404,7 +30404,7 @@
   },
   {
     "name": "Behold the Weave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30429,7 +30429,7 @@
   },
   {
     "name": "Behold the Weave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30454,7 +30454,7 @@
   },
   {
     "name": "Bind Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30477,7 +30477,7 @@
   },
   {
     "name": "Bind Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30500,7 +30500,7 @@
   },
   {
     "name": "Bind Undead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30523,7 +30523,7 @@
   },
   {
     "name": "Blastback",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30546,7 +30546,7 @@
   },
   {
     "name": "Blastback",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30569,7 +30569,7 @@
   },
   {
     "name": "Blindness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30593,7 +30593,7 @@
   },
   {
     "name": "Blindness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30617,7 +30617,7 @@
   },
   {
     "name": "Blindness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30641,7 +30641,7 @@
   },
   {
     "name": "Blindness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30665,7 +30665,7 @@
   },
   {
     "name": "Blister Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30689,7 +30689,7 @@
   },
   {
     "name": "Blister Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30713,7 +30713,7 @@
   },
   {
     "name": "Bone Flense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30736,7 +30736,7 @@
   },
   {
     "name": "Bone Flense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30759,7 +30759,7 @@
   },
   {
     "name": "Bone Flense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30782,7 +30782,7 @@
   },
   {
     "name": "Bracing Tendrils",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30806,7 +30806,7 @@
   },
   {
     "name": "Bracing Tendrils",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30830,7 +30830,7 @@
   },
   {
     "name": "Burglar's Blind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30854,7 +30854,7 @@
   },
   {
     "name": "Cave Fangs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30878,7 +30878,7 @@
   },
   {
     "name": "Cave Fangs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30902,7 +30902,7 @@
   },
   {
     "name": "Chilling Darkness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30929,7 +30929,7 @@
   },
   {
     "name": "Clairaudience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30953,7 +30953,7 @@
   },
   {
     "name": "Clairaudience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -30977,7 +30977,7 @@
   },
   {
     "name": "Cloud Dragon's Cloak",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31000,7 +31000,7 @@
   },
   {
     "name": "Cloud Dragon's Cloak",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31023,7 +31023,7 @@
   },
   {
     "name": "Conjured Conveyance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31048,7 +31048,7 @@
   },
   {
     "name": "Conjured Conveyance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31073,7 +31073,7 @@
   },
   {
     "name": "Coral Scourge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31098,7 +31098,7 @@
   },
   {
     "name": "Coral Scourge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31123,7 +31123,7 @@
   },
   {
     "name": "Cordyceps Command",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31149,7 +31149,7 @@
   },
   {
     "name": "Cozy Cabin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31173,7 +31173,7 @@
   },
   {
     "name": "Cozy Cabin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31197,7 +31197,7 @@
   },
   {
     "name": "Crashing Wave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31221,7 +31221,7 @@
   },
   {
     "name": "Crashing Wave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31245,7 +31245,7 @@
   },
   {
     "name": "Crisis of Faith",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31269,7 +31269,7 @@
   },
   {
     "name": "Croak Voice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31294,7 +31294,7 @@
   },
   {
     "name": "Croak Voice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31319,7 +31319,7 @@
   },
   {
     "name": "Cup of Dust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31343,7 +31343,7 @@
   },
   {
     "name": "Cup of Dust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31367,7 +31367,7 @@
   },
   {
     "name": "Cup of Dust",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31391,7 +31391,7 @@
   },
   {
     "name": "Curse of Lost Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31416,7 +31416,7 @@
   },
   {
     "name": "Curse of Lost Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31441,7 +31441,7 @@
   },
   {
     "name": "Curse of Lost Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31466,7 +31466,7 @@
   },
   {
     "name": "Disruptive Transfer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31491,7 +31491,7 @@
   },
   {
     "name": "Disruptive Transfer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31516,7 +31516,7 @@
   },
   {
     "name": "Dive and Breach",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31541,7 +31541,7 @@
   },
   {
     "name": "Dive and Breach",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31566,7 +31566,7 @@
   },
   {
     "name": "Dividing Trench",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31590,7 +31590,7 @@
   },
   {
     "name": "Dividing Trench",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31614,7 +31614,7 @@
   },
   {
     "name": "Dream Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31638,7 +31638,7 @@
   },
   {
     "name": "Dream Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31662,7 +31662,7 @@
   },
   {
     "name": "Dream Message",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31686,7 +31686,7 @@
   },
   {
     "name": "Eagle's Cry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31711,7 +31711,7 @@
   },
   {
     "name": "Eagle's Cry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31736,7 +31736,7 @@
   },
   {
     "name": "Earthbind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31760,7 +31760,7 @@
   },
   {
     "name": "Earthbind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31784,7 +31784,7 @@
   },
   {
     "name": "Echo Jump",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31809,7 +31809,7 @@
   },
   {
     "name": "Echo Jump",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31834,7 +31834,7 @@
   },
   {
     "name": "Elemental Absorption",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31857,7 +31857,7 @@
   },
   {
     "name": "Elemental Absorption",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31880,7 +31880,7 @@
   },
   {
     "name": "Elemental Annihilation Wave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31907,7 +31907,7 @@
   },
   {
     "name": "Elemental Annihilation Wave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31934,7 +31934,7 @@
   },
   {
     "name": "Enthrall",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31959,7 +31959,7 @@
   },
   {
     "name": "Enthrall",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -31984,7 +31984,7 @@
   },
   {
     "name": "Familiar's Face",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32008,7 +32008,7 @@
   },
   {
     "name": "Familiar's Face",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32032,7 +32032,7 @@
   },
   {
     "name": "Familiar's Face",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32056,7 +32056,7 @@
   },
   {
     "name": "Familiar's Face",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32080,7 +32080,7 @@
   },
   {
     "name": "Feet to Fins",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32104,7 +32104,7 @@
   },
   {
     "name": "Feet to Fins",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32128,7 +32128,7 @@
   },
   {
     "name": "Fireball",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32152,7 +32152,7 @@
   },
   {
     "name": "Fireball",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32176,7 +32176,7 @@
   },
   {
     "name": "Focusing Hum",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32199,7 +32199,7 @@
   },
   {
     "name": "Focusing Hum",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32222,7 +32222,7 @@
   },
   {
     "name": "Ghostly Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32245,7 +32245,7 @@
   },
   {
     "name": "Ghostly Weapon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32268,7 +32268,7 @@
   },
   {
     "name": "Gravity Well",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32291,7 +32291,7 @@
   },
   {
     "name": "Gravity Well",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32314,7 +32314,7 @@
   },
   {
     "name": "Haste",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32337,7 +32337,7 @@
   },
   {
     "name": "Haste",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32360,7 +32360,7 @@
   },
   {
     "name": "Haste",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32383,7 +32383,7 @@
   },
   {
     "name": "Heatvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32407,7 +32407,7 @@
   },
   {
     "name": "Heatvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32431,7 +32431,7 @@
   },
   {
     "name": "Heatvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32455,7 +32455,7 @@
   },
   {
     "name": "Heatvision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32479,7 +32479,7 @@
   },
   {
     "name": "Heroism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32503,7 +32503,7 @@
   },
   {
     "name": "Heroism",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32527,7 +32527,7 @@
   },
   {
     "name": "Holy Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32554,7 +32554,7 @@
   },
   {
     "name": "Holy Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32581,7 +32581,7 @@
   },
   {
     "name": "Horde of Underlings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32604,7 +32604,7 @@
   },
   {
     "name": "Horde of Underlings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32627,7 +32627,7 @@
   },
   {
     "name": "Horde of Underlings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32650,7 +32650,7 @@
   },
   {
     "name": "Horde of Underlings",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32673,7 +32673,7 @@
   },
   {
     "name": "Hypercognition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32695,7 +32695,7 @@
   },
   {
     "name": "Hypnotize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32720,7 +32720,7 @@
   },
   {
     "name": "Hypnotize",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32745,7 +32745,7 @@
   },
   {
     "name": "Ibex's Harvest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32770,7 +32770,7 @@
   },
   {
     "name": "Ibex's Harvest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32795,7 +32795,7 @@
   },
   {
     "name": "Insect Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32819,7 +32819,7 @@
   },
   {
     "name": "Insect Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32843,7 +32843,7 @@
   },
   {
     "name": "Lashing Rope",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32867,7 +32867,7 @@
   },
   {
     "name": "Lashing Rope",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32891,7 +32891,7 @@
   },
   {
     "name": "Levitate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32914,7 +32914,7 @@
   },
   {
     "name": "Levitate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32937,7 +32937,7 @@
   },
   {
     "name": "Lightning Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32961,7 +32961,7 @@
   },
   {
     "name": "Lightning Bolt",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -32985,7 +32985,7 @@
   },
   {
     "name": "Locate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33009,7 +33009,7 @@
   },
   {
     "name": "Locate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33033,7 +33033,7 @@
   },
   {
     "name": "Locate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33057,7 +33057,7 @@
   },
   {
     "name": "Lotus Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33082,7 +33082,7 @@
   },
   {
     "name": "Lotus Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33107,7 +33107,7 @@
   },
   {
     "name": "Lotus Walk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33132,7 +33132,7 @@
   },
   {
     "name": "Mad Monkeys",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33155,7 +33155,7 @@
   },
   {
     "name": "Magnetic Acceleration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33180,7 +33180,7 @@
   },
   {
     "name": "Magnetic Acceleration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33205,7 +33205,7 @@
   },
   {
     "name": "Mind Reading",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33230,7 +33230,7 @@
   },
   {
     "name": "Mind Reading",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33255,7 +33255,7 @@
   },
   {
     "name": "Moonlight Ray",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33282,7 +33282,7 @@
   },
   {
     "name": "Moonlight Ray",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33309,7 +33309,7 @@
   },
   {
     "name": "Moth's Supper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33332,7 +33332,7 @@
   },
   {
     "name": "Moth's Supper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33355,7 +33355,7 @@
   },
   {
     "name": "Noxious Metals",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33380,7 +33380,7 @@
   },
   {
     "name": "One with Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33405,7 +33405,7 @@
   },
   {
     "name": "One with Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33430,7 +33430,7 @@
   },
   {
     "name": "Overwhelming Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33455,7 +33455,7 @@
   },
   {
     "name": "Overwhelming Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33480,7 +33480,7 @@
   },
   {
     "name": "Paralyze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33505,7 +33505,7 @@
   },
   {
     "name": "Paralyze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33530,7 +33530,7 @@
   },
   {
     "name": "Perceive the Threads of Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33555,7 +33555,7 @@
   },
   {
     "name": "Perceive the Threads of Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33580,7 +33580,7 @@
   },
   {
     "name": "Perceive the Threads of Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33605,7 +33605,7 @@
   },
   {
     "name": "Pillar of Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33629,7 +33629,7 @@
   },
   {
     "name": "Pillar of Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33653,7 +33653,7 @@
   },
   {
     "name": "Primal Chorus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33678,7 +33678,7 @@
   },
   {
     "name": "Radiant Globe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33702,7 +33702,7 @@
   },
   {
     "name": "Radiant Globe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33726,7 +33726,7 @@
   },
   {
     "name": "Rally Point",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33750,7 +33750,7 @@
   },
   {
     "name": "Rally Point",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33774,7 +33774,7 @@
   },
   {
     "name": "Ring of Truth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33799,7 +33799,7 @@
   },
   {
     "name": "Ring of Truth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33824,7 +33824,7 @@
   },
   {
     "name": "Rouse Skeletons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33847,7 +33847,7 @@
   },
   {
     "name": "Rouse Skeletons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33870,7 +33870,7 @@
   },
   {
     "name": "Rouse Skeletons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33893,7 +33893,7 @@
   },
   {
     "name": "Safe Passage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33916,7 +33916,7 @@
   },
   {
     "name": "Safe Passage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33939,7 +33939,7 @@
   },
   {
     "name": "Safe Passage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33962,7 +33962,7 @@
   },
   {
     "name": "Sand Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33986,7 +33986,7 @@
   },
   {
     "name": "Sand Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34010,7 +34010,7 @@
   },
   {
     "name": "Scrying Ripples",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34035,7 +34035,7 @@
   },
   {
     "name": "Scrying Ripples",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34060,7 +34060,7 @@
   },
   {
     "name": "Scrying Ripples",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34085,7 +34085,7 @@
   },
   {
     "name": "Scrying Ripples",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34110,7 +34110,7 @@
   },
   {
     "name": "Sea of Thought",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34133,7 +34133,7 @@
   },
   {
     "name": "Sea of Thought",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34156,7 +34156,7 @@
   },
   {
     "name": "Shadow Spy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34179,7 +34179,7 @@
   },
   {
     "name": "Shadow Spy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34202,7 +34202,7 @@
   },
   {
     "name": "Shared Invisibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34227,7 +34227,7 @@
   },
   {
     "name": "Shared Invisibility",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34252,7 +34252,7 @@
   },
   {
     "name": "Shifting Sand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34276,7 +34276,7 @@
   },
   {
     "name": "Shifting Sand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34300,7 +34300,7 @@
   },
   {
     "name": "Show the Way",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34324,7 +34324,7 @@
   },
   {
     "name": "Show the Way",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34348,7 +34348,7 @@
   },
   {
     "name": "Shrink Item",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34372,7 +34372,7 @@
   },
   {
     "name": "Slow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34395,7 +34395,7 @@
   },
   {
     "name": "Slow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34418,7 +34418,7 @@
   },
   {
     "name": "Slow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34441,7 +34441,7 @@
   },
   {
     "name": "Soothing Blossoms",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34466,7 +34466,7 @@
   },
   {
     "name": "Soothing Blossoms",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34491,7 +34491,7 @@
   },
   {
     "name": "Speak with Plants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34516,7 +34516,7 @@
   },
   {
     "name": "Speak with Plants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34541,7 +34541,7 @@
   },
   {
     "name": "Speak with Plants",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34566,7 +34566,7 @@
   },
   {
     "name": "Strength of Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34589,7 +34589,7 @@
   },
   {
     "name": "Strength of Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34612,7 +34612,7 @@
   },
   {
     "name": "Strength of Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34635,7 +34635,7 @@
   },
   {
     "name": "Tempest Cloak",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34659,7 +34659,7 @@
   },
   {
     "name": "Tempest Cloak",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34683,7 +34683,7 @@
   },
   {
     "name": "Temporal Twin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34706,7 +34706,7 @@
   },
   {
     "name": "Temporal Twin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34729,7 +34729,7 @@
   },
   {
     "name": "The Four Hunters",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34754,7 +34754,7 @@
   },
   {
     "name": "The Four Hunters",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34779,7 +34779,7 @@
   },
   {
     "name": "Thief of Fortune",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34802,7 +34802,7 @@
   },
   {
     "name": "Thief of Fortune",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34825,7 +34825,7 @@
   },
   {
     "name": "Threefold Aspect",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34849,7 +34849,7 @@
   },
   {
     "name": "Threefold Aspect",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34873,7 +34873,7 @@
   },
   {
     "name": "Time Pocket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34896,7 +34896,7 @@
   },
   {
     "name": "Time Pocket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34919,7 +34919,7 @@
   },
   {
     "name": "Trade Items",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34943,7 +34943,7 @@
   },
   {
     "name": "Trade Items",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34967,7 +34967,7 @@
   },
   {
     "name": "Trade Items",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -34991,7 +34991,7 @@
   },
   {
     "name": "Travel by Turtle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35015,7 +35015,7 @@
   },
   {
     "name": "Travel by Turtle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35039,7 +35039,7 @@
   },
   {
     "name": "Vampiric Feast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35064,7 +35064,7 @@
   },
   {
     "name": "Vampiric Feast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35089,7 +35089,7 @@
   },
   {
     "name": "Vampiric Feast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35114,7 +35114,7 @@
   },
   {
     "name": "Veil of Privacy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35137,7 +35137,7 @@
   },
   {
     "name": "Veil of Privacy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35160,7 +35160,7 @@
   },
   {
     "name": "Veil of Privacy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35183,7 +35183,7 @@
   },
   {
     "name": "Wall of Shadow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35207,7 +35207,7 @@
   },
   {
     "name": "Wall of Shadow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35231,7 +35231,7 @@
   },
   {
     "name": "Wall of Thorns",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35256,7 +35256,7 @@
   },
   {
     "name": "Wall of Thorns",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35281,7 +35281,7 @@
   },
   {
     "name": "Wall of Wind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35305,7 +35305,7 @@
   },
   {
     "name": "Wall of Wind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35329,7 +35329,7 @@
   },
   {
     "name": "Wanderer's Guide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35352,7 +35352,7 @@
   },
   {
     "name": "Wanderer's Guide",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35375,7 +35375,7 @@
   },
   {
     "name": "Whirling Scarves",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35399,7 +35399,7 @@
   },
   {
     "name": "Whirling Scarves",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35423,7 +35423,7 @@
   },
   {
     "name": "Wooden Double",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35446,7 +35446,7 @@
   },
   {
     "name": "Wooden Double",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35469,7 +35469,7 @@
   },
   {
     "name": "Wooden Double",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35492,7 +35492,7 @@
   },
   {
     "name": "Aerial Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35516,7 +35516,7 @@
   },
   {
     "name": "Aerial Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35540,7 +35540,7 @@
   },
   {
     "name": "Airlift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35564,7 +35564,7 @@
   },
   {
     "name": "Airlift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35588,7 +35588,7 @@
   },
   {
     "name": "Bestial Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35613,7 +35613,7 @@
   },
   {
     "name": "Bestial Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35638,7 +35638,7 @@
   },
   {
     "name": "Bestial Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35663,7 +35663,7 @@
   },
   {
     "name": "Bridge of Vines",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35688,7 +35688,7 @@
   },
   {
     "name": "Bridge of Vines",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35713,7 +35713,7 @@
   },
   {
     "name": "Channel Arrogance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35737,7 +35737,7 @@
   },
   {
     "name": "Channel Arrogance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35761,7 +35761,7 @@
   },
   {
     "name": "Chroma Leach",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35784,7 +35784,7 @@
   },
   {
     "name": "Cinder Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35808,7 +35808,7 @@
   },
   {
     "name": "Cinder Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35832,7 +35832,7 @@
   },
   {
     "name": "Clairvoyance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35856,7 +35856,7 @@
   },
   {
     "name": "Clairvoyance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35880,7 +35880,7 @@
   },
   {
     "name": "Cloak of Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35906,7 +35906,7 @@
   },
   {
     "name": "Cloak of Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35932,7 +35932,7 @@
   },
   {
     "name": "Cloud Current",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35957,7 +35957,7 @@
   },
   {
     "name": "Cloud Current",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -35982,7 +35982,7 @@
   },
   {
     "name": "Confusion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36007,7 +36007,7 @@
   },
   {
     "name": "Confusion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36032,7 +36032,7 @@
   },
   {
     "name": "Containment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36056,7 +36056,7 @@
   },
   {
     "name": "Containment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36080,7 +36080,7 @@
   },
   {
     "name": "Countless Eyes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36103,7 +36103,7 @@
   },
   {
     "name": "Countless Eyes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36126,7 +36126,7 @@
   },
   {
     "name": "Countless Eyes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36149,7 +36149,7 @@
   },
   {
     "name": "Creation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36172,7 +36172,7 @@
   },
   {
     "name": "Creation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36195,7 +36195,7 @@
   },
   {
     "name": "Detect Scrying",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36219,7 +36219,7 @@
   },
   {
     "name": "Detect Scrying",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36243,7 +36243,7 @@
   },
   {
     "name": "Dinosaur Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36267,7 +36267,7 @@
   },
   {
     "name": "Dispelling Globe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36290,7 +36290,7 @@
   },
   {
     "name": "Dispelling Globe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36313,7 +36313,7 @@
   },
   {
     "name": "Dispelling Globe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36336,7 +36336,7 @@
   },
   {
     "name": "Divine Wrath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36361,7 +36361,7 @@
   },
   {
     "name": "Draw the Lightning",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36386,7 +36386,7 @@
   },
   {
     "name": "Draw the Lightning",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36411,7 +36411,7 @@
   },
   {
     "name": "Dull Ambition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36437,7 +36437,7 @@
   },
   {
     "name": "Dull Ambition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36463,7 +36463,7 @@
   },
   {
     "name": "Dull Ambition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36489,7 +36489,7 @@
   },
   {
     "name": "Elemental Gift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36512,7 +36512,7 @@
   },
   {
     "name": "Elemental Sense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36536,7 +36536,7 @@
   },
   {
     "name": "Elemental Sense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36560,7 +36560,7 @@
   },
   {
     "name": "Entangle Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36584,7 +36584,7 @@
   },
   {
     "name": "Entangle Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36608,7 +36608,7 @@
   },
   {
     "name": "Fallen Soldier's Lament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36634,7 +36634,7 @@
   },
   {
     "name": "Fallen Soldier's Lament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36660,7 +36660,7 @@
   },
   {
     "name": "False Nature",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36684,7 +36684,7 @@
   },
   {
     "name": "False Nature",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36708,7 +36708,7 @@
   },
   {
     "name": "Filter Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36733,7 +36733,7 @@
   },
   {
     "name": "Filter Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36758,7 +36758,7 @@
   },
   {
     "name": "Filter Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36783,7 +36783,7 @@
   },
   {
     "name": "Fire Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36807,7 +36807,7 @@
   },
   {
     "name": "Fire Shield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36831,7 +36831,7 @@
   },
   {
     "name": "Flicker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36855,7 +36855,7 @@
   },
   {
     "name": "Flicker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36879,7 +36879,7 @@
   },
   {
     "name": "Fly",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36902,7 +36902,7 @@
   },
   {
     "name": "Fly",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36925,7 +36925,7 @@
   },
   {
     "name": "Fly",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36948,7 +36948,7 @@
   },
   {
     "name": "Fly",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36971,7 +36971,7 @@
   },
   {
     "name": "Ghostly Tragedy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -36995,7 +36995,7 @@
   },
   {
     "name": "Ghostly Tragedy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37019,7 +37019,7 @@
   },
   {
     "name": "Glass Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37043,7 +37043,7 @@
   },
   {
     "name": "Glass Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37067,7 +37067,7 @@
   },
   {
     "name": "Grasp of the Deep",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37092,7 +37092,7 @@
   },
   {
     "name": "Grasp of the Deep",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37117,7 +37117,7 @@
   },
   {
     "name": "Grasping Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37141,7 +37141,7 @@
   },
   {
     "name": "Grasping Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37165,7 +37165,7 @@
   },
   {
     "name": "Holy Cascade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37190,7 +37190,7 @@
   },
   {
     "name": "Honeyed Words",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37214,7 +37214,7 @@
   },
   {
     "name": "Hydraulic Torrent",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37238,7 +37238,7 @@
   },
   {
     "name": "Ice Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37262,7 +37262,7 @@
   },
   {
     "name": "Ice Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37286,7 +37286,7 @@
   },
   {
     "name": "Implement of Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37312,7 +37312,7 @@
   },
   {
     "name": "Implement of Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37338,7 +37338,7 @@
   },
   {
     "name": "Infiltrator's Tunnel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37362,7 +37362,7 @@
   },
   {
     "name": "Infiltrator's Tunnel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37386,7 +37386,7 @@
   },
   {
     "name": "It is Written",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37410,7 +37410,7 @@
   },
   {
     "name": "It is Written",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37434,7 +37434,7 @@
   },
   {
     "name": "It is Written",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37458,7 +37458,7 @@
   },
   {
     "name": "Life-Draining Roots",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37483,7 +37483,7 @@
   },
   {
     "name": "Life-Draining Roots",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37508,7 +37508,7 @@
   },
   {
     "name": "Life's Flowing River",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37531,7 +37531,7 @@
   },
   {
     "name": "Life's Fresh Bloom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37556,7 +37556,7 @@
   },
   {
     "name": "Life's Fresh Bloom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37581,7 +37581,7 @@
   },
   {
     "name": "Liminal Doorway",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37605,7 +37605,7 @@
   },
   {
     "name": "Liminal Doorway",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37629,7 +37629,7 @@
   },
   {
     "name": "Luring Wail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37655,7 +37655,7 @@
   },
   {
     "name": "Luring Wail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37681,7 +37681,7 @@
   },
   {
     "name": "Mantis's Grasp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37705,7 +37705,7 @@
   },
   {
     "name": "Mantis's Grasp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37729,7 +37729,7 @@
   },
   {
     "name": "Mercurial Stride",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37754,7 +37754,7 @@
   },
   {
     "name": "Mercurial Stride",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37779,7 +37779,7 @@
   },
   {
     "name": "Mirage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37803,7 +37803,7 @@
   },
   {
     "name": "Mirage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37827,7 +37827,7 @@
   },
   {
     "name": "Mirage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37851,7 +37851,7 @@
   },
   {
     "name": "Misty Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37875,7 +37875,7 @@
   },
   {
     "name": "Misty Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37899,7 +37899,7 @@
   },
   {
     "name": "Misty Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37923,7 +37923,7 @@
   },
   {
     "name": "Morass of Ages",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37947,7 +37947,7 @@
   },
   {
     "name": "Morass of Ages",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37971,7 +37971,7 @@
   },
   {
     "name": "Mountain Resilience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -37995,7 +37995,7 @@
   },
   {
     "name": "Mountain Resilience",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38019,7 +38019,7 @@
   },
   {
     "name": "Murderous Vine",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38045,7 +38045,7 @@
   },
   {
     "name": "Mutilate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38067,7 +38067,7 @@
   },
   {
     "name": "Mutilate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38089,7 +38089,7 @@
   },
   {
     "name": "Mutilate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38111,7 +38111,7 @@
   },
   {
     "name": "Nightmare",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38136,7 +38136,7 @@
   },
   {
     "name": "Nightmare",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38161,7 +38161,7 @@
   },
   {
     "name": "Outcast's Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38187,7 +38187,7 @@
   },
   {
     "name": "Outcast's Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38213,7 +38213,7 @@
   },
   {
     "name": "Outcast's Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38239,7 +38239,7 @@
   },
   {
     "name": "Peaceful Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38262,7 +38262,7 @@
   },
   {
     "name": "Peaceful Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38285,7 +38285,7 @@
   },
   {
     "name": "Pest Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38309,7 +38309,7 @@
   },
   {
     "name": "Pest Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38333,7 +38333,7 @@
   },
   {
     "name": "Pest Swarm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38357,7 +38357,7 @@
   },
   {
     "name": "Petal Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38383,7 +38383,7 @@
   },
   {
     "name": "Phoenix Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38407,7 +38407,7 @@
   },
   {
     "name": "Phoenix Ward",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38431,7 +38431,7 @@
   },
   {
     "name": "Planar Tether",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38454,7 +38454,7 @@
   },
   {
     "name": "Planar Tether",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38477,7 +38477,7 @@
   },
   {
     "name": "Planar Tether",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38500,7 +38500,7 @@
   },
   {
     "name": "Prophet's Luck",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38523,7 +38523,7 @@
   },
   {
     "name": "Prophet's Luck",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38546,7 +38546,7 @@
   },
   {
     "name": "Ranage's Circle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38574,7 +38574,7 @@
   },
   {
     "name": "Ranage's Circle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38602,7 +38602,7 @@
   },
   {
     "name": "Read Omens",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38626,7 +38626,7 @@
   },
   {
     "name": "Read Omens",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38650,7 +38650,7 @@
   },
   {
     "name": "Reflected Beauty",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38675,7 +38675,7 @@
   },
   {
     "name": "Reflected Beauty",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38700,7 +38700,7 @@
   },
   {
     "name": "Reflective Scales",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38723,7 +38723,7 @@
   },
   {
     "name": "Reflective Scales",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38746,7 +38746,7 @@
   },
   {
     "name": "Rewrite Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38770,7 +38770,7 @@
   },
   {
     "name": "Rigid Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38794,7 +38794,7 @@
   },
   {
     "name": "Rigid Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38818,7 +38818,7 @@
   },
   {
     "name": "Rust Cloud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38842,7 +38842,7 @@
   },
   {
     "name": "Rust Cloud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38866,7 +38866,7 @@
   },
   {
     "name": "Sacred Nimbus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38890,7 +38890,7 @@
   },
   {
     "name": "Sacred Nimbus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38914,7 +38914,7 @@
   },
   {
     "name": "Seal Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38939,7 +38939,7 @@
   },
   {
     "name": "Seal Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38964,7 +38964,7 @@
   },
   {
     "name": "Seal Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -38989,7 +38989,7 @@
   },
   {
     "name": "Shape Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39013,7 +39013,7 @@
   },
   {
     "name": "Shape Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39037,7 +39037,7 @@
   },
   {
     "name": "Sliding Blocks",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39061,7 +39061,7 @@
   },
   {
     "name": "Sliding Blocks",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39085,7 +39085,7 @@
   },
   {
     "name": "Snake Fangs",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39109,7 +39109,7 @@
   },
   {
     "name": "Soft Landing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39132,7 +39132,7 @@
   },
   {
     "name": "Soft Landing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39155,7 +39155,7 @@
   },
   {
     "name": "Soft Landing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39178,7 +39178,7 @@
   },
   {
     "name": "Spiritual Renewal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39203,7 +39203,7 @@
   },
   {
     "name": "Stifling Stillness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39228,7 +39228,7 @@
   },
   {
     "name": "Stifling Stillness",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39253,7 +39253,7 @@
   },
   {
     "name": "Suggestion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39280,7 +39280,7 @@
   },
   {
     "name": "Suggestion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39307,7 +39307,7 @@
   },
   {
     "name": "Talking Corpse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39330,7 +39330,7 @@
   },
   {
     "name": "Talking Corpse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39353,7 +39353,7 @@
   },
   {
     "name": "Telepathy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39378,7 +39378,7 @@
   },
   {
     "name": "Telepathy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39403,7 +39403,7 @@
   },
   {
     "name": "Tomorrow's Dawn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39427,7 +39427,7 @@
   },
   {
     "name": "Tomorrow's Dawn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39451,7 +39451,7 @@
   },
   {
     "name": "Translocate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39475,7 +39475,7 @@
   },
   {
     "name": "Translocate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39499,7 +39499,7 @@
   },
   {
     "name": "Trickster's Feathers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39525,7 +39525,7 @@
   },
   {
     "name": "Trickster's Feathers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39551,7 +39551,7 @@
   },
   {
     "name": "Trickster's Feathers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39577,7 +39577,7 @@
   },
   {
     "name": "Trickster's Feathers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39603,7 +39603,7 @@
   },
   {
     "name": "Unfettered Movement",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39626,7 +39626,7 @@
   },
   {
     "name": "Unfettered Movement",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39649,7 +39649,7 @@
   },
   {
     "name": "Unfettered Movement",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39672,7 +39672,7 @@
   },
   {
     "name": "Vampiric Maiden",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39696,7 +39696,7 @@
   },
   {
     "name": "Vampiric Maiden",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39720,7 +39720,7 @@
   },
   {
     "name": "Vampiric Maiden",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39744,7 +39744,7 @@
   },
   {
     "name": "Vapor Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39769,7 +39769,7 @@
   },
   {
     "name": "Vapor Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39794,7 +39794,7 @@
   },
   {
     "name": "Vapor Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39819,7 +39819,7 @@
   },
   {
     "name": "Vision of Death",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39846,7 +39846,7 @@
   },
   {
     "name": "Vision of Death",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39873,7 +39873,7 @@
   },
   {
     "name": "Vital Beacon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39898,7 +39898,7 @@
   },
   {
     "name": "Vital Beacon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39923,7 +39923,7 @@
   },
   {
     "name": "Wall of Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39947,7 +39947,7 @@
   },
   {
     "name": "Wall of Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39971,7 +39971,7 @@
   },
   {
     "name": "Wall Of Mirrors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -39994,7 +39994,7 @@
   },
   {
     "name": "Wall Of Mirrors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40017,7 +40017,7 @@
   },
   {
     "name": "Weapon Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40040,7 +40040,7 @@
   },
   {
     "name": "Weapon Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40063,7 +40063,7 @@
   },
   {
     "name": "Whispers of the Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40088,7 +40088,7 @@
   },
   {
     "name": "Whispers of the Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40113,7 +40113,7 @@
   },
   {
     "name": "Ymeri's Mark",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40139,7 +40139,7 @@
   },
   {
     "name": "Ymeri's Mark",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40165,7 +40165,7 @@
   },
   {
     "name": "Ymeri's Mark",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40191,7 +40191,7 @@
   },
   {
     "name": "Zephyr Slip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40215,7 +40215,7 @@
   },
   {
     "name": "Zephyr Slip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40239,7 +40239,7 @@
   },
   {
     "name": "Acid Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40263,7 +40263,7 @@
   },
   {
     "name": "Acid Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40287,7 +40287,7 @@
   },
   {
     "name": "Ancestral Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40314,7 +40314,7 @@
   },
   {
     "name": "Ancestral Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40341,7 +40341,7 @@
   },
   {
     "name": "Ancestral Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40368,7 +40368,7 @@
   },
   {
     "name": "Banishment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40392,7 +40392,7 @@
   },
   {
     "name": "Banishment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40416,7 +40416,7 @@
   },
   {
     "name": "Banishment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40440,7 +40440,7 @@
   },
   {
     "name": "Banishment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40464,7 +40464,7 @@
   },
   {
     "name": "Blinding Bottle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40488,7 +40488,7 @@
   },
   {
     "name": "Blinding Bottle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40512,7 +40512,7 @@
   },
   {
     "name": "Blister",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40535,7 +40535,7 @@
   },
   {
     "name": "Blister",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40558,7 +40558,7 @@
   },
   {
     "name": "Blister",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40581,7 +40581,7 @@
   },
   {
     "name": "Blood-Feasting Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40607,7 +40607,7 @@
   },
   {
     "name": "Blood-Feasting Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40633,7 +40633,7 @@
   },
   {
     "name": "Boomerang Shot",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40659,7 +40659,7 @@
   },
   {
     "name": "Boomerang Shot",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40685,7 +40685,7 @@
   },
   {
     "name": "Breath of Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40709,7 +40709,7 @@
   },
   {
     "name": "Chameleon Coat",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40733,7 +40733,7 @@
   },
   {
     "name": "Cloak of Colors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40757,7 +40757,7 @@
   },
   {
     "name": "Cloak of Colors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40781,7 +40781,7 @@
   },
   {
     "name": "Confusing Cry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40808,7 +40808,7 @@
   },
   {
     "name": "Confusing Cry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40835,7 +40835,7 @@
   },
   {
     "name": "Control Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40859,7 +40859,7 @@
   },
   {
     "name": "Control Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40883,7 +40883,7 @@
   },
   {
     "name": "Corrosive Muck",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40907,7 +40907,7 @@
   },
   {
     "name": "Corrosive Muck",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40931,7 +40931,7 @@
   },
   {
     "name": "Desperate Repair",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40953,7 +40953,7 @@
   },
   {
     "name": "Desperate Repair",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -40975,7 +40975,7 @@
   },
   {
     "name": "Diadem of Divine Radiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41001,7 +41001,7 @@
   },
   {
     "name": "Diadem of Divine Radiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41027,7 +41027,7 @@
   },
   {
     "name": "Diadem of Divine Radiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41053,7 +41053,7 @@
   },
   {
     "name": "Diadem of Divine Radiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41079,7 +41079,7 @@
   },
   {
     "name": "Divine Dragon's Watch",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41105,7 +41105,7 @@
   },
   {
     "name": "Divine Immolation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41131,7 +41131,7 @@
   },
   {
     "name": "Domora's Defense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41157,7 +41157,7 @@
   },
   {
     "name": "Domora's Defense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41183,7 +41183,7 @@
   },
   {
     "name": "Domora's Defense",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41209,7 +41209,7 @@
   },
   {
     "name": "Dreaming Potential",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41233,7 +41233,7 @@
   },
   {
     "name": "Drop Dead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41258,7 +41258,7 @@
   },
   {
     "name": "Drop Dead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41283,7 +41283,7 @@
   },
   {
     "name": "Drop Dead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41308,7 +41308,7 @@
   },
   {
     "name": "Elemental Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41331,7 +41331,7 @@
   },
   {
     "name": "Elemental Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41354,7 +41354,7 @@
   },
   {
     "name": "Elemental Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41378,7 +41378,7 @@
   },
   {
     "name": "Elemental Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41402,7 +41402,7 @@
   },
   {
     "name": "Engrave Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41426,7 +41426,7 @@
   },
   {
     "name": "Engrave Memory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41450,7 +41450,7 @@
   },
   {
     "name": "Entwined Roots",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41474,7 +41474,7 @@
   },
   {
     "name": "Entwined Roots",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41498,7 +41498,7 @@
   },
   {
     "name": "Etheric Shards",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41522,7 +41522,7 @@
   },
   {
     "name": "Etheric Shards",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41546,7 +41546,7 @@
   },
   {
     "name": "False Vision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41570,7 +41570,7 @@
   },
   {
     "name": "False Vision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41594,7 +41594,7 @@
   },
   {
     "name": "Fire's Pathway",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41619,7 +41619,7 @@
   },
   {
     "name": "Fire's Pathway",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41644,7 +41644,7 @@
   },
   {
     "name": "Flame Dancer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41668,7 +41668,7 @@
   },
   {
     "name": "Flame Dancer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41692,7 +41692,7 @@
   },
   {
     "name": "Flame Dancer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41716,7 +41716,7 @@
   },
   {
     "name": "Flames of Ego",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41743,7 +41743,7 @@
   },
   {
     "name": "Flames of Ego",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41770,7 +41770,7 @@
   },
   {
     "name": "Flames of Ego",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41797,7 +41797,7 @@
   },
   {
     "name": "Freezing Rain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41822,7 +41822,7 @@
   },
   {
     "name": "Freezing Rain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41847,7 +41847,7 @@
   },
   {
     "name": "Grisly Growths",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41870,7 +41870,7 @@
   },
   {
     "name": "Grisly Growths",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41893,7 +41893,7 @@
   },
   {
     "name": "Hallucination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41919,7 +41919,7 @@
   },
   {
     "name": "Hallucination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41945,7 +41945,7 @@
   },
   {
     "name": "Howling Blizzard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41970,7 +41970,7 @@
   },
   {
     "name": "Howling Blizzard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -41995,7 +41995,7 @@
   },
   {
     "name": "Illusory Scene",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42022,7 +42022,7 @@
   },
   {
     "name": "Illusory Scene",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42049,7 +42049,7 @@
   },
   {
     "name": "Imaginary Lockbox",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42073,7 +42073,7 @@
   },
   {
     "name": "Imaginary Lockbox",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42097,7 +42097,7 @@
   },
   {
     "name": "Impaling Spike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42121,7 +42121,7 @@
   },
   {
     "name": "Impaling Spike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42145,7 +42145,7 @@
   },
   {
     "name": "Instant Minefield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42170,7 +42170,7 @@
   },
   {
     "name": "Instant Minefield",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42195,7 +42195,7 @@
   },
   {
     "name": "Invoke Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42222,7 +42222,7 @@
   },
   {
     "name": "Invoke Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42249,7 +42249,7 @@
   },
   {
     "name": "Invoke Spirits",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42276,7 +42276,7 @@
   },
   {
     "name": "King's Castle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42300,7 +42300,7 @@
   },
   {
     "name": "King's Castle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42324,7 +42324,7 @@
   },
   {
     "name": "King's Castle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42348,7 +42348,7 @@
   },
   {
     "name": "Lashunta's Life Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42371,7 +42371,7 @@
   },
   {
     "name": "Lashunta's Life Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42394,7 +42394,7 @@
   },
   {
     "name": "Lashunta's Life Bubble",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42417,7 +42417,7 @@
   },
   {
     "name": "Lightning Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42441,7 +42441,7 @@
   },
   {
     "name": "Magic Passage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42465,7 +42465,7 @@
   },
   {
     "name": "Magic Passage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42489,7 +42489,7 @@
   },
   {
     "name": "Mantle of the Melting Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42514,7 +42514,7 @@
   },
   {
     "name": "Mantle of the Melting Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42539,7 +42539,7 @@
   },
   {
     "name": "Mantle of the Unwavering Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42565,7 +42565,7 @@
   },
   {
     "name": "Mantle of the Unwavering Heart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42591,7 +42591,7 @@
   },
   {
     "name": "Mariner's Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42615,7 +42615,7 @@
   },
   {
     "name": "Mariner's Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42639,7 +42639,7 @@
   },
   {
     "name": "Mariner's Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42663,7 +42663,7 @@
   },
   {
     "name": "Mind Probe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42688,7 +42688,7 @@
   },
   {
     "name": "Mind Probe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42713,7 +42713,7 @@
   },
   {
     "name": "Moon Frenzy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42737,7 +42737,7 @@
   },
   {
     "name": "Nature's Pathway",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42763,7 +42763,7 @@
   },
   {
     "name": "Plant Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42789,7 +42789,7 @@
   },
   {
     "name": "Pressure Zone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42813,7 +42813,7 @@
   },
   {
     "name": "Pressure Zone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42837,7 +42837,7 @@
   },
   {
     "name": "Quicken Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42860,7 +42860,7 @@
   },
   {
     "name": "Quicken Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42883,7 +42883,7 @@
   },
   {
     "name": "Sawtooth Terrain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42907,7 +42907,7 @@
   },
   {
     "name": "Sawtooth Terrain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42931,7 +42931,7 @@
   },
   {
     "name": "Sawtooth Terrain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42955,7 +42955,7 @@
   },
   {
     "name": "Scouting Eye",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -42979,7 +42979,7 @@
   },
   {
     "name": "Scouting Eye",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43003,7 +43003,7 @@
   },
   {
     "name": "Scouting Eye",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43027,7 +43027,7 @@
   },
   {
     "name": "Sending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43051,7 +43051,7 @@
   },
   {
     "name": "Sending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43075,7 +43075,7 @@
   },
   {
     "name": "Sending",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43099,7 +43099,7 @@
   },
   {
     "name": "Shadow Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43123,7 +43123,7 @@
   },
   {
     "name": "Shadow Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43147,7 +43147,7 @@
   },
   {
     "name": "Shock and Awe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43176,7 +43176,7 @@
   },
   {
     "name": "Shock and Awe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43205,7 +43205,7 @@
   },
   {
     "name": "Slither",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43229,7 +43229,7 @@
   },
   {
     "name": "Slither",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43253,7 +43253,7 @@
   },
   {
     "name": "Speak with Stones",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43277,7 +43277,7 @@
   },
   {
     "name": "Speak with Stones",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43301,7 +43301,7 @@
   },
   {
     "name": "Speak with Stones",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43325,7 +43325,7 @@
   },
   {
     "name": "Spiritual Guardian",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43350,7 +43350,7 @@
   },
   {
     "name": "Spiritual Transport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43374,7 +43374,7 @@
   },
   {
     "name": "Stagnate Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43397,7 +43397,7 @@
   },
   {
     "name": "Stagnate Time",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43420,7 +43420,7 @@
   },
   {
     "name": "Strange Geometry",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43444,7 +43444,7 @@
   },
   {
     "name": "Subconscious Suggestion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43471,7 +43471,7 @@
   },
   {
     "name": "Subconscious Suggestion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43498,7 +43498,7 @@
   },
   {
     "name": "Summon Celestial",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43522,7 +43522,7 @@
   },
   {
     "name": "Summon Dragon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43546,7 +43546,7 @@
   },
   {
     "name": "Summon Dragon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43570,7 +43570,7 @@
   },
   {
     "name": "Summon Dragon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43594,7 +43594,7 @@
   },
   {
     "name": "Summon Dragon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43618,7 +43618,7 @@
   },
   {
     "name": "Summon Entity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43642,7 +43642,7 @@
   },
   {
     "name": "Summon Fiend",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43667,7 +43667,7 @@
   },
   {
     "name": "Summon Giant",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43691,7 +43691,7 @@
   },
   {
     "name": "Summon Monitor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43715,7 +43715,7 @@
   },
   {
     "name": "Synaptic Pulse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43740,7 +43740,7 @@
   },
   {
     "name": "Synesthesia",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43764,7 +43764,7 @@
   },
   {
     "name": "Telekinetic Haul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43787,7 +43787,7 @@
   },
   {
     "name": "Telekinetic Haul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43810,7 +43810,7 @@
   },
   {
     "name": "Toxic Cloud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43835,7 +43835,7 @@
   },
   {
     "name": "Toxic Cloud",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43860,7 +43860,7 @@
   },
   {
     "name": "Truespeech",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43883,7 +43883,7 @@
   },
   {
     "name": "Truespeech",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43906,7 +43906,7 @@
   },
   {
     "name": "Truespeech",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43929,7 +43929,7 @@
   },
   {
     "name": "Umbral Journey",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43954,7 +43954,7 @@
   },
   {
     "name": "Umbral Journey",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -43979,7 +43979,7 @@
   },
   {
     "name": "Wall of Flesh",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44002,7 +44002,7 @@
   },
   {
     "name": "Wall of Flesh",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44025,7 +44025,7 @@
   },
   {
     "name": "Wall of Flesh",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44048,7 +44048,7 @@
   },
   {
     "name": "Wall of Ice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44073,7 +44073,7 @@
   },
   {
     "name": "Wall of Ice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44098,7 +44098,7 @@
   },
   {
     "name": "Wall of Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44122,7 +44122,7 @@
   },
   {
     "name": "Wall of Stone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44146,7 +44146,7 @@
   },
   {
     "name": "Wave of Despair",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44171,7 +44171,7 @@
   },
   {
     "name": "Wave of Despair",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44196,7 +44196,7 @@
   },
   {
     "name": "Wisdom of the Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44220,7 +44220,7 @@
   },
   {
     "name": "Wisdom of the Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44244,7 +44244,7 @@
   },
   {
     "name": "Wisdom of the Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44268,7 +44268,7 @@
   },
   {
     "name": "Wisdom of the Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44292,7 +44292,7 @@
   },
   {
     "name": "Arrow Salvo",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44316,7 +44316,7 @@
   },
   {
     "name": "Arrow Salvo",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44340,7 +44340,7 @@
   },
   {
     "name": "Awaken Entropy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44363,7 +44363,7 @@
   },
   {
     "name": "Awaken Entropy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44386,7 +44386,7 @@
   },
   {
     "name": "Awaken Entropy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44409,7 +44409,7 @@
   },
   {
     "name": "Blanket of Stars",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44433,7 +44433,7 @@
   },
   {
     "name": "Blanket of Stars",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44457,7 +44457,7 @@
   },
   {
     "name": "Blessed Boundary",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44482,7 +44482,7 @@
   },
   {
     "name": "Blinding Fury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44508,7 +44508,7 @@
   },
   {
     "name": "Blinding Fury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44534,7 +44534,7 @@
   },
   {
     "name": "Blinding Fury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44560,7 +44560,7 @@
   },
   {
     "name": "Boots on the Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44586,7 +44586,7 @@
   },
   {
     "name": "Boots on the Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44612,7 +44612,7 @@
   },
   {
     "name": "Bounty of the Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44637,7 +44637,7 @@
   },
   {
     "name": "Bounty of the Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44662,7 +44662,7 @@
   },
   {
     "name": "Chain Lightning",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44686,7 +44686,7 @@
   },
   {
     "name": "Chain Lightning",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44710,7 +44710,7 @@
   },
   {
     "name": "Collective Transposition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44734,7 +44734,7 @@
   },
   {
     "name": "Collective Transposition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44758,7 +44758,7 @@
   },
   {
     "name": "Crimson Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44781,7 +44781,7 @@
   },
   {
     "name": "Crimson Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44804,7 +44804,7 @@
   },
   {
     "name": "Crimson Breath",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44827,7 +44827,7 @@
   },
   {
     "name": "Cursed Metamorphosis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44853,7 +44853,7 @@
   },
   {
     "name": "Cursed Metamorphosis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44879,7 +44879,7 @@
   },
   {
     "name": "Cursed Metamorphosis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44905,7 +44905,7 @@
   },
   {
     "name": "Disintegrate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44929,7 +44929,7 @@
   },
   {
     "name": "Dominate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44954,7 +44954,7 @@
   },
   {
     "name": "Dominate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -44979,7 +44979,7 @@
   },
   {
     "name": "Dominate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45004,7 +45004,7 @@
   },
   {
     "name": "Dragon Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45028,7 +45028,7 @@
   },
   {
     "name": "Dragon Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45052,7 +45052,7 @@
   },
   {
     "name": "Dragon Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45076,7 +45076,7 @@
   },
   {
     "name": "Dragon Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45100,7 +45100,7 @@
   },
   {
     "name": "Earth and Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45125,7 +45125,7 @@
   },
   {
     "name": "Earth and Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45150,7 +45150,7 @@
   },
   {
     "name": "Elemental Confluence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45179,7 +45179,7 @@
   },
   {
     "name": "Elemental Confluence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45208,7 +45208,7 @@
   },
   {
     "name": "Explosive Barrage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45233,7 +45233,7 @@
   },
   {
     "name": "Explosive Barrage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45258,7 +45258,7 @@
   },
   {
     "name": "Fateful Condemnation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45284,7 +45284,7 @@
   },
   {
     "name": "Fateful Condemnation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45310,7 +45310,7 @@
   },
   {
     "name": "Field of Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45335,7 +45335,7 @@
   },
   {
     "name": "Field of Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45360,7 +45360,7 @@
   },
   {
     "name": "Field of Razors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45384,7 +45384,7 @@
   },
   {
     "name": "Field of Razors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45408,7 +45408,7 @@
   },
   {
     "name": "Frost Pillar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45433,7 +45433,7 @@
   },
   {
     "name": "Frost Pillar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45458,7 +45458,7 @@
   },
   {
     "name": "Frozen Fog",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45482,7 +45482,7 @@
   },
   {
     "name": "Frozen Fog",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45506,7 +45506,7 @@
   },
   {
     "name": "Lignify",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45531,7 +45531,7 @@
   },
   {
     "name": "Lignify",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45556,7 +45556,7 @@
   },
   {
     "name": "Mislead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45580,7 +45580,7 @@
   },
   {
     "name": "Mislead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45604,7 +45604,7 @@
   },
   {
     "name": "Missed Cue",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45630,7 +45630,7 @@
   },
   {
     "name": "Missed Cue",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45656,7 +45656,7 @@
   },
   {
     "name": "Nature's Reprisal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45682,7 +45682,7 @@
   },
   {
     "name": "Never Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45708,7 +45708,7 @@
   },
   {
     "name": "Never Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45734,7 +45734,7 @@
   },
   {
     "name": "Pain of Ages",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45758,7 +45758,7 @@
   },
   {
     "name": "Personal Ocean",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45782,7 +45782,7 @@
   },
   {
     "name": "Personal Ocean",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45806,7 +45806,7 @@
   },
   {
     "name": "Petrify",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45830,7 +45830,7 @@
   },
   {
     "name": "Petrify",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45854,7 +45854,7 @@
   },
   {
     "name": "Phantasmal Calamity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45879,7 +45879,7 @@
   },
   {
     "name": "Phantasmal Calamity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45904,7 +45904,7 @@
   },
   {
     "name": "Phantom Orchestra",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45929,7 +45929,7 @@
   },
   {
     "name": "Phantom Orchestra",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45954,7 +45954,7 @@
   },
   {
     "name": "Phantom Orchestra",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -45979,7 +45979,7 @@
   },
   {
     "name": "Poltergeist's Fury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46002,7 +46002,7 @@
   },
   {
     "name": "Poltergeist's Fury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46025,7 +46025,7 @@
   },
   {
     "name": "Raise Dead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46049,7 +46049,7 @@
   },
   {
     "name": "Repulsion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46074,7 +46074,7 @@
   },
   {
     "name": "Repulsion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46099,7 +46099,7 @@
   },
   {
     "name": "Repulsion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46124,7 +46124,7 @@
   },
   {
     "name": "Sacred Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46148,7 +46148,7 @@
   },
   {
     "name": "Scintillating Safeguard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46170,7 +46170,7 @@
   },
   {
     "name": "Scintillating Safeguard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46192,7 +46192,7 @@
   },
   {
     "name": "Scintillating Safeguard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46214,7 +46214,7 @@
   },
   {
     "name": "Scrying",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46238,7 +46238,7 @@
   },
   {
     "name": "Scrying",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46262,7 +46262,7 @@
   },
   {
     "name": "Seize Identity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46289,7 +46289,7 @@
   },
   {
     "name": "Seize Identity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46316,7 +46316,7 @@
   },
   {
     "name": "Siege Weapon's Blessing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46339,7 +46339,7 @@
   },
   {
     "name": "Siege Weapon's Blessing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46362,7 +46362,7 @@
   },
   {
     "name": "Siege Weapon's Blessing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46385,7 +46385,7 @@
   },
   {
     "name": "Skeleton Army",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46409,7 +46409,7 @@
   },
   {
     "name": "Skeleton Army",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46433,7 +46433,7 @@
   },
   {
     "name": "Skeleton Army",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46457,7 +46457,7 @@
   },
   {
     "name": "Spellwrack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46482,7 +46482,7 @@
   },
   {
     "name": "Spellwrack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46507,7 +46507,7 @@
   },
   {
     "name": "Spellwrack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46532,7 +46532,7 @@
   },
   {
     "name": "Spirit Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46556,7 +46556,7 @@
   },
   {
     "name": "Spirit Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46580,7 +46580,7 @@
   },
   {
     "name": "Suspended Retribution",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46606,7 +46606,7 @@
   },
   {
     "name": "Suspended Retribution",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46632,7 +46632,7 @@
   },
   {
     "name": "Tanglecurse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46657,7 +46657,7 @@
   },
   {
     "name": "Tanglecurse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46682,7 +46682,7 @@
   },
   {
     "name": "Tangling Creepers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46707,7 +46707,7 @@
   },
   {
     "name": "Tangling Creepers",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46732,7 +46732,7 @@
   },
   {
     "name": "Teleport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46756,7 +46756,7 @@
   },
   {
     "name": "Teleport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46780,7 +46780,7 @@
   },
   {
     "name": "Tree of Seasons",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46805,7 +46805,7 @@
   },
   {
     "name": "Truesight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46829,7 +46829,7 @@
   },
   {
     "name": "Truesight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46853,7 +46853,7 @@
   },
   {
     "name": "Truesight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46877,7 +46877,7 @@
   },
   {
     "name": "Truesight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46901,7 +46901,7 @@
   },
   {
     "name": "Utter Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46925,7 +46925,7 @@
   },
   {
     "name": "Utter Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46949,7 +46949,7 @@
   },
   {
     "name": "Utter Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46973,7 +46973,7 @@
   },
   {
     "name": "Vampiric Exsanguination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -46998,7 +46998,7 @@
   },
   {
     "name": "Vampiric Exsanguination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47023,7 +47023,7 @@
   },
   {
     "name": "Vampiric Exsanguination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47048,7 +47048,7 @@
   },
   {
     "name": "Vibrant Pattern",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47074,7 +47074,7 @@
   },
   {
     "name": "Vibrant Pattern",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47100,7 +47100,7 @@
   },
   {
     "name": "Vitrifying Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47124,7 +47124,7 @@
   },
   {
     "name": "Vitrifying Blast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47148,7 +47148,7 @@
   },
   {
     "name": "Wall of Force",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47172,7 +47172,7 @@
   },
   {
     "name": "Wall of Force",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47196,7 +47196,7 @@
   },
   {
     "name": "Wall of Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47220,7 +47220,7 @@
   },
   {
     "name": "Wall of Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47244,7 +47244,7 @@
   },
   {
     "name": "Zealous Conviction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47269,7 +47269,7 @@
   },
   {
     "name": "Zealous Conviction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47294,7 +47294,7 @@
   },
   {
     "name": "Attacked from Within",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47318,7 +47318,7 @@
   },
   {
     "name": "Attacked from Within",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47342,7 +47342,7 @@
   },
   {
     "name": "Beheading Buzz Saw",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47366,7 +47366,7 @@
   },
   {
     "name": "Chrysopoetic Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47390,7 +47390,7 @@
   },
   {
     "name": "Chrysopoetic Curse",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47414,7 +47414,7 @@
   },
   {
     "name": "Contingency",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47437,7 +47437,7 @@
   },
   {
     "name": "Dancing Fountain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47461,7 +47461,7 @@
   },
   {
     "name": "Dancing Fountain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47485,7 +47485,7 @@
   },
   {
     "name": "Devouring Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47509,7 +47509,7 @@
   },
   {
     "name": "Devouring Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47533,7 +47533,7 @@
   },
   {
     "name": "Devouring Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47557,7 +47557,7 @@
   },
   {
     "name": "Divine Decree",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47582,7 +47582,7 @@
   },
   {
     "name": "Duplicate Foe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47605,7 +47605,7 @@
   },
   {
     "name": "Duplicate Foe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47628,7 +47628,7 @@
   },
   {
     "name": "Eclipse Burst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47654,7 +47654,7 @@
   },
   {
     "name": "Eclipse Burst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47680,7 +47680,7 @@
   },
   {
     "name": "Eclipse Burst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47706,7 +47706,7 @@
   },
   {
     "name": "Energy Aegis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47729,7 +47729,7 @@
   },
   {
     "name": "Energy Aegis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47752,7 +47752,7 @@
   },
   {
     "name": "Energy Aegis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47775,7 +47775,7 @@
   },
   {
     "name": "Energy Aegis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47798,7 +47798,7 @@
   },
   {
     "name": "Execute",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47823,7 +47823,7 @@
   },
   {
     "name": "Execute",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47848,7 +47848,7 @@
   },
   {
     "name": "Fiery Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47873,7 +47873,7 @@
   },
   {
     "name": "Fiery Body",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47898,7 +47898,7 @@
   },
   {
     "name": "Final Fate of the Locust Host",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47923,7 +47923,7 @@
   },
   {
     "name": "Final Fate of the Locust Host",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47948,7 +47948,7 @@
   },
   {
     "name": "Final Fate of the Locust Host",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47973,7 +47973,7 @@
   },
   {
     "name": "Final Fate of the Locust Host",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -47998,7 +47998,7 @@
   },
   {
     "name": "Heaving Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48022,7 +48022,7 @@
   },
   {
     "name": "Heaving Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48046,7 +48046,7 @@
   },
   {
     "name": "Hungry Depths",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48071,7 +48071,7 @@
   },
   {
     "name": "Hungry Depths",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48096,7 +48096,7 @@
   },
   {
     "name": "Indolent Haze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48122,7 +48122,7 @@
   },
   {
     "name": "Indolent Haze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48148,7 +48148,7 @@
   },
   {
     "name": "Interplanar Teleport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48172,7 +48172,7 @@
   },
   {
     "name": "Interplanar Teleport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48196,7 +48196,7 @@
   },
   {
     "name": "Interplanar Teleport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48220,7 +48220,7 @@
   },
   {
     "name": "Interplanar Teleport",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48244,7 +48244,7 @@
   },
   {
     "name": "Lifewood Cage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48269,7 +48269,7 @@
   },
   {
     "name": "Lifewood Cage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48294,7 +48294,7 @@
   },
   {
     "name": "Love's Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48319,7 +48319,7 @@
   },
   {
     "name": "Love's Sacrifice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48344,7 +48344,7 @@
   },
   {
     "name": "Mask of Terror",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48372,7 +48372,7 @@
   },
   {
     "name": "Mask of Terror",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48400,7 +48400,7 @@
   },
   {
     "name": "Mask of Terror",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48428,7 +48428,7 @@
   },
   {
     "name": "Momentary Recovery",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48452,7 +48452,7 @@
   },
   {
     "name": "Momentary Recovery",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48476,7 +48476,7 @@
   },
   {
     "name": "Moonburst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48502,7 +48502,7 @@
   },
   {
     "name": "Moonburst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48528,7 +48528,7 @@
   },
   {
     "name": "Orb of Twisting Fate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48552,7 +48552,7 @@
   },
   {
     "name": "Planar Palace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48576,7 +48576,7 @@
   },
   {
     "name": "Planar Palace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48600,7 +48600,7 @@
   },
   {
     "name": "Planar Seal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48623,7 +48623,7 @@
   },
   {
     "name": "Planar Seal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48646,7 +48646,7 @@
   },
   {
     "name": "Planar Seal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48669,7 +48669,7 @@
   },
   {
     "name": "Pollen Pods",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48694,7 +48694,7 @@
   },
   {
     "name": "Pollen Pods",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48719,7 +48719,7 @@
   },
   {
     "name": "Possession",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48745,7 +48745,7 @@
   },
   {
     "name": "Project Image",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48770,7 +48770,7 @@
   },
   {
     "name": "Project Image",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48795,7 +48795,7 @@
   },
   {
     "name": "Ray of Corruption",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48820,7 +48820,7 @@
   },
   {
     "name": "Ray of Corruption",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48845,7 +48845,7 @@
   },
   {
     "name": "Recall Legacy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48869,7 +48869,7 @@
   },
   {
     "name": "Recall Legacy",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48893,7 +48893,7 @@
   },
   {
     "name": "Regenerate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48918,7 +48918,7 @@
   },
   {
     "name": "Regenerate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48943,7 +48943,7 @@
   },
   {
     "name": "Restore Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48967,7 +48967,7 @@
   },
   {
     "name": "Restore Ground",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -48991,7 +48991,7 @@
   },
   {
     "name": "Retrocognition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49014,7 +49014,7 @@
   },
   {
     "name": "Shock to the System",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49041,7 +49041,7 @@
   },
   {
     "name": "Shock to the System",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49068,7 +49068,7 @@
   },
   {
     "name": "Shock to the System",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49095,7 +49095,7 @@
   },
   {
     "name": "Spell Riposte",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49117,7 +49117,7 @@
   },
   {
     "name": "Spell Riposte",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49139,7 +49139,7 @@
   },
   {
     "name": "Spell Riposte",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49161,7 +49161,7 @@
   },
   {
     "name": "Summon Stampede",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49185,7 +49185,7 @@
   },
   {
     "name": "Sunburst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49211,7 +49211,7 @@
   },
   {
     "name": "Sunburst",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49237,7 +49237,7 @@
   },
   {
     "name": "Telekinetic Bombardment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49260,7 +49260,7 @@
   },
   {
     "name": "Telekinetic Bombardment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49283,7 +49283,7 @@
   },
   {
     "name": "Time Beacon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49305,7 +49305,7 @@
   },
   {
     "name": "Time Beacon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49327,7 +49327,7 @@
   },
   {
     "name": "True Target",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49351,7 +49351,7 @@
   },
   {
     "name": "True Target",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49375,7 +49375,7 @@
   },
   {
     "name": "Unfettered Pack",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49398,7 +49398,7 @@
   },
   {
     "name": "Vacuum",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49423,7 +49423,7 @@
   },
   {
     "name": "Vacuum",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49448,7 +49448,7 @@
   },
   {
     "name": "Vibrant Vibrato",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49474,7 +49474,7 @@
   },
   {
     "name": "Vibrant Vibrato",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49500,7 +49500,7 @@
   },
   {
     "name": "Visions of Danger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49526,7 +49526,7 @@
   },
   {
     "name": "Volcanic Eruption",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49550,7 +49550,7 @@
   },
   {
     "name": "Warp Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49576,7 +49576,7 @@
   },
   {
     "name": "Warp Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49602,7 +49602,7 @@
   },
   {
     "name": "Arctic Rift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49626,7 +49626,7 @@
   },
   {
     "name": "Arctic Rift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49650,7 +49650,7 @@
   },
   {
     "name": "Canticle of Everlasting Grief",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49678,7 +49678,7 @@
   },
   {
     "name": "Canticle of Everlasting Grief",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49706,7 +49706,7 @@
   },
   {
     "name": "Clockwork Devotion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49730,7 +49730,7 @@
   },
   {
     "name": "Confusing Colors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49756,7 +49756,7 @@
   },
   {
     "name": "Confusing Colors",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49782,7 +49782,7 @@
   },
   {
     "name": "Desiccate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49806,7 +49806,7 @@
   },
   {
     "name": "Desiccate",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49830,7 +49830,7 @@
   },
   {
     "name": "Disappearance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49854,7 +49854,7 @@
   },
   {
     "name": "Disappearance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49878,7 +49878,7 @@
   },
   {
     "name": "Divine Inspiration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49902,7 +49902,7 @@
   },
   {
     "name": "Dream Council",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49928,7 +49928,7 @@
   },
   {
     "name": "Dream Council",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49954,7 +49954,7 @@
   },
   {
     "name": "Earthquake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49978,7 +49978,7 @@
   },
   {
     "name": "Earthquake",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50002,7 +50002,7 @@
   },
   {
     "name": "Falling Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50026,7 +50026,7 @@
   },
   {
     "name": "Falling Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50050,7 +50050,7 @@
   },
   {
     "name": "Ferrous Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50075,7 +50075,7 @@
   },
   {
     "name": "Ferrous Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50100,7 +50100,7 @@
   },
   {
     "name": "Hidden Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50123,7 +50123,7 @@
   },
   {
     "name": "Hidden Mind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50146,7 +50146,7 @@
   },
   {
     "name": "Holy Host",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50171,7 +50171,7 @@
   },
   {
     "name": "Holy Host",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50196,7 +50196,7 @@
   },
   {
     "name": "Migration",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50220,7 +50220,7 @@
   },
   {
     "name": "Mimic Spell",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50243,7 +50243,7 @@
   },
   {
     "name": "Mimic Spell",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50266,7 +50266,7 @@
   },
   {
     "name": "Moment of Renewal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50290,7 +50290,7 @@
   },
   {
     "name": "Moment of Renewal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50314,7 +50314,7 @@
   },
   {
     "name": "Monstrosity Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50338,7 +50338,7 @@
   },
   {
     "name": "Monstrosity Form",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50362,7 +50362,7 @@
   },
   {
     "name": "Musical Shift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50386,7 +50386,7 @@
   },
   {
     "name": "Musical Shift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50410,7 +50410,7 @@
   },
   {
     "name": "Part the Mists to Paradise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50437,7 +50437,7 @@
   },
   {
     "name": "Part the Mists to Paradise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50464,7 +50464,7 @@
   },
   {
     "name": "Part the Mists to Paradise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50491,7 +50491,7 @@
   },
   {
     "name": "Part the Mists to Paradise",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50518,7 +50518,7 @@
   },
   {
     "name": "Pinpoint",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50542,7 +50542,7 @@
   },
   {
     "name": "Pinpoint",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50566,7 +50566,7 @@
   },
   {
     "name": "Pinpoint",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50590,7 +50590,7 @@
   },
   {
     "name": "Punishing Winds",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50614,7 +50614,7 @@
   },
   {
     "name": "Quandary",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50639,7 +50639,7 @@
   },
   {
     "name": "Quandary",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50664,7 +50664,7 @@
   },
   {
     "name": "Rainbow Fumarole",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50690,7 +50690,7 @@
   },
   {
     "name": "Rainbow Fumarole",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50716,7 +50716,7 @@
   },
   {
     "name": "Spirit Song",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50740,7 +50740,7 @@
   },
   {
     "name": "Spirit Song",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50764,7 +50764,7 @@
   },
   {
     "name": "Spiritual Epidemic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50789,7 +50789,7 @@
   },
   {
     "name": "Spiritual Epidemic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50814,7 +50814,7 @@
   },
   {
     "name": "Sudden Transposition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50838,7 +50838,7 @@
   },
   {
     "name": "Sudden Transposition",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50862,7 +50862,7 @@
   },
   {
     "name": "Summon Elemental Herald",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50886,7 +50886,7 @@
   },
   {
     "name": "Summon Elemental Herald",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50910,7 +50910,7 @@
   },
   {
     "name": "Summon Elemental Herald",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50934,7 +50934,7 @@
   },
   {
     "name": "Summon Irii",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50958,7 +50958,7 @@
   },
   {
     "name": "Summon Irii",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -50982,7 +50982,7 @@
   },
   {
     "name": "Summon Warden of the Wild",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51006,7 +51006,7 @@
   },
   {
     "name": "Take Your Places",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51032,7 +51032,7 @@
   },
   {
     "name": "Take Your Places",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51058,7 +51058,7 @@
   },
   {
     "name": "Uncontrollable Dance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51083,7 +51083,7 @@
   },
   {
     "name": "Uncontrollable Dance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51108,7 +51108,7 @@
   },
   {
     "name": "Unholy Army",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51133,7 +51133,7 @@
   },
   {
     "name": "Unholy Army",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51158,7 +51158,7 @@
   },
   {
     "name": "Unrelenting Observation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51182,7 +51182,7 @@
   },
   {
     "name": "Unrelenting Observation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51206,7 +51206,7 @@
   },
   {
     "name": "Whirlpool",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51230,7 +51230,7 @@
   },
   {
     "name": "Whirlpool",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51254,7 +51254,7 @@
   },
   {
     "name": "Beseech Arcanotheign",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51279,7 +51279,7 @@
   },
   {
     "name": "Beseech Arcanotheign",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51304,7 +51304,7 @@
   },
   {
     "name": "Beseech Arcanotheign",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51329,7 +51329,7 @@
   },
   {
     "name": "Beseech Arcanotheign",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51354,7 +51354,7 @@
   },
   {
     "name": "Bilocation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51377,7 +51377,7 @@
   },
   {
     "name": "Bilocation",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51400,7 +51400,7 @@
   },
   {
     "name": "Detonate Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51423,7 +51423,7 @@
   },
   {
     "name": "Detonate Magic",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51446,7 +51446,7 @@
   },
   {
     "name": "Dimensional Excision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51470,7 +51470,7 @@
   },
   {
     "name": "Dimensional Excision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51494,7 +51494,7 @@
   },
   {
     "name": "Dimensional Excision",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51518,7 +51518,7 @@
   },
   {
     "name": "Falling Stars",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51541,7 +51541,7 @@
   },
   {
     "name": "Falling Stars",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51564,7 +51564,7 @@
   },
   {
     "name": "Foresight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51589,7 +51589,7 @@
   },
   {
     "name": "Foresight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51614,7 +51614,7 @@
   },
   {
     "name": "Foresight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51639,7 +51639,7 @@
   },
   {
     "name": "Forest of Gates",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51663,7 +51663,7 @@
   },
   {
     "name": "Forest of Gates",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51687,7 +51687,7 @@
   },
   {
     "name": "Implosion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51710,7 +51710,7 @@
   },
   {
     "name": "Implosion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51733,7 +51733,7 @@
   },
   {
     "name": "Magnetic Dominion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51757,7 +51757,7 @@
   },
   {
     "name": "Magnetic Dominion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51781,7 +51781,7 @@
   },
   {
     "name": "Massacre",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51806,7 +51806,7 @@
   },
   {
     "name": "Massacre",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51831,7 +51831,7 @@
   },
   {
     "name": "Massacre",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51856,7 +51856,7 @@
   },
   {
     "name": "Metamorphosis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51880,7 +51880,7 @@
   },
   {
     "name": "Metamorphosis",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51904,7 +51904,7 @@
   },
   {
     "name": "Nature's Enmity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51929,7 +51929,7 @@
   },
   {
     "name": "Overwhelming Presence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51956,7 +51956,7 @@
   },
   {
     "name": "Overwhelming Presence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -51983,7 +51983,7 @@
   },
   {
     "name": "Phantasmagoria",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52009,7 +52009,7 @@
   },
   {
     "name": "Phantasmagoria",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52035,7 +52035,7 @@
   },
   {
     "name": "Resplendent Mansion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52059,7 +52059,7 @@
   },
   {
     "name": "Resplendent Mansion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52083,7 +52083,7 @@
   },
   {
     "name": "Seize Soul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52107,7 +52107,7 @@
   },
   {
     "name": "Seize Soul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52131,7 +52131,7 @@
   },
   {
     "name": "Telepathic Demand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52157,7 +52157,7 @@
   },
   {
     "name": "Telepathic Demand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52183,7 +52183,7 @@
   },
   {
     "name": "Telepathic Demand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52209,7 +52209,7 @@
   },
   {
     "name": "Trim the Blight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52232,7 +52232,7 @@
   },
   {
     "name": "Trim the Blight",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52255,7 +52255,7 @@
   },
   {
     "name": "Unfathomable Song",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52283,7 +52283,7 @@
   },
   {
     "name": "Wails of the Damned",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52309,7 +52309,7 @@
   },
   {
     "name": "Wails of the Damned",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52335,7 +52335,7 @@
   },
   {
     "name": "Weapon of Judgment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -52360,7 +52360,7 @@
   },
   {
     "name": "Wrathful Storm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/db/seeds/pf2e/weapons.json
+++ b/db/seeds/pf2e/weapons.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Accursed Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -17,7 +17,7 @@
   },
   {
     "name": "Accursed Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -33,7 +33,7 @@
   },
   {
     "name": "Accursed Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -49,7 +49,7 @@
   },
   {
     "name": "Acid Flask (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -67,7 +67,7 @@
   },
   {
     "name": "Acid Flask (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -85,7 +85,7 @@
   },
   {
     "name": "Acid Flask (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -103,7 +103,7 @@
   },
   {
     "name": "Acid Flask (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -121,7 +121,7 @@
   },
   {
     "name": "Adze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -137,7 +137,7 @@
   },
   {
     "name": "Aerekostes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -154,7 +154,7 @@
   },
   {
     "name": "Aether Marbles (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -171,7 +171,7 @@
   },
   {
     "name": "Aether Marbles (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -188,7 +188,7 @@
   },
   {
     "name": "Aether Marbles (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -205,7 +205,7 @@
   },
   {
     "name": "Air Repeater",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -220,7 +220,7 @@
   },
   {
     "name": "Alchemical Gauntlet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -236,7 +236,7 @@
   },
   {
     "name": "Alchemist's Fire (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -254,7 +254,7 @@
   },
   {
     "name": "Alchemist's Fire (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -272,7 +272,7 @@
   },
   {
     "name": "Alchemist's Fire (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -290,7 +290,7 @@
   },
   {
     "name": "Alchemist's Fire (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -308,7 +308,7 @@
   },
   {
     "name": "Aldori Dueling Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -323,7 +323,7 @@
   },
   {
     "name": "Alghollthu Whip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -341,7 +341,7 @@
   },
   {
     "name": "Alicorn Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -358,7 +358,7 @@
   },
   {
     "name": "Alicorn Trigger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -374,7 +374,7 @@
   },
   {
     "name": "Amphisbaena Handwraps",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -389,7 +389,7 @@
   },
   {
     "name": "Animal Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -405,7 +405,7 @@
   },
   {
     "name": "Animal Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -421,7 +421,7 @@
   },
   {
     "name": "Animal Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -437,7 +437,7 @@
   },
   {
     "name": "Animate Dreamer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -456,7 +456,7 @@
   },
   {
     "name": "Ankhrav Duster",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -473,7 +473,7 @@
   },
   {
     "name": "Apotheosis Knife",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -492,7 +492,7 @@
   },
   {
     "name": "Arbalest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -506,7 +506,7 @@
   },
   {
     "name": "Arboreal Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -524,7 +524,7 @@
   },
   {
     "name": "Arboreal's Revenge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -541,7 +541,7 @@
   },
   {
     "name": "Arquebus",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -557,7 +557,7 @@
   },
   {
     "name": "Atlatl",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -571,7 +571,7 @@
   },
   {
     "name": "Atmospheric Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -588,7 +588,7 @@
   },
   {
     "name": "Atmospheric Staff (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -605,7 +605,7 @@
   },
   {
     "name": "Atmospheric Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -622,7 +622,7 @@
   },
   {
     "name": "Atmospheric Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -639,7 +639,7 @@
   },
   {
     "name": "Atrophy Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -657,7 +657,7 @@
   },
   {
     "name": "Atrophy Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -675,7 +675,7 @@
   },
   {
     "name": "Atrophy Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -693,7 +693,7 @@
   },
   {
     "name": "Atrophy Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -711,7 +711,7 @@
   },
   {
     "name": "Axe Musket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -727,7 +727,7 @@
   },
   {
     "name": "Backpack Ballista",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -739,7 +739,7 @@
   },
   {
     "name": "Backpack Catapult",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -753,7 +753,7 @@
   },
   {
     "name": "Barricade Buster",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -771,7 +771,7 @@
   },
   {
     "name": "Bastard Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -785,7 +785,7 @@
   },
   {
     "name": "Batsbreath Cane",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -800,7 +800,7 @@
   },
   {
     "name": "Battle Axe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -814,7 +814,7 @@
   },
   {
     "name": "Battle Lute",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -829,7 +829,7 @@
   },
   {
     "name": "Battle Saddle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -845,7 +845,7 @@
   },
   {
     "name": "Bayonet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -861,7 +861,7 @@
   },
   {
     "name": "Beast Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -877,7 +877,7 @@
   },
   {
     "name": "Beast Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -893,7 +893,7 @@
   },
   {
     "name": "Beast Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -909,7 +909,7 @@
   },
   {
     "name": "Bec de Corbin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -926,7 +926,7 @@
   },
   {
     "name": "Belimarius's Invidious Halberd",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -941,7 +941,7 @@
   },
   {
     "name": "Belkzen Deadsmasher (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -956,7 +956,7 @@
   },
   {
     "name": "Belkzen Deadsmasher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -971,7 +971,7 @@
   },
   {
     "name": "Bellicose Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -990,7 +990,7 @@
   },
   {
     "name": "Big Boom Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1007,7 +1007,7 @@
   },
   {
     "name": "Bioluminescence Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1024,7 +1024,7 @@
   },
   {
     "name": "Black Powder Knuckle Dusters",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1041,7 +1041,7 @@
   },
   {
     "name": "Black Scorpion Stingmace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1057,7 +1057,7 @@
   },
   {
     "name": "Blackaxe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1075,7 +1075,7 @@
   },
   {
     "name": "Bladed Gauntlet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1092,7 +1092,7 @@
   },
   {
     "name": "Bladed Scarf",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1110,7 +1110,7 @@
   },
   {
     "name": "Bladesweeper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1127,7 +1127,7 @@
   },
   {
     "name": "Blasting Stone (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1145,7 +1145,7 @@
   },
   {
     "name": "Blasting Stone (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1163,7 +1163,7 @@
   },
   {
     "name": "Blasting Stone (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1181,7 +1181,7 @@
   },
   {
     "name": "Blasting Stone (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1199,7 +1199,7 @@
   },
   {
     "name": "Blessed Reformer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1215,7 +1215,7 @@
   },
   {
     "name": "Blight Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1233,7 +1233,7 @@
   },
   {
     "name": "Blight Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1251,7 +1251,7 @@
   },
   {
     "name": "Blight Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1269,7 +1269,7 @@
   },
   {
     "name": "Blight Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1287,7 +1287,7 @@
   },
   {
     "name": "Blightburn Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1306,7 +1306,7 @@
   },
   {
     "name": "Blightburn Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1325,7 +1325,7 @@
   },
   {
     "name": "Blood-Drinker Blade (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1342,7 +1342,7 @@
   },
   {
     "name": "Blood-Drinker Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1359,7 +1359,7 @@
   },
   {
     "name": "Blood-Drinker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1376,7 +1376,7 @@
   },
   {
     "name": "Bloodgorger Scythe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1392,7 +1392,7 @@
   },
   {
     "name": "Bloodletting Kukri",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1409,7 +1409,7 @@
   },
   {
     "name": "Bloody Fang",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1427,7 +1427,7 @@
   },
   {
     "name": "Blowgun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1442,7 +1442,7 @@
   },
   {
     "name": "Blunderbuss",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1457,7 +1457,7 @@
   },
   {
     "name": "Bo Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1474,7 +1474,7 @@
   },
   {
     "name": "Boastful Hunter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1491,7 +1491,7 @@
   },
   {
     "name": "Bola",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1507,7 +1507,7 @@
   },
   {
     "name": "Boomerang",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1522,7 +1522,7 @@
   },
   {
     "name": "Boreal Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1539,7 +1539,7 @@
   },
   {
     "name": "Boreal Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1556,7 +1556,7 @@
   },
   {
     "name": "Boreal Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1573,7 +1573,7 @@
   },
   {
     "name": "Bottled Lightning (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1591,7 +1591,7 @@
   },
   {
     "name": "Bottled Lightning (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1609,7 +1609,7 @@
   },
   {
     "name": "Bottled Lightning (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1627,7 +1627,7 @@
   },
   {
     "name": "Bottled Lightning (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1645,7 +1645,7 @@
   },
   {
     "name": "Boughshatter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1662,7 +1662,7 @@
   },
   {
     "name": "Boulder Seed (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1679,7 +1679,7 @@
   },
   {
     "name": "Boulder Seed",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1696,7 +1696,7 @@
   },
   {
     "name": "Bounty's Light",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1714,7 +1714,7 @@
   },
   {
     "name": "Bow of Sun Slaying",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1732,7 +1732,7 @@
   },
   {
     "name": "Bow Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1748,7 +1748,7 @@
   },
   {
     "name": "Branch of the Great Sugi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1767,7 +1767,7 @@
   },
   {
     "name": "Breaching Pike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1783,7 +1783,7 @@
   },
   {
     "name": "Breath Blaster (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1798,7 +1798,7 @@
   },
   {
     "name": "Breath Blaster (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1813,7 +1813,7 @@
   },
   {
     "name": "Breath Blaster",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1828,7 +1828,7 @@
   },
   {
     "name": "Butterfly Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1847,7 +1847,7 @@
   },
   {
     "name": "Calamity",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1862,7 +1862,7 @@
   },
   {
     "name": "Cane Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1879,7 +1879,7 @@
   },
   {
     "name": "Capturing Spetum",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1896,7 +1896,7 @@
   },
   {
     "name": "Caress of the Great Serpent",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1912,7 +1912,7 @@
   },
   {
     "name": "Carver-cutter (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1928,7 +1928,7 @@
   },
   {
     "name": "Carver-cutter (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1944,7 +1944,7 @@
   },
   {
     "name": "Carver-cutter (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1960,7 +1960,7 @@
   },
   {
     "name": "Carver-cutter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1976,7 +1976,7 @@
   },
   {
     "name": "Castrovel's Beacon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -1993,7 +1993,7 @@
   },
   {
     "name": "Caterwaul Sling",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2008,7 +2008,7 @@
   },
   {
     "name": "Catoblepas Maul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2024,7 +2024,7 @@
   },
   {
     "name": "Cavalry Commander's Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2041,7 +2041,7 @@
   },
   {
     "name": "Cayden's Tankard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2058,7 +2058,7 @@
   },
   {
     "name": "Celestial Peachwood Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2077,7 +2077,7 @@
   },
   {
     "name": "Celestial Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2094,7 +2094,7 @@
   },
   {
     "name": "Chain of Command",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2111,7 +2111,7 @@
   },
   {
     "name": "Chain Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2127,7 +2127,7 @@
   },
   {
     "name": "Chainbreaker (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2142,7 +2142,7 @@
   },
   {
     "name": "Chainbreaker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2157,7 +2157,7 @@
   },
   {
     "name": "Chakri",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2172,7 +2172,7 @@
   },
   {
     "name": "Chalice of Justice",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2188,7 +2188,7 @@
   },
   {
     "name": "Chaplain's Cudgel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2203,7 +2203,7 @@
   },
   {
     "name": "Chimera Flail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2220,7 +2220,7 @@
   },
   {
     "name": "Chronomancer Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2236,7 +2236,7 @@
   },
   {
     "name": "Clan Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2253,7 +2253,7 @@
   },
   {
     "name": "Clan Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2269,7 +2269,7 @@
   },
   {
     "name": "Claw Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2288,7 +2288,7 @@
   },
   {
     "name": "Clear Cutter's Axe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2305,7 +2305,7 @@
   },
   {
     "name": "Club",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2319,7 +2319,7 @@
   },
   {
     "name": "Coat Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2335,7 +2335,7 @@
   },
   {
     "name": "Coldstar Pistols",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2353,7 +2353,7 @@
   },
   {
     "name": "Combat Fishing Pole",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2370,7 +2370,7 @@
   },
   {
     "name": "Combat Lure",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2387,7 +2387,7 @@
   },
   {
     "name": "Composer Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2403,7 +2403,7 @@
   },
   {
     "name": "Composer Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2419,7 +2419,7 @@
   },
   {
     "name": "Composer Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2435,7 +2435,7 @@
   },
   {
     "name": "Composite Longbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2451,7 +2451,7 @@
   },
   {
     "name": "Composite Shortbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2466,7 +2466,7 @@
   },
   {
     "name": "Constricting Meteor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2484,7 +2484,7 @@
   },
   {
     "name": "Corset Knife",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2501,7 +2501,7 @@
   },
   {
     "name": "Crescent Cross",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2517,7 +2517,7 @@
   },
   {
     "name": "Crimson Bluff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2535,7 +2535,7 @@
   },
   {
     "name": "Crimson Thorn",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2551,7 +2551,7 @@
   },
   {
     "name": "Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2563,7 +2563,7 @@
   },
   {
     "name": "Cruuk",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2579,7 +2579,7 @@
   },
   {
     "name": "Crystal Shards (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2597,7 +2597,7 @@
   },
   {
     "name": "Crystal Shards (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2615,7 +2615,7 @@
   },
   {
     "name": "Crystal Shards (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2633,7 +2633,7 @@
   },
   {
     "name": "Cythbikian Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2650,7 +2650,7 @@
   },
   {
     "name": "Dagger Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2666,7 +2666,7 @@
   },
   {
     "name": "Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2683,7 +2683,7 @@
   },
   {
     "name": "Daikyu",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2698,7 +2698,7 @@
   },
   {
     "name": "Dancer's Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2716,7 +2716,7 @@
   },
   {
     "name": "Dart Umbrella",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2732,7 +2732,7 @@
   },
   {
     "name": "Dart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2747,7 +2747,7 @@
   },
   {
     "name": "Dawnsilver Tree",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2764,7 +2764,7 @@
   },
   {
     "name": "Dazzling Shortbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2779,7 +2779,7 @@
   },
   {
     "name": "Deathseeker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2796,7 +2796,7 @@
   },
   {
     "name": "Defoliation Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2814,7 +2814,7 @@
   },
   {
     "name": "Defoliation Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2832,7 +2832,7 @@
   },
   {
     "name": "Defoliation Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2850,7 +2850,7 @@
   },
   {
     "name": "Defoliation Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2868,7 +2868,7 @@
   },
   {
     "name": "Dezullon Fountain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2885,7 +2885,7 @@
   },
   {
     "name": "Dog-Bone Knife",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2902,7 +2902,7 @@
   },
   {
     "name": "Dogslicer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2919,7 +2919,7 @@
   },
   {
     "name": "Doomsweeper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2934,7 +2934,7 @@
   },
   {
     "name": "Double-Barreled Musket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2950,7 +2950,7 @@
   },
   {
     "name": "Double-Barreled Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2966,7 +2966,7 @@
   },
   {
     "name": "Draddeth's Edge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -2982,7 +2982,7 @@
   },
   {
     "name": "Dragon Handwraps",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3002,7 +3002,7 @@
   },
   {
     "name": "Dragon Mouth Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3017,7 +3017,7 @@
   },
   {
     "name": "Dragonfire Halfbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3034,7 +3034,7 @@
   },
   {
     "name": "Dragonprism Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3050,7 +3050,7 @@
   },
   {
     "name": "Dragonprism Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3066,7 +3066,7 @@
   },
   {
     "name": "Dragon's Tongue (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3078,7 +3078,7 @@
   },
   {
     "name": "Dragon's Tongue (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3090,7 +3090,7 @@
   },
   {
     "name": "Dragon's Tongue",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3102,7 +3102,7 @@
   },
   {
     "name": "Dragonscale Bo Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3119,7 +3119,7 @@
   },
   {
     "name": "Dragontooth Leiomano",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3134,7 +3134,7 @@
   },
   {
     "name": "Drake Rifle (Acid)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3148,7 +3148,7 @@
   },
   {
     "name": "Drake Rifle (Cold)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3162,7 +3162,7 @@
   },
   {
     "name": "Drake Rifle (Electricity)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3176,7 +3176,7 @@
   },
   {
     "name": "Drake Rifle (Fire)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3190,7 +3190,7 @@
   },
   {
     "name": "Drake Rifle (Poison)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3204,7 +3204,7 @@
   },
   {
     "name": "Dread Ampoule (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3225,7 +3225,7 @@
   },
   {
     "name": "Dread Ampoule (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3246,7 +3246,7 @@
   },
   {
     "name": "Dread Ampoule (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3267,7 +3267,7 @@
   },
   {
     "name": "Dread Ampoule (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3288,7 +3288,7 @@
   },
   {
     "name": "Dreamcrusher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3303,7 +3303,7 @@
   },
   {
     "name": "Duchy Defender",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3320,7 +3320,7 @@
   },
   {
     "name": "Dueling Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3336,7 +3336,7 @@
   },
   {
     "name": "Durian Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3355,7 +3355,7 @@
   },
   {
     "name": "Durian Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3374,7 +3374,7 @@
   },
   {
     "name": "Durian Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3393,7 +3393,7 @@
   },
   {
     "name": "Durian Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3412,7 +3412,7 @@
   },
   {
     "name": "Dwarven Dorn-Dergar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3428,7 +3428,7 @@
   },
   {
     "name": "Dwarven Scattergun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3445,7 +3445,7 @@
   },
   {
     "name": "Dwarven War Axe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3461,7 +3461,7 @@
   },
   {
     "name": "Earthbreaker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3478,7 +3478,7 @@
   },
   {
     "name": "Elven Curve Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3494,7 +3494,7 @@
   },
   {
     "name": "Explosive Dogslicer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3512,7 +3512,7 @@
   },
   {
     "name": "Falcata",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3526,7 +3526,7 @@
   },
   {
     "name": "Falchion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3541,7 +3541,7 @@
   },
   {
     "name": "Fangwire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3560,7 +3560,7 @@
   },
   {
     "name": "Fauchard",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3577,7 +3577,7 @@
   },
   {
     "name": "Faultline Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3595,7 +3595,7 @@
   },
   {
     "name": "Feng Huo Lun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3615,7 +3615,7 @@
   },
   {
     "name": "Fiendbreaker (Heroic)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3637,7 +3637,7 @@
   },
   {
     "name": "Fiendbreaker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3654,7 +3654,7 @@
   },
   {
     "name": "Fiend's Hunger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3672,7 +3672,7 @@
   },
   {
     "name": "Fighter's Fork",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3687,7 +3687,7 @@
   },
   {
     "name": "Fighting Fan",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3705,7 +3705,7 @@
   },
   {
     "name": "Fighting Oar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3720,7 +3720,7 @@
   },
   {
     "name": "Filcher's Fork",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3739,7 +3739,7 @@
   },
   {
     "name": "Final Stand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3758,7 +3758,7 @@
   },
   {
     "name": "Fire Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3772,7 +3772,7 @@
   },
   {
     "name": "Flail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3788,7 +3788,7 @@
   },
   {
     "name": "Flashblade (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3805,7 +3805,7 @@
   },
   {
     "name": "Flashblade (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3822,7 +3822,7 @@
   },
   {
     "name": "Flashblade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3839,7 +3839,7 @@
   },
   {
     "name": "Fleshrender",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3856,7 +3856,7 @@
   },
   {
     "name": "Flingflenser",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3873,7 +3873,7 @@
   },
   {
     "name": "Flintlock Musket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3888,7 +3888,7 @@
   },
   {
     "name": "Flintlock Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3903,7 +3903,7 @@
   },
   {
     "name": "Fluid Form Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3919,7 +3919,7 @@
   },
   {
     "name": "Fluid Form Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3935,7 +3935,7 @@
   },
   {
     "name": "Fluid Form Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3951,7 +3951,7 @@
   },
   {
     "name": "Flying Talon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3971,7 +3971,7 @@
   },
   {
     "name": "Flyssa",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -3987,7 +3987,7 @@
   },
   {
     "name": "Forked Bipod",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4003,7 +4003,7 @@
   },
   {
     "name": "Four-Tiger Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4018,7 +4018,7 @@
   },
   {
     "name": "Four-Ways Dogslicer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4039,7 +4039,7 @@
   },
   {
     "name": "Freedom's Flame",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4057,7 +4057,7 @@
   },
   {
     "name": "Frost Fair Yanyuedao",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4075,7 +4075,7 @@
   },
   {
     "name": "Frost Vial (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4093,7 +4093,7 @@
   },
   {
     "name": "Frost Vial (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4111,7 +4111,7 @@
   },
   {
     "name": "Frost Vial (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4129,7 +4129,7 @@
   },
   {
     "name": "Frost Vial (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4147,7 +4147,7 @@
   },
   {
     "name": "Frying Pan",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4162,7 +4162,7 @@
   },
   {
     "name": "Fulmination Fang",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4179,7 +4179,7 @@
   },
   {
     "name": "Gaff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4194,7 +4194,7 @@
   },
   {
     "name": "Gakgung",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4210,7 +4210,7 @@
   },
   {
     "name": "Gambler's Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4226,7 +4226,7 @@
   },
   {
     "name": "Gauntlet Bow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4242,7 +4242,7 @@
   },
   {
     "name": "Gauntlet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4257,7 +4257,7 @@
   },
   {
     "name": "General's Word",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4272,7 +4272,7 @@
   },
   {
     "name": "Ghost Charge (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4290,7 +4290,7 @@
   },
   {
     "name": "Ghost Charge (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4308,7 +4308,7 @@
   },
   {
     "name": "Ghost Charge (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4326,7 +4326,7 @@
   },
   {
     "name": "Ghost Charge (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4344,7 +4344,7 @@
   },
   {
     "name": "Ghosthand's Comet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4363,7 +4363,7 @@
   },
   {
     "name": "Ghoul Stiletto",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4380,7 +4380,7 @@
   },
   {
     "name": "Giant Squid Lash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4399,7 +4399,7 @@
   },
   {
     "name": "Glacier Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4413,7 +4413,7 @@
   },
   {
     "name": "Gladius",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4428,7 +4428,7 @@
   },
   {
     "name": "Glaive",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4444,7 +4444,7 @@
   },
   {
     "name": "Gloom Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4461,7 +4461,7 @@
   },
   {
     "name": "Glue Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4477,7 +4477,7 @@
   },
   {
     "name": "Glue Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4493,7 +4493,7 @@
   },
   {
     "name": "Glue Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4509,7 +4509,7 @@
   },
   {
     "name": "Glue Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4525,7 +4525,7 @@
   },
   {
     "name": "Gnome Amalgam Musket",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4542,7 +4542,7 @@
   },
   {
     "name": "Gnome Flickmace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4558,7 +4558,7 @@
   },
   {
     "name": "Gnome Hooked Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4575,7 +4575,7 @@
   },
   {
     "name": "Gravedigger's Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4593,7 +4593,7 @@
   },
   {
     "name": "Greataxe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4607,7 +4607,7 @@
   },
   {
     "name": "Greatclub",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4622,7 +4622,7 @@
   },
   {
     "name": "Greatpick",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4636,7 +4636,7 @@
   },
   {
     "name": "Greatsword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4650,7 +4650,7 @@
   },
   {
     "name": "Grounding Spike",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4668,7 +4668,7 @@
   },
   {
     "name": "Growth Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4683,7 +4683,7 @@
   },
   {
     "name": "Guardian Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4699,7 +4699,7 @@
   },
   {
     "name": "Guardian Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4715,7 +4715,7 @@
   },
   {
     "name": "Guardian Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4731,7 +4731,7 @@
   },
   {
     "name": "Guisarme",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4746,7 +4746,7 @@
   },
   {
     "name": "Gun Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4762,7 +4762,7 @@
   },
   {
     "name": "Gut-Ripper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4779,7 +4779,7 @@
   },
   {
     "name": "Halberd",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4794,7 +4794,7 @@
   },
   {
     "name": "Halfling Sling Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4809,7 +4809,7 @@
   },
   {
     "name": "Hammer Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4825,7 +4825,7 @@
   },
   {
     "name": "Hand Adze",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4843,7 +4843,7 @@
   },
   {
     "name": "Hand Cannon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4857,7 +4857,7 @@
   },
   {
     "name": "Hand Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4869,7 +4869,7 @@
   },
   {
     "name": "Handwraps of Mighty Blows",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4884,7 +4884,7 @@
   },
   {
     "name": "Harmona Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4898,7 +4898,7 @@
   },
   {
     "name": "Harpoon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4913,7 +4913,7 @@
   },
   {
     "name": "Hatchet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4929,7 +4929,7 @@
   },
   {
     "name": "Heavenly Rolling Flames",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4950,7 +4950,7 @@
   },
   {
     "name": "Heavy Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4962,7 +4962,7 @@
   },
   {
     "name": "Hell Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4979,7 +4979,7 @@
   },
   {
     "name": "Hell's Judgment",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -4996,7 +4996,7 @@
   },
   {
     "name": "Holy Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5014,7 +5014,7 @@
   },
   {
     "name": "Hook Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5032,7 +5032,7 @@
   },
   {
     "name": "Horsechopper",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5049,7 +5049,7 @@
   },
   {
     "name": "Horselord's Longbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5065,7 +5065,7 @@
   },
   {
     "name": "Howler Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5080,7 +5080,7 @@
   },
   {
     "name": "Hunter's Anthem",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5095,7 +5095,7 @@
   },
   {
     "name": "Hunter's Bow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5110,7 +5110,7 @@
   },
   {
     "name": "Hydra Head Club",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5125,7 +5125,7 @@
   },
   {
     "name": "Hydra Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5140,7 +5140,7 @@
   },
   {
     "name": "Hydrocannon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5155,7 +5155,7 @@
   },
   {
     "name": "Hyldarf's Fang",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5169,7 +5169,7 @@
   },
   {
     "name": "Icicle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5184,7 +5184,7 @@
   },
   {
     "name": "Infiltrator's Accessory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5202,7 +5202,7 @@
   },
   {
     "name": "Inflammation Flask (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5221,7 +5221,7 @@
   },
   {
     "name": "Inflammation Flask (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5240,7 +5240,7 @@
   },
   {
     "name": "Inflammation Flask (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5259,7 +5259,7 @@
   },
   {
     "name": "Inflammation Flask (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5278,7 +5278,7 @@
   },
   {
     "name": "Injection Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5293,7 +5293,7 @@
   },
   {
     "name": "Iris of the Sky",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5308,7 +5308,7 @@
   },
   {
     "name": "Javelin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5322,7 +5322,7 @@
   },
   {
     "name": "Jezail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5337,7 +5337,7 @@
   },
   {
     "name": "Jian of Life's Duality",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5352,7 +5352,7 @@
   },
   {
     "name": "Jistkan Colossus Crusher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5367,7 +5367,7 @@
   },
   {
     "name": "Jistkan War Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5382,7 +5382,7 @@
   },
   {
     "name": "Jiu Huan Dao",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5396,7 +5396,7 @@
   },
   {
     "name": "Jorngarl's Harm",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5410,7 +5410,7 @@
   },
   {
     "name": "Kaldemash's Lament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5426,7 +5426,7 @@
   },
   {
     "name": "Kama",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5442,7 +5442,7 @@
   },
   {
     "name": "Karambit",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5459,7 +5459,7 @@
   },
   {
     "name": "Katana",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5475,7 +5475,7 @@
   },
   {
     "name": "Katar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5491,7 +5491,7 @@
   },
   {
     "name": "Kestros",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5506,7 +5506,7 @@
   },
   {
     "name": "Khakkhara",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5522,7 +5522,7 @@
   },
   {
     "name": "Khopesh",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5536,7 +5536,7 @@
   },
   {
     "name": "Kinetic Club",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5553,7 +5553,7 @@
   },
   {
     "name": "Kithrender",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5568,7 +5568,7 @@
   },
   {
     "name": "Knuckle Duster",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5584,7 +5584,7 @@
   },
   {
     "name": "Kukri",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5600,7 +5600,7 @@
   },
   {
     "name": "Kusarigama",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5618,7 +5618,7 @@
   },
   {
     "name": "Lamentation of the Faithless",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5636,7 +5636,7 @@
   },
   {
     "name": "Lance of Sun's Radiance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5654,7 +5654,7 @@
   },
   {
     "name": "Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5670,7 +5670,7 @@
   },
   {
     "name": "Lancer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5685,7 +5685,7 @@
   },
   {
     "name": "Last Hope",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5700,7 +5700,7 @@
   },
   {
     "name": "Leiomano",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5715,7 +5715,7 @@
   },
   {
     "name": "Leydroth Spellbreaker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5731,7 +5731,7 @@
   },
   {
     "name": "Liar's Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5749,7 +5749,7 @@
   },
   {
     "name": "Librarian Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5766,7 +5766,7 @@
   },
   {
     "name": "Librarian Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5783,7 +5783,7 @@
   },
   {
     "name": "Lifebloom",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5802,7 +5802,7 @@
   },
   {
     "name": "Light Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5817,7 +5817,7 @@
   },
   {
     "name": "Light Mace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5833,7 +5833,7 @@
   },
   {
     "name": "Light Pick",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5848,7 +5848,7 @@
   },
   {
     "name": "Lion Scythe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5864,7 +5864,7 @@
   },
   {
     "name": "Lionfish Spear (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5880,7 +5880,7 @@
   },
   {
     "name": "Lionfish Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5896,7 +5896,7 @@
   },
   {
     "name": "Lion's Call",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5912,7 +5912,7 @@
   },
   {
     "name": "Liuyedao",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5930,7 +5930,7 @@
   },
   {
     "name": "Lodestone Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5948,7 +5948,7 @@
   },
   {
     "name": "Lodestone Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5966,7 +5966,7 @@
   },
   {
     "name": "Long Air Repeater",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5981,7 +5981,7 @@
   },
   {
     "name": "Long Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -5999,7 +5999,7 @@
   },
   {
     "name": "Longbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6014,7 +6014,7 @@
   },
   {
     "name": "Longspear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6028,7 +6028,7 @@
   },
   {
     "name": "Longsword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6042,7 +6042,7 @@
   },
   {
     "name": "Lumber Lord's Axe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6057,7 +6057,7 @@
   },
   {
     "name": "Lyrakien Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6073,7 +6073,7 @@
   },
   {
     "name": "Lyrakien Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6089,7 +6089,7 @@
   },
   {
     "name": "Lyrakien Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6105,7 +6105,7 @@
   },
   {
     "name": "Mace Multipistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6122,7 +6122,7 @@
   },
   {
     "name": "Mace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6136,7 +6136,7 @@
   },
   {
     "name": "Machete",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6151,7 +6151,7 @@
   },
   {
     "name": "Macuahuitl",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6167,7 +6167,7 @@
   },
   {
     "name": "Mageslayer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6183,7 +6183,7 @@
   },
   {
     "name": "Magnetic Bola",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6199,7 +6199,7 @@
   },
   {
     "name": "Main-Gauche",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6217,7 +6217,7 @@
   },
   {
     "name": "Mambele",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6233,7 +6233,7 @@
   },
   {
     "name": "Maul-spade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6249,7 +6249,7 @@
   },
   {
     "name": "Maul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6263,7 +6263,7 @@
   },
   {
     "name": "Mentalist's Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6279,7 +6279,7 @@
   },
   {
     "name": "Mentalist's Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6295,7 +6295,7 @@
   },
   {
     "name": "Mentalist's Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6311,7 +6311,7 @@
   },
   {
     "name": "Meteor Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6328,7 +6328,7 @@
   },
   {
     "name": "Mikazuki",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6344,7 +6344,7 @@
   },
   {
     "name": "Mindlance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6363,7 +6363,7 @@
   },
   {
     "name": "Morning Glow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6379,7 +6379,7 @@
   },
   {
     "name": "Morningstar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6393,7 +6393,7 @@
   },
   {
     "name": "Mountebank's Passage",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6408,7 +6408,7 @@
   },
   {
     "name": "Musket Staff of Force",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6426,7 +6426,7 @@
   },
   {
     "name": "Musket Staff of Void",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6444,7 +6444,7 @@
   },
   {
     "name": "Naginata",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6460,7 +6460,7 @@
   },
   {
     "name": "Nail Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6477,7 +6477,7 @@
   },
   {
     "name": "Nail Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6494,7 +6494,7 @@
   },
   {
     "name": "Nail Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6511,7 +6511,7 @@
   },
   {
     "name": "Nail Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6528,7 +6528,7 @@
   },
   {
     "name": "Nightmare's Lament",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6545,7 +6545,7 @@
   },
   {
     "name": "Nodachi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6561,7 +6561,7 @@
   },
   {
     "name": "Nunchaku",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6578,7 +6578,7 @@
   },
   {
     "name": "Obsidian Edge (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6596,7 +6596,7 @@
   },
   {
     "name": "Obsidian Edge (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6614,7 +6614,7 @@
   },
   {
     "name": "Obsidian Edge (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6632,7 +6632,7 @@
   },
   {
     "name": "Obsidian Edge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6650,7 +6650,7 @@
   },
   {
     "name": "Ogre Hook",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6665,7 +6665,7 @@
   },
   {
     "name": "Orc Knuckle Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6681,7 +6681,7 @@
   },
   {
     "name": "Orc Necksplitter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6697,7 +6697,7 @@
   },
   {
     "name": "Orc Skewermaul",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6714,7 +6714,7 @@
   },
   {
     "name": "Pact-Bound Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6734,7 +6734,7 @@
   },
   {
     "name": "Palstave",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6748,7 +6748,7 @@
   },
   {
     "name": "Panabas",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6764,7 +6764,7 @@
   },
   {
     "name": "Pantograph Gauntlet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6781,7 +6781,7 @@
   },
   {
     "name": "Pepperbox",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6797,7 +6797,7 @@
   },
   {
     "name": "Petrification Cannon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6814,7 +6814,7 @@
   },
   {
     "name": "Phalanx Piercer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6832,7 +6832,7 @@
   },
   {
     "name": "Pick",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6846,7 +6846,7 @@
   },
   {
     "name": "Piercing Wind",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6862,7 +6862,7 @@
   },
   {
     "name": "Pirate Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6878,7 +6878,7 @@
   },
   {
     "name": "Pistol of Wonder",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6894,7 +6894,7 @@
   },
   {
     "name": "Pistol Wand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6911,7 +6911,7 @@
   },
   {
     "name": "Piston Gauntlets",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6929,7 +6929,7 @@
   },
   {
     "name": "Poisonous Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6948,7 +6948,7 @@
   },
   {
     "name": "Polarizing Mace",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6964,7 +6964,7 @@
   },
   {
     "name": "Polytool",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6979,7 +6979,7 @@
   },
   {
     "name": "Preordained Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -6996,7 +6996,7 @@
   },
   {
     "name": "Protector's Final Gift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7013,7 +7013,7 @@
   },
   {
     "name": "Purgatory Emissary's Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7030,7 +7030,7 @@
   },
   {
     "name": "Radiant Victory",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7047,7 +7047,7 @@
   },
   {
     "name": "Ranseur",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7062,7 +7062,7 @@
   },
   {
     "name": "Rapier Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7079,7 +7079,7 @@
   },
   {
     "name": "Rapier",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7095,7 +7095,7 @@
   },
   {
     "name": "Reaper's Crescent",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7112,7 +7112,7 @@
   },
   {
     "name": "Reaper's Grasp",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7128,7 +7128,7 @@
   },
   {
     "name": "Reaper's Sigh",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7146,7 +7146,7 @@
   },
   {
     "name": "Reaper's Toll",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7162,7 +7162,7 @@
   },
   {
     "name": "Reinforced Stock",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7178,7 +7178,7 @@
   },
   {
     "name": "Repeating Hand Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7192,7 +7192,7 @@
   },
   {
     "name": "Restorative Handwraps",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7206,7 +7206,7 @@
   },
   {
     "name": "Retribution Axe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7221,7 +7221,7 @@
   },
   {
     "name": "Retribution",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7240,7 +7240,7 @@
   },
   {
     "name": "Returning Starknife",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7257,7 +7257,7 @@
   },
   {
     "name": "Revenant Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7276,7 +7276,7 @@
   },
   {
     "name": "Righteous Fury",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7292,7 +7292,7 @@
   },
   {
     "name": "Rime Foil",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7308,7 +7308,7 @@
   },
   {
     "name": "Rope Dart",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7327,7 +7327,7 @@
   },
   {
     "name": "Rotary Bow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7341,7 +7341,7 @@
   },
   {
     "name": "Rowan Rifle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7358,7 +7358,7 @@
   },
   {
     "name": "Rustbringer (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7376,7 +7376,7 @@
   },
   {
     "name": "Rustbringer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7394,7 +7394,7 @@
   },
   {
     "name": "Sai",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7412,7 +7412,7 @@
   },
   {
     "name": "Sansetsukon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7429,7 +7429,7 @@
   },
   {
     "name": "Sap",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7444,7 +7444,7 @@
   },
   {
     "name": "Sawtooth Saber",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7460,7 +7460,7 @@
   },
   {
     "name": "Scalding Gauntlets (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7478,7 +7478,7 @@
   },
   {
     "name": "Scalding Gauntlets (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7496,7 +7496,7 @@
   },
   {
     "name": "Scalding Gauntlets (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7514,7 +7514,7 @@
   },
   {
     "name": "Scalding Gauntlets",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7532,7 +7532,7 @@
   },
   {
     "name": "Scimitar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7547,7 +7547,7 @@
   },
   {
     "name": "Scizore of the Crab",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7563,7 +7563,7 @@
   },
   {
     "name": "Scizore",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7578,7 +7578,7 @@
   },
   {
     "name": "Scourge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7596,7 +7596,7 @@
   },
   {
     "name": "Screaming Pinion",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7611,7 +7611,7 @@
   },
   {
     "name": "Screech Shooter (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7626,7 +7626,7 @@
   },
   {
     "name": "Screech Shooter (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7641,7 +7641,7 @@
   },
   {
     "name": "Screech Shooter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7656,7 +7656,7 @@
   },
   {
     "name": "Scythe",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7671,7 +7671,7 @@
   },
   {
     "name": "Searing Blade (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7687,7 +7687,7 @@
   },
   {
     "name": "Searing Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7703,7 +7703,7 @@
   },
   {
     "name": "Sensei's Parasol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7721,7 +7721,7 @@
   },
   {
     "name": "Serithtial",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7738,7 +7738,7 @@
   },
   {
     "name": "Serpent Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7757,7 +7757,7 @@
   },
   {
     "name": "Shadefield Knife",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7775,7 +7775,7 @@
   },
   {
     "name": "Shadowpiercer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7793,7 +7793,7 @@
   },
   {
     "name": "Shard of Self-Destruction",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7808,7 +7808,7 @@
   },
   {
     "name": "Shattered Plan",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7823,7 +7823,7 @@
   },
   {
     "name": "Shatterstone (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7841,7 +7841,7 @@
   },
   {
     "name": "Shatterstone",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7859,7 +7859,7 @@
   },
   {
     "name": "Shears",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7875,7 +7875,7 @@
   },
   {
     "name": "Shield Boss",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7889,7 +7889,7 @@
   },
   {
     "name": "Shield Bow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7904,7 +7904,7 @@
   },
   {
     "name": "Shield Spikes",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7918,7 +7918,7 @@
   },
   {
     "name": "Shortbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7932,7 +7932,7 @@
   },
   {
     "name": "Shortsword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7948,7 +7948,7 @@
   },
   {
     "name": "Shuan Ji",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7965,7 +7965,7 @@
   },
   {
     "name": "Shuln Fang Katar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7982,7 +7982,7 @@
   },
   {
     "name": "Shuriken",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -7998,7 +7998,7 @@
   },
   {
     "name": "Sickle",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8014,7 +8014,7 @@
   },
   {
     "name": "Silverscrap Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8031,7 +8031,7 @@
   },
   {
     "name": "Silverscrap Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8048,7 +8048,7 @@
   },
   {
     "name": "Silverscrap Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8065,7 +8065,7 @@
   },
   {
     "name": "Silversoul Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8083,7 +8083,7 @@
   },
   {
     "name": "Silversoul Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8101,7 +8101,7 @@
   },
   {
     "name": "Silversoul Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8119,7 +8119,7 @@
   },
   {
     "name": "Sinew-Song",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8136,7 +8136,7 @@
   },
   {
     "name": "Singing Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8152,7 +8152,7 @@
   },
   {
     "name": "Skunk Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8171,7 +8171,7 @@
   },
   {
     "name": "Skunk Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8190,7 +8190,7 @@
   },
   {
     "name": "Skunk Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8209,7 +8209,7 @@
   },
   {
     "name": "Skunk Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8228,7 +8228,7 @@
   },
   {
     "name": "Sky Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8243,7 +8243,7 @@
   },
   {
     "name": "Slide Pistol",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8259,7 +8259,7 @@
   },
   {
     "name": "Sling",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8273,7 +8273,7 @@
   },
   {
     "name": "Smoking Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8289,7 +8289,7 @@
   },
   {
     "name": "Snowcaster's Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8306,7 +8306,7 @@
   },
   {
     "name": "Socialite Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8322,7 +8322,7 @@
   },
   {
     "name": "Solar Shellflower",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8337,7 +8337,7 @@
   },
   {
     "name": "Sorshen's Sinuous Guisarme",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8356,7 +8356,7 @@
   },
   {
     "name": "Soulcutter (Heroic)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8377,7 +8377,7 @@
   },
   {
     "name": "Soulcutter",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8394,7 +8394,7 @@
   },
   {
     "name": "Spark Dancer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8412,7 +8412,7 @@
   },
   {
     "name": "Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8427,7 +8427,7 @@
   },
   {
     "name": "Spectral Dagger",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8444,7 +8444,7 @@
   },
   {
     "name": "Spellguard Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8463,7 +8463,7 @@
   },
   {
     "name": "Spellsap Grenade (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8479,7 +8479,7 @@
   },
   {
     "name": "Spellsap Grenade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8495,7 +8495,7 @@
   },
   {
     "name": "Spellstriker Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8511,7 +8511,7 @@
   },
   {
     "name": "Spellstriker Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8527,7 +8527,7 @@
   },
   {
     "name": "Spellstriker Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8543,7 +8543,7 @@
   },
   {
     "name": "Spider Gun (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8557,7 +8557,7 @@
   },
   {
     "name": "Spider Gun (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8571,7 +8571,7 @@
   },
   {
     "name": "Spider Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8585,7 +8585,7 @@
   },
   {
     "name": "Spider Satchel (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8603,7 +8603,7 @@
   },
   {
     "name": "Spider Satchel (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8621,7 +8621,7 @@
   },
   {
     "name": "Spider Satchel (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8639,7 +8639,7 @@
   },
   {
     "name": "Spider Satchel (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8657,7 +8657,7 @@
   },
   {
     "name": "Spike Launcher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8673,7 +8673,7 @@
   },
   {
     "name": "Spiked Chain",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8689,7 +8689,7 @@
   },
   {
     "name": "Spiked Gauntlet",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8704,7 +8704,7 @@
   },
   {
     "name": "Spirit Fan",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8722,7 +8722,7 @@
   },
   {
     "name": "Spirit Thresher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8738,7 +8738,7 @@
   },
   {
     "name": "Spiritsight Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8753,7 +8753,7 @@
   },
   {
     "name": "Splintering Spear (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8770,7 +8770,7 @@
   },
   {
     "name": "Splintering Spear (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8787,7 +8787,7 @@
   },
   {
     "name": "Splintering Spear",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8804,7 +8804,7 @@
   },
   {
     "name": "Splithead Bow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8820,7 +8820,7 @@
   },
   {
     "name": "Spoon Gun",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8837,7 +8837,7 @@
   },
   {
     "name": "Spraysling",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8853,7 +8853,7 @@
   },
   {
     "name": "Spy Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8870,7 +8870,7 @@
   },
   {
     "name": "Spy Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8887,7 +8887,7 @@
   },
   {
     "name": "Spy Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8904,7 +8904,7 @@
   },
   {
     "name": "Staff of Air (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8920,7 +8920,7 @@
   },
   {
     "name": "Staff of Air (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8936,7 +8936,7 @@
   },
   {
     "name": "Staff of Air",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8952,7 +8952,7 @@
   },
   {
     "name": "Staff of Arcane Might (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8968,7 +8968,7 @@
   },
   {
     "name": "Staff of Arcane Might (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -8984,7 +8984,7 @@
   },
   {
     "name": "Staff of Arcane Might",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9000,7 +9000,7 @@
   },
   {
     "name": "Staff of Control (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9016,7 +9016,7 @@
   },
   {
     "name": "Staff of Control (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9032,7 +9032,7 @@
   },
   {
     "name": "Staff of Control",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9048,7 +9048,7 @@
   },
   {
     "name": "Staff of Earth (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9064,7 +9064,7 @@
   },
   {
     "name": "Staff of Earth (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9080,7 +9080,7 @@
   },
   {
     "name": "Staff of Earth",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9096,7 +9096,7 @@
   },
   {
     "name": "Staff of Elemental Power (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9112,7 +9112,7 @@
   },
   {
     "name": "Staff of Elemental Power (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9128,7 +9128,7 @@
   },
   {
     "name": "Staff of Elemental Power",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9144,7 +9144,7 @@
   },
   {
     "name": "Staff of Fire (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9160,7 +9160,7 @@
   },
   {
     "name": "Staff of Fire (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9176,7 +9176,7 @@
   },
   {
     "name": "Staff of Fire",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9192,7 +9192,7 @@
   },
   {
     "name": "Staff of Healing (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9208,7 +9208,7 @@
   },
   {
     "name": "Staff of Healing (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9224,7 +9224,7 @@
   },
   {
     "name": "Staff of Healing (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9240,7 +9240,7 @@
   },
   {
     "name": "Staff of Healing",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9256,7 +9256,7 @@
   },
   {
     "name": "Staff of Illumination",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9272,7 +9272,7 @@
   },
   {
     "name": "Staff of Impossible Visions (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9288,7 +9288,7 @@
   },
   {
     "name": "Staff of Impossible Visions (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9304,7 +9304,7 @@
   },
   {
     "name": "Staff of Impossible Visions (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9320,7 +9320,7 @@
   },
   {
     "name": "Staff of Impossible Visions",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9336,7 +9336,7 @@
   },
   {
     "name": "Staff of Metal (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9353,7 +9353,7 @@
   },
   {
     "name": "Staff of Metal (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9370,7 +9370,7 @@
   },
   {
     "name": "Staff of Metal",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9387,7 +9387,7 @@
   },
   {
     "name": "Staff of Phantasms (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9403,7 +9403,7 @@
   },
   {
     "name": "Staff of Phantasms (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9419,7 +9419,7 @@
   },
   {
     "name": "Staff of Phantasms",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9435,7 +9435,7 @@
   },
   {
     "name": "Staff of Protection (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9451,7 +9451,7 @@
   },
   {
     "name": "Staff of Protection (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9467,7 +9467,7 @@
   },
   {
     "name": "Staff of Protection",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9483,7 +9483,7 @@
   },
   {
     "name": "Staff of Providence (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9499,7 +9499,7 @@
   },
   {
     "name": "Staff of Providence (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9515,7 +9515,7 @@
   },
   {
     "name": "Staff of Providence (True)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9531,7 +9531,7 @@
   },
   {
     "name": "Staff of Providence",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9547,7 +9547,7 @@
   },
   {
     "name": "Staff of Summoning (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9563,7 +9563,7 @@
   },
   {
     "name": "Staff of Summoning (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9579,7 +9579,7 @@
   },
   {
     "name": "Staff of Summoning",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9595,7 +9595,7 @@
   },
   {
     "name": "Staff of Sun Wukong",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9614,7 +9614,7 @@
   },
   {
     "name": "Staff of the Dead (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9630,7 +9630,7 @@
   },
   {
     "name": "Staff of the Dead (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9646,7 +9646,7 @@
   },
   {
     "name": "Staff of the Dead",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9662,7 +9662,7 @@
   },
   {
     "name": "Staff of the Ruling Beast",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9679,7 +9679,7 @@
   },
   {
     "name": "Staff of the Tempest (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9695,7 +9695,7 @@
   },
   {
     "name": "Staff of the Tempest (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9711,7 +9711,7 @@
   },
   {
     "name": "Staff of the Tempest",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9727,7 +9727,7 @@
   },
   {
     "name": "Staff of the Unblinking Eye (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9743,7 +9743,7 @@
   },
   {
     "name": "Staff of the Unblinking Eye (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9759,7 +9759,7 @@
   },
   {
     "name": "Staff of the Unblinking Eye",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9775,7 +9775,7 @@
   },
   {
     "name": "Staff of Water (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9791,7 +9791,7 @@
   },
   {
     "name": "Staff of Water (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9807,7 +9807,7 @@
   },
   {
     "name": "Staff of Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9823,7 +9823,7 @@
   },
   {
     "name": "Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9838,7 +9838,7 @@
   },
   {
     "name": "Stargazer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9855,7 +9855,7 @@
   },
   {
     "name": "Starknife",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9873,7 +9873,7 @@
   },
   {
     "name": "Sticky Algae Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9891,7 +9891,7 @@
   },
   {
     "name": "Sticky Algae Bomb (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9909,7 +9909,7 @@
   },
   {
     "name": "Sticky Algae Bomb (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9927,7 +9927,7 @@
   },
   {
     "name": "Sticky Algae Bomb (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9945,7 +9945,7 @@
   },
   {
     "name": "Storm Flash (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9963,7 +9963,7 @@
   },
   {
     "name": "Storm Flash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9981,7 +9981,7 @@
   },
   {
     "name": "Storm Hammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -9997,7 +9997,7 @@
   },
   {
     "name": "Storm Herald",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10018,7 +10018,7 @@
   },
   {
     "name": "Sukgung",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10032,7 +10032,7 @@
   },
   {
     "name": "Sword Cane",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10048,7 +10048,7 @@
   },
   {
     "name": "Talonstrike Blade (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10063,7 +10063,7 @@
   },
   {
     "name": "Talonstrike Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10078,7 +10078,7 @@
   },
   {
     "name": "Taw Launcher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10094,7 +10094,7 @@
   },
   {
     "name": "Tekko-Kagi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10113,7 +10113,7 @@
   },
   {
     "name": "Temperbrand",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10129,7 +10129,7 @@
   },
   {
     "name": "Temple Sword",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10144,7 +10144,7 @@
   },
   {
     "name": "Tenderizer Grenade (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10163,7 +10163,7 @@
   },
   {
     "name": "Tenderizer Grenade (Lesser)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10182,7 +10182,7 @@
   },
   {
     "name": "Tenderizer Grenade (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10201,7 +10201,7 @@
   },
   {
     "name": "Tenderizer Grenade (Moderate)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10220,7 +10220,7 @@
   },
   {
     "name": "Tengu Gale Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10237,7 +10237,7 @@
   },
   {
     "name": "Tentacle Cannon (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10254,7 +10254,7 @@
   },
   {
     "name": "Tentacle Cannon (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10271,7 +10271,7 @@
   },
   {
     "name": "Tentacle Cannon",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10288,7 +10288,7 @@
   },
   {
     "name": "Tetsubo",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10304,7 +10304,7 @@
   },
   {
     "name": "Thorn Brush",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10320,7 +10320,7 @@
   },
   {
     "name": "Three-peaked Tree",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10338,7 +10338,7 @@
   },
   {
     "name": "Three-Section Naginata",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10355,7 +10355,7 @@
   },
   {
     "name": "Thunder Sling",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10371,7 +10371,7 @@
   },
   {
     "name": "Thundercrasher",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10386,7 +10386,7 @@
   },
   {
     "name": "Thundering Fury Dadao",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10402,7 +10402,7 @@
   },
   {
     "name": "Tidal Crossbow",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10417,7 +10417,7 @@
   },
   {
     "name": "Tiger Fork",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10434,7 +10434,7 @@
   },
   {
     "name": "Tiger's Claw",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10452,7 +10452,7 @@
   },
   {
     "name": "Timeflaying Blade",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10468,7 +10468,7 @@
   },
   {
     "name": "Tri-bladed Katar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10484,7 +10484,7 @@
   },
   {
     "name": "Tricky Pick",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10501,7 +10501,7 @@
   },
   {
     "name": "Trident",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10515,7 +10515,7 @@
   },
   {
     "name": "Trollhound Pick",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10530,7 +10530,7 @@
   },
   {
     "name": "Trueshape Bomb (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10548,7 +10548,7 @@
   },
   {
     "name": "Trueshape Bomb",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10566,7 +10566,7 @@
   },
   {
     "name": "Twining Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10582,7 +10582,7 @@
   },
   {
     "name": "Twisting Gale",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10600,7 +10600,7 @@
   },
   {
     "name": "Ugly Cute's Gift",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10616,7 +10616,7 @@
   },
   {
     "name": "Ulfen Shieldbreaker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10631,7 +10631,7 @@
   },
   {
     "name": "Umbrella Injector",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10648,7 +10648,7 @@
   },
   {
     "name": "Undead Scourge",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10665,7 +10665,7 @@
   },
   {
     "name": "Unholy Water",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10683,7 +10683,7 @@
   },
   {
     "name": "Urumi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10698,7 +10698,7 @@
   },
   {
     "name": "Vampire-Fang Morningstar",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10712,7 +10712,7 @@
   },
   {
     "name": "Vashu's Ninth Life",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10729,7 +10729,7 @@
   },
   {
     "name": "Venom Lash",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10747,7 +10747,7 @@
   },
   {
     "name": "Verdant Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10763,7 +10763,7 @@
   },
   {
     "name": "Verdant Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10779,7 +10779,7 @@
   },
   {
     "name": "Versatile Vial",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10798,7 +10798,7 @@
   },
   {
     "name": "Vine Whip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10816,7 +10816,7 @@
   },
   {
     "name": "Viper Rapier",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10834,7 +10834,7 @@
   },
   {
     "name": "Wakizashi",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10851,7 +10851,7 @@
   },
   {
     "name": "War Flail",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10867,7 +10867,7 @@
   },
   {
     "name": "War Gavel",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10881,7 +10881,7 @@
   },
   {
     "name": "War Javelin",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10896,7 +10896,7 @@
   },
   {
     "name": "War Lance",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10913,7 +10913,7 @@
   },
   {
     "name": "War Razor",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10930,7 +10930,7 @@
   },
   {
     "name": "Warhammer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10944,7 +10944,7 @@
   },
   {
     "name": "Whip Claw",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10961,7 +10961,7 @@
   },
   {
     "name": "Whip-Tongue Sling",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10975,7 +10975,7 @@
   },
   {
     "name": "Whip",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -10993,7 +10993,7 @@
   },
   {
     "name": "Whipstaff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11011,7 +11011,7 @@
   },
   {
     "name": "Whisperer of Souls",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11029,7 +11029,7 @@
   },
   {
     "name": "Whispering Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11047,7 +11047,7 @@
   },
   {
     "name": "Windlass Bola",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11064,7 +11064,7 @@
   },
   {
     "name": "Wintershot (Heroic)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11085,7 +11085,7 @@
   },
   {
     "name": "Wintershot",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11101,7 +11101,7 @@
   },
   {
     "name": "Worldringer (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11117,7 +11117,7 @@
   },
   {
     "name": "Worldringer",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11133,7 +11133,7 @@
   },
   {
     "name": "Wrecker",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11150,7 +11150,7 @@
   },
   {
     "name": "Zealot Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11166,7 +11166,7 @@
   },
   {
     "name": "Zhuazhi Bang",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11183,7 +11183,7 @@
   },
   {
     "name": "Zombie Staff (Greater)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11199,7 +11199,7 @@
   },
   {
     "name": "Zombie Staff (Major)",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",
@@ -11215,7 +11215,7 @@
   },
   {
     "name": "Zombie Staff",
-    "core_rules": "Pathfinder 2e",
+    "core_rules": "pf2e",
     "is_shared": true,
     "is_3pp": false,
     "publisher": "Paizo Inc.",

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_campaign.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_campaign.html.erb
@@ -2,7 +2,7 @@
   <div class="medium-12 columns">
     <h2><%= link_to campaign.name, campaignmanager.campaign_path(campaign) %><span class="subheader"><%= " - #{campaign.page_label}" if campaign.page_label.present? %></span></h2>
     <strong>Game Master:</strong> <%= link_to campaign.resident.name, main_app.resident_path(campaign.resident.slug) %></br>
-    <% if campaign.core_rules.present? %><strong>Core Rules:</strong> <%= campaign.core_rules %></br><% end %>
+    <% if campaign.core_rules.present? %><strong>Core Rules:</strong> <%= CoreRules.display_name(campaign.core_rules) %></br><% end %>
     <h4 style="color:#c5c5c5;">Updated: <span data-timestamp="<%= campaign.updated_at.to_i*1000 %>"></span></h4>
     <p><%= campaign.short_description %></p>
   </div>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_form.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <%= f.input :privacy, collection: Campaignmanager::Campaign::PRIVACY_OPTIONS %>
       <% unless @campaign.new_record? %>
-        <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
+        <%= f.input :core_rules, collection: CoreRules.all(admin_signed_in?), label_method: :name, value_method: :slug, :include_blank => true %>
         <%= f.association :district, collection: current_user.resident.district_list, label_method: :name, value_method: :id, :include_blank => true %>
         <%= f.input :adventure_ids,
             as: :check_boxes,

--- a/engines/entitybuilder/app/models/entitybuilder/entity.rb
+++ b/engines/entitybuilder/app/models/entitybuilder/entity.rb
@@ -134,7 +134,7 @@ module Entitybuilder
     end
 
     def index_title
-      title_builder = self.core_rules.titleize
+      title_builder = CoreRules.display_name(self.core_rules) || self.core_rules.titleize
       title_builder += " - #{title}" if title.present?
       title_builder[0, 50]
     end

--- a/engines/entitybuilder/app/views/entitybuilder/ability_scores/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/ability_scores/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/attacks/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/attacks/index.html.erb
@@ -31,7 +31,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/base_values/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/base_values/index.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/caster_levels/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/caster_levels/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/class_levels/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/class_levels/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/currencies/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/currencies/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/defenses/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/defenses/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/descriptors/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/descriptors/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/entities/_form.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.input :name %>
 
       <% if f.object.new_record? %>
-        <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
+        <%= f.input :core_rules, collection: CoreRules.all(admin_signed_in?), label_method: :name, value_method: :slug, :include_blank => true %>
       <% end %>
       <%= render 'layouts/license/attribution', core_rules: f.object.core_rules %>
 

--- a/engines/entitybuilder/app/views/entitybuilder/entities/edit.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/edit.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/entities/options.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/options.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/index.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/known_spells/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/known_spells/index.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/linked_rules/_rule.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/linked_rules/_rule.html.erb
@@ -11,7 +11,7 @@
     <%= link_to (image_tag @linked_rule.rule.gallery_image.file.url(:medium), :alt => @linked_rule.rule.name, :align=>"right", class: "images_space"), "#{gallery.polymorphic_path(@linked_rule.rule.gallery_image)}/swoosh", "data-reveal-id" => "imageModal", :remote => true  %>
   <% end %>
 
-  <% if @linked_rule.rule.prerequisites? && ('5th Edition Generic'.include?@linked_rule.rule.core_rules) %><p class="italic"><strong>Prerequisites:</strong> <%= @linked_rule.rule.prerequisites %></p><% end %>
+  <% if @linked_rule.rule.prerequisites? && %w[dnd5e generic].include?(@linked_rule.rule.core_rules) %><p class="italic"><strong>Prerequisites:</strong> <%= @linked_rule.rule.prerequisites %></p><% end %>
   <%= sanitize @linked_rule.rule.full_description %>
   <%= render :partial => 'rulebuilder/rules/rule_details', :locals => { :rule => @linked_rule.rule } %>
 

--- a/engines/entitybuilder/app/views/entitybuilder/linked_rules/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/linked_rules/index.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/modifiers/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/modifiers/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/movements/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/movements/index.html.erb
@@ -31,7 +31,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/notables/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/notables/index.html.erb
@@ -27,7 +27,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/saving_throws/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/saving_throws/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/skills/_about.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/skills/_about.html.erb
@@ -7,7 +7,7 @@
     </p>
     <% if @parent_object.missing_core_skills.any? %>
     <strong><%= link_to "<i class='fa fa-plus-circle'></i> Core Skill".html_safe, "#{route_path(@parent_object)}/skills/new/core", :remote => true %></strong>
-    <p>Add a <%= @parent_object.core_rules %> core skill.</p>
+    <p>Add a <%= CoreRules.display_name(@parent_object.core_rules) %> core skill.</p>
     <% end %>
     <strong><%= link_to "<i class='fa fa-plus-circle'></i> Custom Skill".html_safe, new_route_child_path(@parent_object, :skill), :remote => true %></strong>
     <p>Add a blank skill that you can name what you want.</p>

--- a/engines/entitybuilder/app/views/entitybuilder/skills/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/skills/index.html.erb
@@ -28,7 +28,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/entitybuilder/app/views/entitybuilder/trackables/index.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/trackables/index.html.erb
@@ -30,7 +30,7 @@
     <hr class="faded">
     <div class="row">
       <div class="medium-12 columns text-right">
-        <h3 class="color-c5"><%= "#{@parent_object.core_rules}" %></h3>
+        <h3 class="color-c5"><%= CoreRules.display_name(@parent_object.core_rules) %></h3>
       </div>
     </div>
     <div class="row">

--- a/engines/report/app/views/report/entity_snapshots/partial/_free.html.erb
+++ b/engines/report/app/views/report/entity_snapshots/partial/_free.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @free_counts.each do |item| %>
             <tr>
-              <td><strong><%= item.core_rules %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
               <td class="text-center"><%= item.characters %></td>
               <td class="text-center"><%= item.creatures %></td>
               <td class="text-center"><%= item.npcs %></td>

--- a/engines/report/app/views/report/entity_snapshots/partial/_free.html.erb
+++ b/engines/report/app/views/report/entity_snapshots/partial/_free.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @free_counts.each do |item| %>
             <tr>
-              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) || item.core_rules %></strong></td>
               <td class="text-center"><%= item.characters %></td>
               <td class="text-center"><%= item.creatures %></td>
               <td class="text-center"><%= item.npcs %></td>

--- a/engines/report/app/views/report/entity_snapshots/partial/_paid.html.erb
+++ b/engines/report/app/views/report/entity_snapshots/partial/_paid.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @paid_counts.each do |item| %>
             <tr>
-              <td><strong><%= item.core_rules %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
               <td class="text-center"><%= item.characters %></td>
               <td class="text-center"><%= item.creatures %></td>
               <td class="text-center"><%= item.npcs %></td>

--- a/engines/report/app/views/report/entity_snapshots/partial/_paid.html.erb
+++ b/engines/report/app/views/report/entity_snapshots/partial/_paid.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @paid_counts.each do |item| %>
             <tr>
-              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) || item.core_rules %></strong></td>
               <td class="text-center"><%= item.characters %></td>
               <td class="text-center"><%= item.creatures %></td>
               <td class="text-center"><%= item.npcs %></td>

--- a/engines/report/app/views/report/entity_snapshots/partial/_stock.html.erb
+++ b/engines/report/app/views/report/entity_snapshots/partial/_stock.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @stock_counts.each do |item| %>
             <tr>
-              <td><strong><%= item.core_rules %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
               <td class="text-center"><%= item.characters %></td>
               <td class="text-center"><%= item.creatures %></td>
               <td class="text-center"><%= item.npcs %></td>

--- a/engines/report/app/views/report/entity_snapshots/partial/_stock.html.erb
+++ b/engines/report/app/views/report/entity_snapshots/partial/_stock.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @stock_counts.each do |item| %>
             <tr>
-              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) || item.core_rules %></strong></td>
               <td class="text-center"><%= item.characters %></td>
               <td class="text-center"><%= item.creatures %></td>
               <td class="text-center"><%= item.npcs %></td>

--- a/engines/report/app/views/report/rulebuilder_snapshots/partial/_free.html.erb
+++ b/engines/report/app/views/report/rulebuilder_snapshots/partial/_free.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @free_counts.each do |item| %>
             <tr>
-              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) || item.core_rules %></strong></td>
               <td class="text-center"><%= item.rules %></td>
               <td class="text-center"><%= item.items %></td>
               <td class="text-center"><%= item.spells %></td>

--- a/engines/report/app/views/report/rulebuilder_snapshots/partial/_free.html.erb
+++ b/engines/report/app/views/report/rulebuilder_snapshots/partial/_free.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @free_counts.each do |item| %>
             <tr>
-              <td><strong><%= item.core_rules %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
               <td class="text-center"><%= item.rules %></td>
               <td class="text-center"><%= item.items %></td>
               <td class="text-center"><%= item.spells %></td>

--- a/engines/report/app/views/report/rulebuilder_snapshots/partial/_paid.html.erb
+++ b/engines/report/app/views/report/rulebuilder_snapshots/partial/_paid.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @paid_counts.each do |item| %>
             <tr>
-              <td><strong><%= item.core_rules %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
               <td class="text-center"><%= item.rules %></td>
               <td class="text-center"><%= item.items %></td>
               <td class="text-center"><%= item.spells %></td>

--- a/engines/report/app/views/report/rulebuilder_snapshots/partial/_paid.html.erb
+++ b/engines/report/app/views/report/rulebuilder_snapshots/partial/_paid.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @paid_counts.each do |item| %>
             <tr>
-              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) || item.core_rules %></strong></td>
               <td class="text-center"><%= item.rules %></td>
               <td class="text-center"><%= item.items %></td>
               <td class="text-center"><%= item.spells %></td>

--- a/engines/report/app/views/report/rulebuilder_snapshots/partial/_stock.html.erb
+++ b/engines/report/app/views/report/rulebuilder_snapshots/partial/_stock.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @stock_counts.each do |item| %>
             <tr>
-              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) || item.core_rules %></strong></td>
               <td class="text-center"><%= item.rules %></td>
               <td class="text-center"><%= item.items %></td>
               <td class="text-center"><%= item.spells %></td>

--- a/engines/report/app/views/report/rulebuilder_snapshots/partial/_stock.html.erb
+++ b/engines/report/app/views/report/rulebuilder_snapshots/partial/_stock.html.erb
@@ -19,7 +19,7 @@
         <tbody>
           <% @stock_counts.each do |item| %>
             <tr>
-              <td><strong><%= item.core_rules %></strong></td>
+              <td><strong><%= CoreRules.display_name(item.core_rules) %></strong></td>
               <td class="text-center"><%= item.rules %></td>
               <td class="text-center"><%= item.items %></td>
               <td class="text-center"><%= item.spells %></td>

--- a/engines/rulebuilder/app/assets/javascripts/rulebuilder/rules.js
+++ b/engines/rulebuilder/app/assets/javascripts/rulebuilder/rules.js
@@ -29,7 +29,7 @@ $(document).on('turbolinks:load', function () {
 $(document).on('turbolinks:load', function () {
 
   $('.select2-rule_type > optgroup').each(function () {
-    if (this.label !== $('select[id$="rule_core_rules"] option:selected').text()) {
+    if (this.label !== $('select[id$="rule_core_rules"] option:selected').val()) {
       this.remove();
     }
   });

--- a/engines/rulebuilder/app/views/rulebuilder/items/_form.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/items/_form.html.erb
@@ -8,7 +8,7 @@
     <div class="medium-8 columns">
       <%= f.input :name %>
       <%= f.association :parent, collection: f.object.class.where(core_rules: f.object.core_rules).select(:name, :id).order_name, label_method: :name, value_method: :id, :include_blank => true if admin_signed_in? %>
-      <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
+      <%= f.input :core_rules, collection: CoreRules.all(admin_signed_in?), label_method: :name, value_method: :slug, :include_blank => true %>
       <div class="row">
         <div class="medium-9 columns">
           <%= f.input :publisher %>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/_form.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/_form.html.erb
@@ -3,7 +3,7 @@
     <h3 class="color-c5"><%= @rule.rule_type.blank? ? "Rule" : "#{@rule.rule_type}" %></h3>
   </div>
   <div class="medium-6 columns text-right">
-    <h3 class="color-c5"><%= "#{@rule.core_rules}" %></h3>
+    <h3 class="color-c5"><%= CoreRules.display_name(@rule.core_rules) %></h3>
   </div>
 </div>
 <fieldset>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/_list.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/_list.html.erb
@@ -1,7 +1,7 @@
 <% core_rules_list = @rules.to_a.map(&:core_rules).uniq.sort() %>
 <% core_rules_list.each do |core_rules| %>
 
-  <h2><%= core_rules %></h2>
+  <h2><%= CoreRules.display_name(core_rules) || core_rules %></h2>
   <div class="row show-div">
     <div class="medium-12 columns">
       <% rule_types = CoreRules::Rule.rule_types(core_rules)%>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/_menu.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/_menu.html.erb
@@ -2,9 +2,9 @@
   <dd class="<%= 'active' if current_page?(route_collection_path(@type.tableize)) && params[:core_rules].blank? %>">
     <h3><%= link_to 'All', route_collection_path(@type.tableize), :style => 'display:block;' %></h3>
   </dd>
-  <% CoreRules.options(admin_signed_in?).each do |item| %>
-    <dd class="<%= 'active' if current_page?("#{route_collection_path(@type.tableize)}?core_rules=#{item}") %>">
-      <h3><%= link_to "#{item}", "#{route_collection_path(@type.tableize)}?core_rules=#{item}", :style => 'display:block;' %></h3>
+  <% CoreRules.all(admin_signed_in?).each do |rulebook| %>
+    <dd class="<%= 'active' if current_page?("#{route_collection_path(@type.tableize)}?core_rules=#{rulebook.slug}") %>">
+      <h3><%= link_to rulebook.name, "#{route_collection_path(@type.tableize)}?core_rules=#{rulebook.slug}", :style => 'display:block;' %></h3>
     </dd>
   <% end %>
 </dl>
@@ -19,8 +19,8 @@
   <li><label>Rules</label></li>
   <li><%= link_to 'All', route_collection_path(@type.tableize) %></li>
 
-  <% CoreRules.options(admin_signed_in?).each do |item| %>
-    <li><%= link_to "#{item}", "#{route_collection_path(@type.tableize)}?core_rules=#{item}" %></li>
+  <% CoreRules.all(admin_signed_in?).each do |rulebook| %>
+    <li><%= link_to rulebook.name, "#{route_collection_path(@type.tableize)}?core_rules=#{rulebook.slug}" %></li>
   <% end %>
 <% end %>
 
@@ -29,8 +29,8 @@
     <ul class="dropdown">
       <li><%= link_to 'All', route_collection_path(@type.tableize) %></li>
 
-      <% CoreRules.options(admin_signed_in?).each do |item| %>
-        <li><%= link_to "#{item}", "#{route_collection_path(@type.tableize)}?core_rules=#{item}" %></li>
+      <% CoreRules.all(admin_signed_in?).each do |rulebook| %>
+        <li><%= link_to rulebook.name, "#{route_collection_path(@type.tableize)}?core_rules=#{rulebook.slug}" %></li>
       <% end %>
     </ul>
   </li>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/_rule.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/_rule.html.erb
@@ -14,7 +14,7 @@
     <%= link_to (image_tag @rule.gallery_image.file.url(:medium), :alt => @rule.name, :align=>"right", class: "images_space"), "#{gallery.polymorphic_path(@rule.gallery_image)}/swoosh", "data-reveal-id" => "imageModal", :remote => true  %>
   <% end %>
 
-  <% if @rule.prerequisites? && ('5th Edition Generic'.include?@rule.core_rules) %><p class="italic"><strong>Prerequisites:</strong> <%= @rule.prerequisites %></p><% end %>
+  <% if @rule.prerequisites? && %w[dnd5e generic].include?(@rule.core_rules) %><p class="italic"><strong>Prerequisites:</strong> <%= @rule.prerequisites %></p><% end %>
   <%= sanitize @rule.full_description %>
   <%= render :partial => 'rulebuilder/rules/rule_details', :locals => { :rule => @rule } %>
 

--- a/engines/rulebuilder/app/views/rulebuilder/rules/_rule_details.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/_rule_details.html.erb
@@ -1,4 +1,4 @@
-<% if rule.prerequisites? && rule.core_rules != '5th Edition' %><h2>Prerequisites</h2> <p><%= rule.prerequisites %></p><% end %>
+<% if rule.prerequisites? && rule.core_rules != 'dnd5e' %><h2>Prerequisites</h2> <p><%= rule.prerequisites %></p><% end %>
 <% if rule.benefit? %><h2>Benefit</h2> <%= sanitize rule.benefit %><% end %>
 <% if rule.normal? %><h2>Normal</h2> <%= sanitize rule.normal %><% end %>
 <% if rule.special? %><h2>Special</h2> <%= sanitize rule.special %><% end %>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/form/_new.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/form/_new.html.erb
@@ -3,7 +3,7 @@
     <%= f.input :name %>
     <div class="row">
       <div class="small-6 columns">
-        <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
+        <%= f.input :core_rules, collection: CoreRules.all(admin_signed_in?), label_method: :name, value_method: :slug, :include_blank => true %>
       </div>
       <div class="small-6 columns">
         <%= f.input :rule_type, as: :grouped_select, collection: CoreRules::Rule.options(admin_signed_in?), group_method: :last, include_blank: false, input_html: { class: "select2-rule_type"} %>

--- a/engines/rulebuilder/app/views/rulebuilder/rules/new.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/new.html.erb
@@ -28,7 +28,7 @@
       <div class="small-12 columns">
         <div id="rule_form">
           <%= simple_form_for [@route_namespace, @rule].compact do |f| %>
-            <h3 class="color-c5"><%= "#{@rule.core_rules}" %> <%= @rule.rule_type.blank? ? "Rule" : "#{@rule.rule_type}" %></h3>
+            <h3 class="color-c5"><%= CoreRules.display_name(@rule.core_rules) %> <%= @rule.rule_type.blank? ? "Rule" : "#{@rule.rule_type}" %></h3>
             <fieldset>
 
               <%= render "rulebuilder/rules/form/new", :f => f %>

--- a/engines/rulebuilder/app/views/rulebuilder/spells/_form.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/spells/_form.html.erb
@@ -9,7 +9,7 @@
     <div class="medium-8 columns">
       <%= f.input :name %>
       <%= f.association :parent, collection: f.object.class.where(core_rules: f.object.core_rules).select(:name, :id).order_name, label_method: :name, value_method: :id, :include_blank => true if admin_signed_in? %>
-      <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
+      <%= f.input :core_rules, collection: CoreRules.all(admin_signed_in?), label_method: :name, value_method: :slug, :include_blank => true %>
       <div class="row">
         <div class="medium-9 columns">
           <%= f.input :publisher %>

--- a/engines/rulebuilder/app/views/rulebuilder/spells/_list.html.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/spells/_list.html.erb
@@ -1,6 +1,6 @@
 <% rules = @spells.to_a.map(&:core_rules).uniq %>
 <% rules.each do |rule| %>
-  <h2><%= rule %></h2>
+  <h2><%= CoreRules.display_name(rule) || rule %></h2>
   <div class="row show-div">
     <div class="medium-12 columns">
       <% spells = @spells.select { |i| i.core_rules == rule } %>

--- a/engines/storybuilder/app/views/storybuilder/adventures/_form.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/adventures/_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.input :name %>
       <%= f.input :page_label, label: 'Label' %>
       <%= f.input :privacy, collection: Storybuilder::Adventure::PRIVACY_OPTIONS %>
-      <%= f.input :core_rules, collection: CoreRules.options(admin_signed_in?), :include_blank => true %>
+      <%= f.input :core_rules, collection: CoreRules.all(admin_signed_in?), label_method: :name, value_method: :slug, :include_blank => true %>
       <%= f.fields_for :menu_item_join do |p| %>
         <%= p.association :menu_item, collection: @adventure.menu_items, label_method: :item_label, value_method: :id, :include_blank => true %>
       <% end %>

--- a/engines/storybuilder/app/views/storybuilder/adventures/_list.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/adventures/_list.html.erb
@@ -2,7 +2,7 @@
   <%= render :partial =>'layouts/index_row',
     :locals => {
     :main => adventure.name,
-    :sub => adventure.core_rules,
+    :sub => CoreRules.display_name(adventure.core_rules),
     :description => adventure.short_description,
     :show_link => polymorphic_path(adventure),
     :edit_link => edit_polymorphic_path(adventure),

--- a/lib/core_rules.rb
+++ b/lib/core_rules.rb
@@ -6,7 +6,7 @@ require "core_rules/seeder"
 module CoreRules
   mattr_accessor :rulebooks
 
-  def self.all(show_all = true)
+  def self.all(show_all = false)
     config = show_all ? rulebooks : rulebooks.select { |v| v["active"] == "true" }
     config.map do |v|
       Rulebook.new(
@@ -26,13 +26,11 @@ module CoreRules
   end
 
   def self.display_name(slug)
-    rulebook = rulebooks.detect { |v| v["slug"] == slug }
-    rulebook["name"] if rulebook.present?
+    find(slug)&.name
   end
 
   def self.options(show_all)
-    config = show_all ? rulebooks : rulebooks.select { |v| v["active"] == "true" }
-    config.map { |r| [ r["name"], r["slug"] ] }
+    all(show_all).map { |r| [ r.name, r.slug ] }
   end
 
   def self.d20_system?(slug)

--- a/lib/core_rules.rb
+++ b/lib/core_rules.rb
@@ -1,3 +1,4 @@
+require "core_rules/rulebook"
 require "core_rules/entity"
 require "core_rules/rule"
 require "core_rules/seeder"
@@ -5,46 +6,50 @@ require "core_rules/seeder"
 module CoreRules
   mattr_accessor :rulebooks
 
+  def self.all(show_all = true)
+    config = show_all ? rulebooks : rulebooks.select { |v| v["active"] == "true" }
+    config.map do |v|
+      Rulebook.new(
+        slug:         v["slug"],
+        name:         v["name"],
+        active:       v["active"],
+        stock:        v["stock"],
+        d20_system:   v["d20_system"],
+        default_dice: v["default_dice"],
+        license:      v["license"]
+      )
+    end
+  end
+
+  def self.find(slug)
+    all.detect { |r| r.slug == slug }
+  end
+
+  def self.display_name(slug)
+    rulebook = rulebooks.detect { |v| v["slug"] == slug }
+    rulebook["name"] if rulebook.present?
+  end
+
   def self.options(show_all)
-    if show_all
-      config = CoreRules.rulebooks
-    else
-      config = CoreRules.rulebooks.select { |v| v["active"] == "true" }
-    end
-    options = []
-    config.each_with_index do |r, i|
-      options[i] = r["name"]
-    end
-    options
+    config = show_all ? rulebooks : rulebooks.select { |v| v["active"] == "true" }
+    config.map { |r| [ r["name"], r["slug"] ] }
   end
 
-  def self.d20_system?(core_rules)
-    options = rulebooks.detect { |v| v["name"] == core_rules && v["d20_system"] == "true" }
-    if options.present?
-      true
-    else
-      false
-    end
+  def self.d20_system?(slug)
+    rulebooks.any? { |v| v["slug"] == slug && v["d20_system"] == "true" }
   end
 
-  def self.stock?(core_rules)
-    options = rulebooks.detect { |v| v["name"] == core_rules && v["stock"] == "true" }
-    if options.present?
-      true
-    else
-      false
-    end
+  def self.stock?(slug)
+    rulebooks.any? { |v| v["slug"] == slug && v["stock"] == "true" }
   end
 
-  def self.license(core_rules)
-    rulebook = rulebooks.detect { |v| v["name"] == core_rules }
-    license = rulebook["license"] if rulebook.present?
-    license
+  def self.license(slug)
+    rulebook = rulebooks.detect { |v| v["slug"] == slug }
+    rulebook["license"] if rulebook.present?
   end
 
-  def self.default_dice(core_rules)
-    rulebook = rulebooks.detect { |v| v["name"] == core_rules }
-    dice = rulebook["default_dice"] if rulebook.present?
-    dice
+  def self.default_dice(slug)
+    rulebook = rulebooks.detect { |v| v["slug"] == slug }
+    rulebook["default_dice"] if rulebook.present?
   end
 end

--- a/lib/core_rules.rb
+++ b/lib/core_rules.rb
@@ -29,10 +29,6 @@ module CoreRules
     find(slug)&.name
   end
 
-  def self.options(show_all)
-    all(show_all).map { |r| [ r.name, r.slug ] }
-  end
-
   def self.d20_system?(slug)
     rulebooks.any? { |v| v["slug"] == slug && v["d20_system"] == "true" }
   end

--- a/lib/core_rules.rb
+++ b/lib/core_rules.rb
@@ -22,7 +22,7 @@ module CoreRules
   end
 
   def self.find(slug)
-    all.detect { |r| r.slug == slug }
+    all(true).detect { |r| r.slug == slug }
   end
 
   def self.display_name(slug)

--- a/lib/core_rules/entity.rb
+++ b/lib/core_rules/entity.rb
@@ -2,25 +2,25 @@ module CoreRules
   module Entity
 
     def self.sheet_layout(core_rules)
-      rulebook = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      rulebook = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       sheet = rulebook['entitybuilder']['sheet'] unless rulebook.blank?
       return sheet
     end
 
     def self.use_modifiers?(core_rules)
-      rulebook = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      rulebook = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       use_modifiers = rulebook['entitybuilder']['use_modifiers'] unless rulebook.blank?
       return use_modifiers == "true" ? true : false
     end
 
     def self.show_core_blocks?(core_rules)
-      rulebook = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      rulebook = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       show_core_blocks = rulebook['entitybuilder']['show_core_blocks'] unless rulebook.blank?
       return show_core_blocks == "true" ? true : false
     end
 
     def self.menu(core_rules)
-      rulebook = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      rulebook = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       menu = rulebook['entitybuilder']['menu'] unless rulebook.blank?
       return menu
     end
@@ -30,7 +30,7 @@ module CoreRules
     end
 
     def self.core_skills(core_rules)
-      rulebook = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      rulebook = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       core_skills = rulebook['entitybuilder']['core_skills'] unless rulebook.blank?
       return core_skills
     end
@@ -40,13 +40,13 @@ module CoreRules
     end
 
     def self.default_types(core_rules, entity_type)
-      config = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      config = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       default_types = config['entitybuilder'][entity_type].keys unless config.blank?
       return default_types
     end
 
     def self.defaults_values(core_rules, entity_type, default_type)
-      rulebook = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+      rulebook = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
       defaults = rulebook['entitybuilder'][entity_type][default_type] unless rulebook.blank?
       return defaults
     end

--- a/lib/core_rules/rule.rb
+++ b/lib/core_rules/rule.rb
@@ -10,8 +10,7 @@ module CoreRules
 
         rules = []
         config.each do |core|
-          hash = []
-          hash = [core['name'], core['rulebuilder']['rules'].collect{ |r| r['name'] }]
+          hash = [core['slug'], core['rulebuilder']['rules'].collect{ |r| r['name'] }]
           rules += [hash]
         end
         return rules
@@ -25,8 +24,8 @@ module CoreRules
         end
 
         rules = {}
-        CoreRules.rulebooks.each do |core|
-          hash = { core['name'] => core['rulebuilder']['rules'].collect{ |r| r['name'] } }
+        config.each do |core|
+          hash = { core['slug'] => core['rulebuilder']['rules'].collect{ |r| r['name'] } }
           rules.merge!(hash)
         end
         return rules.to_json

--- a/lib/core_rules/rule.rb
+++ b/lib/core_rules/rule.rb
@@ -33,7 +33,7 @@ module CoreRules
       end
 
       def self.rule_types(core_rules)
-        config = CoreRules.rulebooks.detect { |v| v['name'] == core_rules }
+        config = CoreRules.rulebooks.detect { |v| v['slug'] == core_rules }
         rule_types = config['rulebuilder']['rules'].collect{ |r| r['name'] }.to_a unless config.blank?
         return rule_types
       end

--- a/lib/core_rules/rulebook.rb
+++ b/lib/core_rules/rulebook.rb
@@ -1,0 +1,7 @@
+module CoreRules
+  Rulebook = Struct.new(:slug, :name, :active, :stock, :d20_system, :default_dice, :license, keyword_init: true) do
+    def active? = active == "true"
+    def stock?  = stock  == "true"
+    def d20_system? = d20_system == "true"
+  end
+end

--- a/test/controllers/entitybuilder/inventory_items_controller_test.rb
+++ b/test/controllers/entitybuilder/inventory_items_controller_test.rb
@@ -38,10 +38,10 @@ module Entitybuilder
 
     test "admin should get stock item options for non-stock core rules" do
       item = Rulebuilder::StockItem.create!(
-        core_rules: "Generic",
+        core_rules: "generic",
         name: "Generic stock item"
       )
-      @character.update!(core_rules: "Generic")
+      @character.update!(core_rules: "generic")
 
       sign_in @user
       sign_in admins(:dan)

--- a/test/controllers/entitybuilder/known_spells_controller_test.rb
+++ b/test/controllers/entitybuilder/known_spells_controller_test.rb
@@ -38,10 +38,10 @@ module Entitybuilder
 
     test "admin should get stock spell options for non-stock core rules" do
       spell = Rulebuilder::StockSpell.create!(
-        core_rules: "Generic",
+        core_rules: "generic",
         name: "Generic stock spell"
       )
-      @character.update!(core_rules: "Generic")
+      @character.update!(core_rules: "generic")
 
       sign_in @user
       sign_in admins(:dan)

--- a/test/controllers/entitybuilder/linked_rules_controller_test.rb
+++ b/test/controllers/entitybuilder/linked_rules_controller_test.rb
@@ -50,12 +50,12 @@ module Entitybuilder
 
     test "admin should get stock rule options for non-stock core rules" do
       rule = Rulebuilder::StockRule.create!(
-        core_rules: "Generic",
+        core_rules: "generic",
         rule_type: "Rule",
         is_shared: true,
         name: "Generic stock rule"
       )
-      @character.update!(core_rules: "Generic")
+      @character.update!(core_rules: "generic")
 
       sign_in @user
       sign_in admins(:dan)

--- a/test/controllers/rulebuilder/admin/stock_rules_controller_test.rb
+++ b/test/controllers/rulebuilder/admin/stock_rules_controller_test.rb
@@ -36,7 +36,7 @@ module Rulebuilder
 
       test "should filter index by core rules" do
         Rulebuilder::StockRule.create!(
-          core_rules: "Fate Core",
+          core_rules: "fateCore",
           rule_type: "Stunt",
           is_shared: true,
           name: "Different ruleset"
@@ -44,10 +44,10 @@ module Rulebuilder
 
         sign_in @user
         sign_in @admin
-        get :index, params: { core_rules: "PFRPG" }
+        get :index, params: { core_rules: "pf1e" }
 
         assert_response :success
-        assert_equal [ "PFRPG" ], assigns(:rules).map(&:core_rules).uniq
+        assert_equal [ "pf1e" ], assigns(:rules).map(&:core_rules).uniq
       end
 
       test "should not get new" do

--- a/test/controllers/rulebuilder/stock_rules_controller_test.rb
+++ b/test/controllers/rulebuilder/stock_rules_controller_test.rb
@@ -82,7 +82,7 @@ module Rulebuilder
 
       %w[Backgrounds Class Condition Rule\ Reference Species Subclass].each do |rule_type|
         rule = Rulebuilder::StockRule.create!(
-          core_rules: "5th Edition",
+          core_rules: "dnd5e",
           rule_type: rule_type,
           is_shared: true,
           name: "Test #{rule_type}",
@@ -101,7 +101,7 @@ module Rulebuilder
 
       %w[Condition Species].each do |rule_type|
         rule = Rulebuilder::StockRule.create!(
-          core_rules: "5th Edition",
+          core_rules: "dnd5e",
           rule_type: rule_type,
           is_shared: true,
           name: "Trait #{rule_type}",

--- a/test/fixtures/campaignmanager/campaigns.yml
+++ b/test/fixtures/campaignmanager/campaigns.yml
@@ -7,7 +7,7 @@ resident_one:
   slug: long-trail
   page_label: ima label
   privacy: Friends
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
 
@@ -18,6 +18,6 @@ resident_two:
   slug: see-the-world
   page_label:
   privacy: Public
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>

--- a/test/fixtures/entitybuilder/entities.yml
+++ b/test/fixtures/entitybuilder/entities.yml
@@ -10,7 +10,7 @@ resident_character_one:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -26,7 +26,7 @@ resident_character_two:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -42,7 +42,7 @@ resident_character_three:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -58,7 +58,7 @@ resident_creature_one:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -74,7 +74,7 @@ resident_creature_two:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -90,7 +90,7 @@ resident_creature_three:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -106,7 +106,7 @@ resident_npc_one:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -122,7 +122,7 @@ resident_npc_two:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -137,7 +137,7 @@ stock_creature_one:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -152,7 +152,7 @@ stock_creature_two:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -167,7 +167,7 @@ stock_npc_one:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -182,7 +182,7 @@ stock_npc_two:
   tags: ["hello1", "world2"]
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
   introduction: <p>Text for test</p>
@@ -194,7 +194,7 @@ draw_steel_character:
   name: Steelborn
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: Draw Steel
+  core_rules: drawSteel
   short_description: A Draw Steel test character
 
 fifth_edition_character:
@@ -203,7 +203,7 @@ fifth_edition_character:
   name: Valra
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: 5th Edition
+  core_rules: dnd5e
   short_description: A 5th Edition test character
 
 pf2e_character:
@@ -212,5 +212,5 @@ pf2e_character:
   name: Valeros
   privacy: Residents
   sheet_privacy: Residents
-  core_rules: Pathfinder 2e
+  core_rules: pf2e
   short_description: A Pathfinder 2e test character

--- a/test/fixtures/rulebuilder/items.yml
+++ b/test/fixtures/rulebuilder/items.yml
@@ -3,7 +3,7 @@
 resident_one:
   type: Rulebuilder::ResidentItem
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   privacy: Private
   publisher: Embers Design Studios
@@ -18,7 +18,7 @@ resident_one:
 resident_two:
   type: Rulebuilder::ResidentItem
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   privacy: Private
   publisher: Embers Design Studios
@@ -32,7 +32,7 @@ resident_two:
 
 stock_one:
   type: Rulebuilder::StockItem
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   privacy: Private
   publisher: Embers Design Studios
@@ -46,7 +46,7 @@ stock_one:
 
 stock_two:
   type: Rulebuilder::StockItem
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   privacy: Private
   publisher: Embers Design Studios

--- a/test/fixtures/rulebuilder/rules.yml
+++ b/test/fixtures/rulebuilder/rules.yml
@@ -3,7 +3,7 @@
 resident_one:
   type: Rulebuilder::ResidentRule
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   rule_type: Feat
   is_shared: true
   name: MyString
@@ -22,7 +22,7 @@ resident_one:
 resident_two:
   type: Rulebuilder::ResidentRule
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   rule_type: Ability
   is_shared: false
   name: MyString
@@ -41,7 +41,7 @@ resident_two:
 resident_three:
   type: Rulebuilder::ResidentRule
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   rule_type: Stunt
   is_shared: false
   name: MyString
@@ -59,7 +59,7 @@ resident_three:
 
 stock_one:
   type: Rulebuilder::StockRule
-  core_rules: PFRPG
+  core_rules: pf1e
   rule_type: Feat
   is_shared: true
   name: MyString
@@ -77,7 +77,7 @@ stock_one:
 
 stock_two:
   type: Rulebuilder::StockRule
-  core_rules: PFRPG
+  core_rules: pf1e
   rule_type: Feat
   is_shared: true
   name: MyString

--- a/test/fixtures/rulebuilder/spells.yml
+++ b/test/fixtures/rulebuilder/spells.yml
@@ -3,7 +3,7 @@
 resident_one:
   type: Rulebuilder::ResidentSpell
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   publisher: Embers Design Studios
   is_3pp: true
@@ -26,7 +26,7 @@ resident_one:
 resident_two:
   type: Rulebuilder::ResidentSpell
   resident: razune
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   publisher: Embers Design Studios
   is_3pp: true
@@ -48,7 +48,7 @@ resident_two:
 
 stock_one:
   type: Rulebuilder::StockSpell
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   publisher: Embers Design Studios
   is_3pp: true
@@ -70,7 +70,7 @@ stock_one:
 
 stock_two:
   type: Rulebuilder::StockSpell
-  core_rules: PFRPG
+  core_rules: pf1e
   name: MyString
   publisher: Embers Design Studios
   is_3pp: true

--- a/test/fixtures/storybuilder/adventures.yml
+++ b/test/fixtures/storybuilder/adventures.yml
@@ -7,7 +7,7 @@ resident_one:
   name: Kobold Layer
   slug: kobold-layer
   privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
 
@@ -18,7 +18,7 @@ resident_two:
   name: Wizards Tower
   slug: wizards-tower
   privacy: Private
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
 
@@ -29,7 +29,7 @@ stock_one:
   name: Kobold Layer
   slug: kobold-layer
   privacy: Residents
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>
 
@@ -40,6 +40,6 @@ stock_two:
   name: Wizards Tower
   slug: wizards-tower
   privacy: Private
-  core_rules: PFRPG
+  core_rules: pf1e
   short_description: MyString
   full_description: <p>Text for test</p>

--- a/test/integration/admin_stock_entity_navigation_test.rb
+++ b/test/integration/admin_stock_entity_navigation_test.rb
@@ -58,7 +58,7 @@ class AdminStockEntityNavigationTest < ActionDispatch::IntegrationTest
   end
 
   test "admin can add stock notables for non-stock entity core rules" do
-    @character.update!(core_rules: "Generic")
+    @character.update!(core_rules: "generic")
     sign_in @user
     sign_in @admin
 
@@ -69,7 +69,7 @@ class AdminStockEntityNavigationTest < ActionDispatch::IntegrationTest
   end
 
   test "admin can add stock notables for non-stock adventure core rules" do
-    @adventure.update!(core_rules: "Generic")
+    @adventure.update!(core_rules: "generic")
     sign_in @user
     sign_in @admin
 

--- a/test/integration/campaign_lifecycle_test.rb
+++ b/test/integration/campaign_lifecycle_test.rb
@@ -94,7 +94,7 @@ class CampaignLifecycleTest < ActionDispatch::IntegrationTest
       {
         name: name,
         privacy: privacy,
-        core_rules: "PFRPG",
+        core_rules: "pf1e",
         short_description: "A campaign for integration testing.",
         full_description: "<p>A campaign for integration testing.</p>"
       }

--- a/test/integration/draw_steel_system_test.rb
+++ b/test/integration/draw_steel_system_test.rb
@@ -7,20 +7,20 @@ class DrawSteelSystemTest < ActiveSupport::TestCase
   end
 
   test "Draw Steel declares the six expected rule types" do
-    types = CoreRules::Rule.rule_types("Draw Steel")
+    types = CoreRules::Rule.rule_types("drawSteel")
     assert_equal %w[Ancestry Class Kit Career Complication Condition].sort,
                  types.sort
   end
 
   test "Draw Steel has 57 core skills across 5 groups" do
-    skills = CoreRules::Entity.core_skills("Draw Steel")
+    skills = CoreRules::Entity.core_skills("drawSteel")
     assert_equal 57, skills.size
     groups = skills.map { |s| s["group"] }.uniq.sort
     assert_equal %w[Crafting Exploration Interpersonal Intrigue Lore], groups
   end
 
   test "Draw Steel separates inline attribution from FAQ lookup key" do
-    license = CoreRules.license("Draw Steel")
+    license = CoreRules.license("drawSteel")
 
     assert license["core_faq"].blank?
     assert_match(/Draw Steel Creator License/, license["attribution"])
@@ -28,13 +28,13 @@ class DrawSteelSystemTest < ActiveSupport::TestCase
   end
 
   test "Draw Steel character has 5 ability scores: the characteristics" do
-    abilities = CoreRules::Entity.defaults_values("Draw Steel", "character", "ability_scores") || []
+    abilities = CoreRules::Entity.defaults_values("drawSteel", "character", "ability_scores") || []
     assert_equal %w[Might Agility Reason Intuition Presence],
                  abilities.map { |a| a["name"] }
   end
 
   test "Draw Steel character has Stamina-related trackables" do
-    trackables = CoreRules::Entity.defaults_values("Draw Steel", "character", "trackables") || []
+    trackables = CoreRules::Entity.defaults_values("drawSteel", "character", "trackables") || []
     names = trackables.map { |t| t["name"] }
     assert_includes names, "Stamina"
     assert_includes names, "Recoveries"
@@ -46,7 +46,7 @@ class DrawSteelSystemTest < ActiveSupport::TestCase
   end
 
   test "Draw Steel character has identity descriptors" do
-    descs = CoreRules::Entity.defaults_values("Draw Steel", "character", "descriptors") || []
+    descs = CoreRules::Entity.defaults_values("drawSteel", "character", "descriptors") || []
     names = descs.map { |d| d["name"] }
     %w[Ancestry Class Subclass Career Complication Languages].each do |n|
       assert_includes names, n, "expected descriptor: #{n}"
@@ -57,14 +57,14 @@ class DrawSteelSystemTest < ActiveSupport::TestCase
   end
 
   test "Draw Steel character has no defenses or saving_throws blocks (or empty)" do
-    defenses = CoreRules::Entity.defaults_values("Draw Steel", "character", "defenses") || []
-    saves    = CoreRules::Entity.defaults_values("Draw Steel", "character", "saving_throws") || []
+    defenses = CoreRules::Entity.defaults_values("drawSteel", "character", "defenses") || []
+    saves    = CoreRules::Entity.defaults_values("drawSteel", "character", "saving_throws") || []
     assert_equal 0, defenses.size
     assert_equal 0, saves.size
   end
 
   test "Draw Steel core_skills cover all 5 groups with expected counts" do
-    skills = CoreRules::Entity.core_skills("Draw Steel")
+    skills = CoreRules::Entity.core_skills("drawSteel")
     by_group = skills.group_by { |s| s["group"] }
     assert_equal 10, by_group["Crafting"]&.size,      "Crafting count"
     assert_equal 10, by_group["Exploration"]&.size,   "Exploration count"
@@ -74,12 +74,12 @@ class DrawSteelSystemTest < ActiveSupport::TestCase
   end
 
   test "Draw Steel creature has 5 characteristics too" do
-    abilities = CoreRules::Entity.defaults_values("Draw Steel", "creature", "ability_scores")
+    abilities = CoreRules::Entity.defaults_values("drawSteel", "creature", "ability_scores")
     assert_equal 5, abilities&.size
   end
 
   test "Draw Steel menu links to sheet sections that match has_many on Entity" do
-    menu = CoreRules::Entity.menu("Draw Steel")
+    menu = CoreRules::Entity.menu("drawSteel")
     valid_links = %w[
       descriptors ability_scores base_values movements trackables
       class_levels caster_levels skills attacks defenses saving_throws

--- a/test/integration/fifth_edition_system_test.rb
+++ b/test/integration/fifth_edition_system_test.rb
@@ -7,14 +7,14 @@ class FifthEditionSystemTest < ActiveSupport::TestCase
   end
 
   test "5th Edition declares the expected 2024 rule types" do
-    types = CoreRules::Rule.rule_types("5th Edition")
+    types = CoreRules::Rule.rule_types("dnd5e")
 
     assert_equal %w[Ability Backgrounds Class Condition Feat Rule\ Reference Species Subclass].sort,
                  types.sort
   end
 
   test "5th Edition separates inline attribution from FAQ lookup key" do
-    license = CoreRules.license("5th Edition")
+    license = CoreRules.license("dnd5e")
 
     assert license["core_faq"].blank?
     assert_equal "Creative Commons Attribution 4.0 International", license["label"]
@@ -23,7 +23,7 @@ class FifthEditionSystemTest < ActiveSupport::TestCase
   end
 
   test "5th Edition character defaults use Species" do
-    descriptors = CoreRules::Entity.defaults_values("5th Edition", "character", "descriptors") || []
+    descriptors = CoreRules::Entity.defaults_values("dnd5e", "character", "descriptors") || []
     names = descriptors.map { |descriptor| descriptor["name"] }
 
     assert_includes names, "Species"

--- a/test/integration/pf2e_system_test.rb
+++ b/test/integration/pf2e_system_test.rb
@@ -3,23 +3,23 @@ require "test_helper"
 class Pf2eSystemTest < ActiveSupport::TestCase
   test "Pathfinder 2e is registered in CoreRules.rulebooks" do
     names = CoreRules.rulebooks.map { |r| r["name"] }
-    assert_includes names, "Pathfinder 2e"
+    assert_includes names, "Pathfinder 2E"
   end
 
   test "Pathfinder 2e declares 10 expected rule types" do
-    types = CoreRules::Rule.rule_types("Pathfinder 2e")
+    types = CoreRules::Rule.rule_types("pf2e")
     assert_equal 10, types.size
   end
 
   test "Pathfinder 2e has 17 core skills across 5 ability groups" do
-    skills = CoreRules::Entity.core_skills("Pathfinder 2e")
+    skills = CoreRules::Entity.core_skills("pf2e")
     assert_equal 17, skills.size
     groups = skills.map { |s| s["group"] }.uniq.sort
     assert_equal %w[Charisma Dexterity Intelligence Strength Wisdom], groups
   end
 
   test "Pathfinder 2e skills have correct per-group counts" do
-    skills = CoreRules::Entity.core_skills("Pathfinder 2e")
+    skills = CoreRules::Entity.core_skills("pf2e")
     by_group = skills.group_by { |s| s["group"] }
     assert_equal 1, by_group["Strength"]&.size,     "Strength count"
     assert_equal 3, by_group["Dexterity"]&.size,    "Dexterity count"
@@ -29,7 +29,7 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e license has ORC label and core_faq key" do
-    license = CoreRules.license("Pathfinder 2e")
+    license = CoreRules.license("pf2e")
     assert_equal "ORC License", license["label"]
     assert_equal "License ORC", license["core_faq"]
     assert license["attribution"].present?
@@ -38,13 +38,13 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e character has 6 ability scores" do
-    ability_scores = CoreRules::Entity.defaults_values("Pathfinder 2e", "character", "ability_scores") || []
+    ability_scores = CoreRules::Entity.defaults_values("pf2e", "character", "ability_scores") || []
     assert_equal %w[Strength Dexterity Constitution Intelligence Wisdom Charisma],
                  ability_scores.map { |a| a["name"] }
   end
 
   test "Pathfinder 2e character has HP, Hero Points, and Focus Points trackables" do
-    trackables = CoreRules::Entity.defaults_values("Pathfinder 2e", "character", "trackables") || []
+    trackables = CoreRules::Entity.defaults_values("pf2e", "character", "trackables") || []
     names = trackables.map { |t| t["name"] }
     assert_includes names, "Hit Points"
     assert_includes names, "Hero Points"
@@ -52,20 +52,20 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e character base_values includes Proficiency Bonus" do
-    base_values = CoreRules::Entity.defaults_values("Pathfinder 2e", "character", "base_values") || []
+    base_values = CoreRules::Entity.defaults_values("pf2e", "character", "base_values") || []
     names = base_values.map { |bv| bv["name"] }
     assert_includes names, "Proficiency Bonus"
     assert_includes names, "Level"
   end
 
   test "Pathfinder 2e character has Armor Class defense" do
-    defenses = CoreRules::Entity.defaults_values("Pathfinder 2e", "character", "defenses") || []
+    defenses = CoreRules::Entity.defaults_values("pf2e", "character", "defenses") || []
     assert_equal 1, defenses.size
     assert_equal "Armor Class", defenses.first["name"]
   end
 
   test "Pathfinder 2e character has Fortitude, Reflex, Will saving throws" do
-    saves = CoreRules::Entity.defaults_values("Pathfinder 2e", "character", "saving_throws") || []
+    saves = CoreRules::Entity.defaults_values("pf2e", "character", "saving_throws") || []
     names = saves.map { |s| s["name"] }
     assert_includes names, "Fortitude"
     assert_includes names, "Reflex"
@@ -74,12 +74,12 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e creature has 6 ability scores" do
-    abilities = CoreRules::Entity.defaults_values("Pathfinder 2e", "creature", "ability_scores")
+    abilities = CoreRules::Entity.defaults_values("pf2e", "creature", "ability_scores")
     assert_equal 6, abilities&.size
   end
 
   test "Pathfinder 2e creature has Hit Points only (no Hero/Focus)" do
-    trackables = CoreRules::Entity.defaults_values("Pathfinder 2e", "creature", "trackables") || []
+    trackables = CoreRules::Entity.defaults_values("pf2e", "creature", "trackables") || []
     names = trackables.map { |t| t["name"] }
     assert_includes names, "Hit Points"
     assert_not_includes names, "Hero Points"
@@ -87,7 +87,7 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e character has identity descriptors" do
-    descs = CoreRules::Entity.defaults_values("Pathfinder 2e", "character", "descriptors") || []
+    descs = CoreRules::Entity.defaults_values("pf2e", "character", "descriptors") || []
     names = descs.map { |d| d["name"] }
     %w[Ancestry Heritage Background Class Deity Alignment Languages].each do |n|
       assert_includes names, n, "expected descriptor: #{n}"
@@ -95,7 +95,7 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e menu links to valid sheet sections" do
-    menu = CoreRules::Entity.menu("Pathfinder 2e")
+    menu = CoreRules::Entity.menu("pf2e")
     valid_links = %w[
       descriptors ability_scores base_values movements trackables
       class_levels caster_levels skills attacks defenses saving_throws
@@ -110,7 +110,7 @@ class Pf2eSystemTest < ActiveSupport::TestCase
   end
 
   test "Pathfinder 2e is a d20 system with 1d20 default dice" do
-    rulebook = CoreRules.rulebooks.find { |r| r["name"] == "Pathfinder 2e" }
+    rulebook = CoreRules.rulebooks.find { |r| r["name"] == "Pathfinder 2E" }
     assert_equal "true", rulebook["d20_system"]
     assert_equal "1d20", rulebook["default_dice"]
   end

--- a/test/integration/rulebuilder_item_privacy_test.rb
+++ b/test/integration/rulebuilder_item_privacy_test.rb
@@ -131,7 +131,7 @@ class RulebuilderItemPrivacyTest < ActionDispatch::IntegrationTest
 
     def create_item(item_class, privacy:, name:, parent: nil)
       attributes = {
-        core_rules: "PFRPG",
+        core_rules: "pf1e",
         full_description: "#{name} full description",
         name: name,
         parent: parent,

--- a/test/lib/core_rules_license_test.rb
+++ b/test/lib/core_rules_license_test.rb
@@ -2,6 +2,6 @@ require "test_helper"
 
 class CoreRulesLicenseTest < ActiveSupport::TestCase
   test "4th Edition has no license metadata" do
-    assert_nil CoreRules.license("4th Edition")
+    assert_nil CoreRules.license("dnd4e")
   end
 end

--- a/test/lib/tasks/db_seed_test.rb
+++ b/test/lib/tasks/db_seed_test.rb
@@ -9,19 +9,19 @@ class DbSeedTest < ActiveSupport::TestCase
   test "db:seed invokes stock system seed aggregates" do
     User.where(email: "user@example.com").delete_all
     Admin.where(email: "user@example.com").delete_all
-    Rulebuilder::StockRule.where(core_rules: [ "5th Edition", "Draw Steel" ]).delete_all
-    Rulebuilder::StockSpell.where(core_rules: [ "5th Edition", "Draw Steel" ]).delete_all
-    Rulebuilder::StockItem.where(core_rules: "5th Edition").delete_all
-    Entitybuilder::StockCreature.where(core_rules: "5th Edition").delete_all
+    Rulebuilder::StockRule.where(core_rules: [ "dnd5e", "drawSteel" ]).delete_all
+    Rulebuilder::StockSpell.where(core_rules: [ "dnd5e", "drawSteel" ]).delete_all
+    Rulebuilder::StockItem.where(core_rules: "dnd5e").delete_all
+    Entitybuilder::StockCreature.where(core_rules: "dnd5e").delete_all
 
     Rake::Task["db:seed"].reenable
     Rake::Task["db:seed"].invoke
 
-    assert Rulebuilder::StockRule.exists?(core_rules: "5th Edition", rule_type: "Class", name: "Barbarian")
-    assert Rulebuilder::StockRule.exists?(core_rules: "Draw Steel", rule_type: "Ancestry", name: "Devil")
-    assert Rulebuilder::StockSpell.exists?(core_rules: "5th Edition", name: "Acid Splash")
-    assert Rulebuilder::StockSpell.exists?(core_rules: "Draw Steel", name: "Blessing of Secrets")
-    assert Rulebuilder::StockItem.exists?(core_rules: "5th Edition", name: "Club")
-    assert Entitybuilder::StockCreature.exists?(core_rules: "5th Edition", name: "Adult Black Dragon")
+    assert Rulebuilder::StockRule.exists?(core_rules: "dnd5e", rule_type: "Class", name: "Barbarian")
+    assert Rulebuilder::StockRule.exists?(core_rules: "drawSteel", rule_type: "Ancestry", name: "Devil")
+    assert Rulebuilder::StockSpell.exists?(core_rules: "dnd5e", name: "Acid Splash")
+    assert Rulebuilder::StockSpell.exists?(core_rules: "drawSteel", name: "Blessing of Secrets")
+    assert Rulebuilder::StockItem.exists?(core_rules: "dnd5e", name: "Club")
+    assert Entitybuilder::StockCreature.exists?(core_rules: "dnd5e", name: "Adult Black Dragon")
   end
 end

--- a/test/lib/tasks/draw_steel_seed_test.rb
+++ b/test/lib/tasks/draw_steel_seed_test.rb
@@ -7,12 +7,12 @@ class DrawSteelSeedTest < ActiveSupport::TestCase
   end
 
   test "ancestries seed task creates StockRules with attribution" do
-    Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Ancestry").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Ancestry").destroy_all
 
     Rake::Task["db:seed:draw_steel:ancestries"].reenable
     Rake::Task["db:seed:draw_steel:ancestries"].invoke
 
-    rules = Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Ancestry")
+    rules = Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Ancestry")
     assert rules.count >= 9, "expected at least 9 ancestry records, got #{rules.count}"
 
     rules.each do |r|
@@ -25,37 +25,37 @@ class DrawSteelSeedTest < ActiveSupport::TestCase
   end
 
   test "seed task is idempotent — running twice does not duplicate" do
-    Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Kit").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Kit").destroy_all
 
     Rake::Task["db:seed:draw_steel:kits"].reenable
     Rake::Task["db:seed:draw_steel:kits"].invoke
-    first_count = Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Kit").count
+    first_count = Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Kit").count
 
     Rake::Task["db:seed:draw_steel:kits"].reenable
     Rake::Task["db:seed:draw_steel:kits"].invoke
-    second_count = Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Kit").count
+    second_count = Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Kit").count
 
     assert_equal first_count, second_count, "seed should be idempotent"
   end
 
   test "classes seed task creates valid StockRules with long descriptions" do
-    Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Class").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Class").destroy_all
 
     Rake::Task["db:seed:draw_steel:classes"].reenable
     Rake::Task["db:seed:draw_steel:classes"].invoke
 
-    rules = Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Class")
+    rules = Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Class")
     assert_equal 9, rules.count
     assert rules.all?(&:valid?), "expected seeded class records to be valid"
   end
 
   test "abilities seed task creates StockSpells with attribution" do
-    Rulebuilder::StockSpell.where(core_rules: "Draw Steel").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "drawSteel").destroy_all
 
     Rake::Task["db:seed:draw_steel:abilities"].reenable
     Rake::Task["db:seed:draw_steel:abilities"].invoke
 
-    spells = Rulebuilder::StockSpell.where(core_rules: "Draw Steel")
+    spells = Rulebuilder::StockSpell.where(core_rules: "drawSteel")
     assert spells.count >= 50, "expected many ability records, got #{spells.count}"
 
     sample = spells.first
@@ -64,14 +64,14 @@ class DrawSteelSeedTest < ActiveSupport::TestCase
   end
 
   test "abilities seed task keeps same-name abilities from different schools" do
-    Rulebuilder::StockSpell.where(core_rules: "Draw Steel").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "drawSteel").destroy_all
 
     Rake::Task["db:seed:draw_steel:abilities"].reenable
     Rake::Task["db:seed:draw_steel:abilities"].invoke
 
     records = JSON.parse(File.read(Rails.root.join("db", "seeds", "draw-steel", "abilities.json")))
     expected_count = records.uniq.size
-    spells = Rulebuilder::StockSpell.where(core_rules: "Draw Steel")
+    spells = Rulebuilder::StockSpell.where(core_rules: "drawSteel")
 
     assert_equal expected_count, spells.count
     assert spells.exists?(name: "Blessing of Secrets", school: "Censor")
@@ -79,8 +79,8 @@ class DrawSteelSeedTest < ActiveSupport::TestCase
   end
 
   test "seed tasks store rendered HTML descriptions" do
-    Rulebuilder::StockRule.where(core_rules: "Draw Steel", rule_type: "Ancestry").destroy_all
-    Rulebuilder::StockSpell.where(core_rules: "Draw Steel").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "drawSteel", rule_type: "Ancestry").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "drawSteel").destroy_all
 
     Rake::Task["db:seed:draw_steel:ancestries"].reenable
     Rake::Task["db:seed:draw_steel:ancestries"].invoke
@@ -88,8 +88,8 @@ class DrawSteelSeedTest < ActiveSupport::TestCase
     Rake::Task["db:seed:draw_steel:abilities"].reenable
     Rake::Task["db:seed:draw_steel:abilities"].invoke
 
-    rule = Rulebuilder::StockRule.find_by!(core_rules: "Draw Steel", rule_type: "Ancestry")
-    spell = Rulebuilder::StockSpell.find_by!(core_rules: "Draw Steel")
+    rule = Rulebuilder::StockRule.find_by!(core_rules: "drawSteel", rule_type: "Ancestry")
+    spell = Rulebuilder::StockSpell.find_by!(core_rules: "drawSteel")
 
     assert_match(/<h\d/, rule.full_description)
     assert_match(/<h\d/, spell.full_description)

--- a/test/lib/tasks/fifth_edition_seed_test.rb
+++ b/test/lib/tasks/fifth_edition_seed_test.rb
@@ -7,11 +7,11 @@ class FifthEditionSeedTest < ActiveSupport::TestCase
   end
 
   test "classes seed task creates valid StockRules with normalized source fields" do
-    Rulebuilder::StockRule.where(core_rules: "5th Edition", rule_type: "Class").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "dnd5e", rule_type: "Class").destroy_all
 
     run_task("db:seed:5e:classes")
 
-    rules = Rulebuilder::StockRule.where(core_rules: "5th Edition", rule_type: "Class")
+    rules = Rulebuilder::StockRule.where(core_rules: "dnd5e", rule_type: "Class")
     assert_equal 12, rules.count
     assert rules.all?(&:valid?), "expected seeded class records to be valid"
 
@@ -22,36 +22,36 @@ class FifthEditionSeedTest < ActiveSupport::TestCase
   end
 
   test "spells seed task is idempotent" do
-    Rulebuilder::StockSpell.where(core_rules: "5th Edition").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "dnd5e").destroy_all
 
     run_task("db:seed:5e:spells")
-    first_count = Rulebuilder::StockSpell.where(core_rules: "5th Edition").count
+    first_count = Rulebuilder::StockSpell.where(core_rules: "dnd5e").count
 
     run_task("db:seed:5e:spells")
-    second_count = Rulebuilder::StockSpell.where(core_rules: "5th Edition").count
+    second_count = Rulebuilder::StockSpell.where(core_rules: "dnd5e").count
 
     assert_equal first_count, second_count
   end
 
   test "seed tasks store rendered HTML descriptions" do
-    Rulebuilder::StockRule.where(core_rules: "5th Edition", rule_type: "Species").destroy_all
-    Rulebuilder::StockRule.where(core_rules: "5th Edition", rule_type: "Backgrounds").destroy_all
-    Rulebuilder::StockSpell.where(core_rules: "5th Edition").destroy_all
-    Rulebuilder::StockItem.where(core_rules: "5th Edition").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "dnd5e", rule_type: "Species").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "dnd5e", rule_type: "Backgrounds").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "dnd5e").destroy_all
+    Rulebuilder::StockItem.where(core_rules: "dnd5e").destroy_all
 
     run_task("db:seed:5e:species")
     run_task("db:seed:5e:backgrounds")
     run_task("db:seed:5e:spells")
     run_task("db:seed:5e:items")
 
-    species = Rulebuilder::StockRule.find_by!(core_rules: "5th Edition", rule_type: "Species", name: "Elf")
+    species = Rulebuilder::StockRule.find_by!(core_rules: "dnd5e", rule_type: "Species", name: "Elf")
     background = Rulebuilder::StockRule.find_by!(
-      core_rules: "5th Edition",
+      core_rules: "dnd5e",
       rule_type: "Backgrounds",
       name: "Acolyte"
     )
-    spell = Rulebuilder::StockSpell.find_by!(core_rules: "5th Edition", name: "Acid Splash")
-    item = Rulebuilder::StockItem.find_by!(core_rules: "5th Edition", name: "Club")
+    spell = Rulebuilder::StockSpell.find_by!(core_rules: "dnd5e", name: "Acid Splash")
+    item = Rulebuilder::StockItem.find_by!(core_rules: "dnd5e", name: "Club")
 
     [ species, background, spell, item ].each do |record|
       assert_match(/<h\d/, record.full_description)
@@ -62,13 +62,13 @@ class FifthEditionSeedTest < ActiveSupport::TestCase
   end
 
   test "creature and animal seed tasks create valid StockCreatures and stay idempotent" do
-    Entitybuilder::StockCreature.where(core_rules: "5th Edition").destroy_all
+    Entitybuilder::StockCreature.where(core_rules: "dnd5e").destroy_all
 
     run_task("db:seed:5e:creatures")
     run_task("db:seed:5e:animals")
 
-    monster = Entitybuilder::StockCreature.find_by!(core_rules: "5th Edition", name: "Adult Black Dragon")
-    animal = Entitybuilder::StockCreature.find_by!(core_rules: "5th Edition", name: "Ape")
+    monster = Entitybuilder::StockCreature.find_by!(core_rules: "dnd5e", name: "Adult Black Dragon")
+    animal = Entitybuilder::StockCreature.find_by!(core_rules: "dnd5e", name: "Ape")
 
     [ monster, animal ].each do |creature|
       assert_seeded_creature_basics(creature)
@@ -85,40 +85,40 @@ class FifthEditionSeedTest < ActiveSupport::TestCase
     run_task("db:seed:5e:animals")
 
     second_snapshot = snapshot_creature(
-      Entitybuilder::StockCreature.find_by!(core_rules: "5th Edition", name: "Adult Black Dragon")
+      Entitybuilder::StockCreature.find_by!(core_rules: "dnd5e", name: "Adult Black Dragon")
     )
 
     assert_equal first_snapshot, second_snapshot
   end
 
   test "creature seed task normalizes ranged attacks to the app range bucket" do
-    Entitybuilder::StockCreature.where(core_rules: "5th Edition").destroy_all
+    Entitybuilder::StockCreature.where(core_rules: "dnd5e").destroy_all
 
     run_task("db:seed:5e:creatures")
 
-    assassin = Entitybuilder::StockCreature.find_by!(core_rules: "5th Edition", name: "Assassin")
+    assassin = Entitybuilder::StockCreature.find_by!(core_rules: "dnd5e", name: "Assassin")
 
     assert assassin.attacks.exists?(attack_type: "Range")
     assert_not assassin.attacks.exists?(attack_type: "Ranged")
   end
 
   test "creature descriptions stop at the current stat block" do
-    Entitybuilder::StockCreature.where(core_rules: "5th Edition").destroy_all
+    Entitybuilder::StockCreature.where(core_rules: "dnd5e").destroy_all
 
     run_task("db:seed:5e:creatures")
 
-    aboleth = Entitybuilder::StockCreature.find_by!(core_rules: "5th Edition", name: "Aboleth")
-    air_elemental = Entitybuilder::StockCreature.find_by!(core_rules: "5th Edition", name: "Air Elemental")
+    aboleth = Entitybuilder::StockCreature.find_by!(core_rules: "dnd5e", name: "Aboleth")
+    air_elemental = Entitybuilder::StockCreature.find_by!(core_rules: "dnd5e", name: "Air Elemental")
 
     assert_no_match(/Air Elemental/, aboleth.full_description)
     assert_no_match(/Animated Objects/, air_elemental.full_description)
   end
 
   test "all seed categories provide spot-check records" do
-    Rulebuilder::StockRule.where(core_rules: "5th Edition").destroy_all
-    Rulebuilder::StockSpell.where(core_rules: "5th Edition").destroy_all
-    Rulebuilder::StockItem.where(core_rules: "5th Edition").destroy_all
-    Entitybuilder::StockCreature.where(core_rules: "5th Edition").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "dnd5e").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "dnd5e").destroy_all
+    Rulebuilder::StockItem.where(core_rules: "dnd5e").destroy_all
+    Entitybuilder::StockCreature.where(core_rules: "dnd5e").destroy_all
 
     %w[
       db:seed:5e:classes
@@ -132,15 +132,15 @@ class FifthEditionSeedTest < ActiveSupport::TestCase
       db:seed:5e:animals
     ].each { |task_name| run_task(task_name) }
 
-    assert Rulebuilder::StockRule.exists?(core_rules: "5th Edition", rule_type: "Class", name: "Barbarian")
-    assert Rulebuilder::StockRule.exists?(core_rules: "5th Edition", rule_type: "Backgrounds", name: "Acolyte")
-    assert Rulebuilder::StockRule.exists?(core_rules: "5th Edition", rule_type: "Species", name: "Elf")
-    assert Rulebuilder::StockRule.exists?(core_rules: "5th Edition", rule_type: "Feat", name: "Alert")
-    assert Rulebuilder::StockRule.exists?(core_rules: "5th Edition", rule_type: "Condition", name: "Blinded")
-    assert Rulebuilder::StockSpell.exists?(core_rules: "5th Edition", name: "Acid Splash")
-    assert Rulebuilder::StockItem.exists?(core_rules: "5th Edition", name: "Club")
-    assert Entitybuilder::StockCreature.exists?(core_rules: "5th Edition", name: "Adult Black Dragon")
-    assert Entitybuilder::StockCreature.exists?(core_rules: "5th Edition", name: "Ape")
+    assert Rulebuilder::StockRule.exists?(core_rules: "dnd5e", rule_type: "Class", name: "Barbarian")
+    assert Rulebuilder::StockRule.exists?(core_rules: "dnd5e", rule_type: "Backgrounds", name: "Acolyte")
+    assert Rulebuilder::StockRule.exists?(core_rules: "dnd5e", rule_type: "Species", name: "Elf")
+    assert Rulebuilder::StockRule.exists?(core_rules: "dnd5e", rule_type: "Feat", name: "Alert")
+    assert Rulebuilder::StockRule.exists?(core_rules: "dnd5e", rule_type: "Condition", name: "Blinded")
+    assert Rulebuilder::StockSpell.exists?(core_rules: "dnd5e", name: "Acid Splash")
+    assert Rulebuilder::StockItem.exists?(core_rules: "dnd5e", name: "Club")
+    assert Entitybuilder::StockCreature.exists?(core_rules: "dnd5e", name: "Adult Black Dragon")
+    assert Entitybuilder::StockCreature.exists?(core_rules: "dnd5e", name: "Ape")
   end
 
   test "5e seed namespace exposes aggregate task under db:seed" do

--- a/test/lib/tasks/pf2e_seed_test.rb
+++ b/test/lib/tasks/pf2e_seed_test.rb
@@ -7,12 +7,12 @@ class Pf2eSeedTest < ActiveSupport::TestCase
   end
 
   test "ancestries seed task creates StockRules with ORC attribution" do
-    Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Ancestry").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Ancestry").destroy_all
 
     Rake::Task["db:seed:pf2e:ancestries"].reenable
     Rake::Task["db:seed:pf2e:ancestries"].invoke
 
-    rules = Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Ancestry")
+    rules = Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Ancestry")
     assert rules.count >= 10, "expected at least 10 ancestry records, got #{rules.count}"
 
     rules.each do |r|
@@ -23,72 +23,72 @@ class Pf2eSeedTest < ActiveSupport::TestCase
   end
 
   test "seed task is idempotent — running twice does not duplicate" do
-    Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Condition").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Condition").destroy_all
 
     Rake::Task["db:seed:pf2e:conditions"].reenable
     Rake::Task["db:seed:pf2e:conditions"].invoke
-    first_count = Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Condition").count
+    first_count = Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Condition").count
 
     Rake::Task["db:seed:pf2e:conditions"].reenable
     Rake::Task["db:seed:pf2e:conditions"].invoke
-    second_count = Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Condition").count
+    second_count = Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Condition").count
 
     assert_equal first_count, second_count, "seed should be idempotent"
   end
 
   test "spells seed preserves same-name spells across traditions (schools)" do
     # Fireball is in Arcane (and Primal); Heal appears in Divine and Primal
-    Rulebuilder::StockSpell.where(core_rules: "Pathfinder 2e").destroy_all
+    Rulebuilder::StockSpell.where(core_rules: "pf2e").destroy_all
 
     Rake::Task["db:seed:pf2e:spells"].reenable
     Rake::Task["db:seed:pf2e:spells"].invoke
 
-    assert Rulebuilder::StockSpell.exists?(core_rules: "Pathfinder 2e", name: "Fireball", school: "Arcane"),
+    assert Rulebuilder::StockSpell.exists?(core_rules: "pf2e", name: "Fireball", school: "Arcane"),
            "expected Fireball in Arcane tradition"
 
     # Heal should appear in multiple traditions (Divine and Primal at minimum)
-    heal_records = Rulebuilder::StockSpell.where(core_rules: "Pathfinder 2e", name: "Heal")
+    heal_records = Rulebuilder::StockSpell.where(core_rules: "pf2e", name: "Heal")
     assert heal_records.count >= 2, "expected Heal in at least 2 traditions, got #{heal_records.map(&:school).inspect}"
   end
 
   test "seed tasks store rendered HTML descriptions (no raw markdown)" do
-    Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Ancestry").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Ancestry").destroy_all
 
     Rake::Task["db:seed:pf2e:ancestries"].reenable
     Rake::Task["db:seed:pf2e:ancestries"].invoke
 
-    rule = Rulebuilder::StockRule.find_by!(core_rules: "Pathfinder 2e", rule_type: "Ancestry")
+    rule = Rulebuilder::StockRule.find_by!(core_rules: "pf2e", rule_type: "Ancestry")
     assert_no_match(/^##\s/, rule.full_description)
   end
 
   test "conditions seed task creates exactly 43 condition records" do
-    Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Condition").destroy_all
+    Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Condition").destroy_all
 
     Rake::Task["db:seed:pf2e:conditions"].reenable
     Rake::Task["db:seed:pf2e:conditions"].invoke
 
-    count = Rulebuilder::StockRule.where(core_rules: "Pathfinder 2e", rule_type: "Condition").count
+    count = Rulebuilder::StockRule.where(core_rules: "pf2e", rule_type: "Condition").count
     assert_equal 43, count
   end
 
   test "creatures seed normalises Ranged attack_type to Range" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").destroy_all
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").destroy_all
 
     Rake::Task["db:seed:pf2e:creatures"].reenable
     Rake::Task["db:seed:pf2e:creatures"].invoke
 
-    creature = Entitybuilder::StockCreature.find_by!(name: "Aapoph Granitescale", core_rules: "Pathfinder 2e")
+    creature = Entitybuilder::StockCreature.find_by!(name: "Aapoph Granitescale", core_rules: "pf2e")
     assert creature.attacks.exists?(attack_type: "Range"), "expected ranged attack stored as 'Range'"
     assert_not creature.attacks.exists?(attack_type: "Ranged"), "expected no attacks stored as 'Ranged'"
   end
 
   test "creatures seed assigns sort_order to child records" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").destroy_all
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").destroy_all
 
     Rake::Task["db:seed:pf2e:creatures"].reenable
     Rake::Task["db:seed:pf2e:creatures"].invoke
 
-    creature = Entitybuilder::StockCreature.find_by!(name: "Aapoph Granitescale", core_rules: "Pathfinder 2e")
+    creature = Entitybuilder::StockCreature.find_by!(name: "Aapoph Granitescale", core_rules: "pf2e")
     assert creature.attacks.exists?(sort_order: 0), "expected first attack to have sort_order 0"
     assert creature.ability_scores.exists?(sort_order: 0), "expected first ability score to have sort_order 0"
   end

--- a/test/migrations/convert_proprietary_records_to_stock_test.rb
+++ b/test/migrations/convert_proprietary_records_to_stock_test.rb
@@ -24,7 +24,7 @@ class ConvertProprietaryRecordsToStockTest < ActiveSupport::TestCase
         "entitybuilder_entities",
         type: type,
         name: "Legacy creature",
-        core_rules: "PFRPG",
+        core_rules: "pf1e",
         privacy: "Residents",
         sheet_privacy: "Residents",
         created_at: Time.current,
@@ -36,7 +36,7 @@ class ConvertProprietaryRecordsToStockTest < ActiveSupport::TestCase
       insert_row(
         "rulebuilder_rules",
         type: type,
-        core_rules: "PFRPG",
+        core_rules: "pf1e",
         rule_type: "Feat",
         name: "Legacy rule",
         created_at: Time.current,

--- a/test/models/dice_test.rb
+++ b/test/models/dice_test.rb
@@ -10,9 +10,9 @@ class DiceTest < ActiveSupport::TestCase
   test "uses rulebook default dice for Draw Steel rolls" do
     roller = Roller.new
 
-    dice = roller.game_dice("Draw Steel")
+    dice = roller.game_dice("drawSteel")
 
     assert_equal "2d10", dice
-    assert_equal "3", roller.display_dice_or_modifier("Draw Steel", 3, dice)
+    assert_equal "3", roller.display_dice_or_modifier("drawSteel", 3, dice)
   end
 end

--- a/test/models/entitybuilder/pf2e_stock_creature_test.rb
+++ b/test/models/entitybuilder/pf2e_stock_creature_test.rb
@@ -10,12 +10,12 @@ class Pf2eStockCreatureTest < ActiveSupport::TestCase
   end
 
   test "sample creatures are seeded (10 creatures)" do
-    count = Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").count
+    count = Entitybuilder::StockCreature.where(core_rules: "pf2e").count
     assert_equal 10, count
   end
 
   test "each creature has exactly 6 ability scores" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").each do |c|
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").each do |c|
       assert_equal 6, c.ability_scores.count, "#{c.name} should have 6 ability scores"
       names = c.ability_scores.map(&:name)
       %w[Strength Dexterity Constitution Intelligence Wisdom Charisma].each do |n|
@@ -25,19 +25,19 @@ class Pf2eStockCreatureTest < ActiveSupport::TestCase
   end
 
   test "each creature has Hit Points trackable" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").each do |c|
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").each do |c|
       assert c.trackables.exists?(name: "Hit Points"), "#{c.name} missing Hit Points"
     end
   end
 
   test "each creature has Armor Class defense" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").each do |c|
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").each do |c|
       assert c.defenses.exists?(name: "Armor Class"), "#{c.name} missing Armor Class"
     end
   end
 
   test "each creature has Fort, Reflex, Will saving throws" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").each do |c|
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").each do |c|
       save_names = c.saving_throws.map(&:name)
       assert_includes save_names, "Fortitude", "#{c.name} missing Fortitude"
       assert_includes save_names, "Reflex",    "#{c.name} missing Reflex"
@@ -46,7 +46,7 @@ class Pf2eStockCreatureTest < ActiveSupport::TestCase
   end
 
   test "each creature has Level and Proficiency Bonus base values" do
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e").each do |c|
+    Entitybuilder::StockCreature.where(core_rules: "pf2e").each do |c|
       bv_names = c.base_values.map(&:name)
       assert_includes bv_names, "Level",             "#{c.name} missing Level"
       assert_includes bv_names, "Proficiency Bonus", "#{c.name} missing Proficiency Bonus"
@@ -91,7 +91,7 @@ class Pf2eStockCreatureTest < ActiveSupport::TestCase
   end
 
   def pf2e_creatures
-    Entitybuilder::StockCreature.where(core_rules: "Pathfinder 2e")
+    Entitybuilder::StockCreature.where(core_rules: "pf2e")
   end
 
   def sample_records

--- a/test/models/entitybuilder/skill_grouping_test.rb
+++ b/test/models/entitybuilder/skill_grouping_test.rb
@@ -42,6 +42,7 @@ module Entitybuilder
       original = CoreRules.rulebooks
       CoreRules.rulebooks = original + [ {
         "name" => "TestGroupingSystem",
+        "slug" => "testGroupingSystem",
         "active" => "true",
         "entitybuilder" => {
           "core_skills" => [
@@ -56,7 +57,7 @@ module Entitybuilder
 
       entity = entitybuilder_entities(:resident_character_one)
       entity.skills.destroy_all
-      entity.update!(core_rules: "TestGroupingSystem")
+      entity.update!(core_rules: "testGroupingSystem")
       CoreRules::Entity.add_core_skills(entity)
 
       grouped   = entity.skills.find_by(name: "Test Crafting Skill")

--- a/test/models/rulebuilder/item_test.rb
+++ b/test/models/rulebuilder/item_test.rb
@@ -36,7 +36,7 @@ module Rulebuilder
     end
 
     test "invalid privacy adds symbolic error" do
-      item = Rulebuilder::ResidentItem.new(name: "ResidentItemTest", core_rules: "PFRPG", privacy: "Invalid")
+      item = Rulebuilder::ResidentItem.new(name: "ResidentItemTest", core_rules: "pf1e", privacy: "Invalid")
       item.valid?
       assert_equal :invalid_privacy, item.errors.details[:privacy].first[:error]
       assert_equal "is not valid.", item.errors[:privacy].first

--- a/test/models/rulebuilder/rule_test.rb
+++ b/test/models/rulebuilder/rule_test.rb
@@ -24,7 +24,7 @@ module Rulebuilder
     test "allows long full descriptions" do
       rule = StockRule.new(
         name: "Long Rule",
-        core_rules: "PFRPG",
+        core_rules: "pf1e",
         rule_type: "Ability",
         full_description: "x" * 100_000
       )

--- a/test/models/rulebuilder/spell_test.rb
+++ b/test/models/rulebuilder/spell_test.rb
@@ -18,7 +18,7 @@ module Rulebuilder
     test "allows long full descriptions" do
       spell = StockSpell.new(
         name: "Long Spell",
-        core_rules: "PFRPG",
+        core_rules: "pf1e",
         full_description: "x" * 100_000
       )
 

--- a/test/views/license_link_test.rb
+++ b/test/views/license_link_test.rb
@@ -2,26 +2,26 @@ require "test_helper"
 
 class LicenseLinkTest < ActionView::TestCase
   test "does not render a modal link when no FAQ lookup key exists" do
-    render partial: "layouts/license/link", locals: { core_rules: "Draw Steel" }
+    render partial: "layouts/license/link", locals: { core_rules: "drawSteel" }
 
     assert_no_match(/scrolls\/license/, rendered)
   end
 
   test "does not render attribution when system only has a FAQ lookup key" do
-    render partial: "layouts/license/attribution", locals: { core_rules: "PFRPG" }
+    render partial: "layouts/license/attribution", locals: { core_rules: "pf1e" }
 
     assert_no_match(/rpg-system-attribution/, rendered)
     assert_no_match(/License d20 OGL/, rendered)
   end
 
   test "does not render a modal link for 4th Edition" do
-    render partial: "layouts/license/link", locals: { core_rules: "4th Edition" }
+    render partial: "layouts/license/link", locals: { core_rules: "dnd4e" }
 
     assert_no_match(/scrolls\/license/, rendered)
   end
 
   test "does not render attribution for 4th Edition" do
-    render partial: "layouts/license/attribution", locals: { core_rules: "4th Edition" }
+    render partial: "layouts/license/attribution", locals: { core_rules: "dnd4e" }
 
     assert_no_match(/rpg-system-attribution/, rendered)
     assert_no_match(/Game System License/, rendered)


### PR DESCRIPTION
## Summary

- Introduces `CoreRules::Rulebook` value object (slug + display name) and updates `CoreRules` module to look up rulesets by slug instead of display name
- Renames PFRPG → **Pathfinder 1E** and Pathfinder 2e → **Pathfinder 2E**; adds a stable URL-safe slug to every ruleset config (`pf1e`, `pf2e`, `dnd5e`, `dnd4e`, `dnd35e`, `drawSteel`, `fateCore`, `woin`, etc.)
- All 8 DB tables migrated via reversible data migration; forms submit slugs as values and display names as labels; 1,181+ seed files updated; 959 tests pass

## What changed

**Architecture:**
- `config/core_rules/*.json` — new top-level `"slug"` field on all 11 rulesets
- `lib/core_rules/rulebook.rb` — new `CoreRules::Rulebook` Struct with `slug`, `name`, and predicate helpers
- `lib/core_rules.rb` — new `all()`, `find(slug)`, `display_name(slug)` API; all lookups by slug; dead `options()` removed
- `lib/core_rules/entity.rb`, `rule.rb` — slug-based lookups throughout

**Data:**
- `db/migrate/20260616053635_convert_core_rules_display_names_to_slugs.rb` — reversible migration, updates all 8 `core_rules` tables
- `db/seeds/5th-edition/` (1,181 files), `db/seeds/pf2e/` (13 files), `db/seeds/draw-steel/` (7 files) — `core_rules` values → slugs

**Views & forms:**
- All form selects use `CoreRules.all(admin_signed_in?)` with `label_method: :name, value_method: :slug`
- All display sites use `CoreRules.display_name(slug)` with `|| slug` fallback in report partials

## Test plan

- [ ] Run `bin/rails db:migrate` on a fresh DB — all 88 UPDATE statements execute cleanly
- [ ] Run `bin/rails test` — 959 runs, 0 failures
- [ ] Check ruleset dropdown shows "Pathfinder 1E" (not "pf1e") and "5th Edition" (not "dnd5e")
- [ ] Verify URLs use slugs: `?core_rules=dnd5e` (no spaces)
- [ ] Verify rollback: `bin/rails db:rollback` restores display names

🤖 Generated with [Claude Code](https://claude.com/claude-code)