### PR TITLE
Add i18n infrastructure: Dutch/Italian translations, locale switcher, CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,19 @@ jobs:
           BROWSER_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
           RAILS_ENV: test
         run: bin/rails test:system
+
+  i18n_check:
+    name: Check i18n
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: spinel-coop/setup-rv@main
+        with:
+          ruby-version: current
+          install-gems: true
+
+      - run: bin/i18n-tasks health

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "redcarpet"
 gem "redis"
 gem "sidekiq"
 gem "simple_form"
+gem "rails-i18n"
+gem "devise-i18n"
 gem "stripe"
 # gem 'sinatra' # used for sidekiq ui
 gem "bundle-audit"
@@ -69,6 +71,10 @@ gem "rulebuilder", path: "engines/rulebuilder"
 gem "storybuilder", path: "engines/storybuilder"
 gem "support", path: "engines/support"
 gem "worldbuilder", path: "engines/worldbuilder"
+
+group :development do
+  gem "i18n-tasks"
+end
 
 group :development, :test do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.15.0)
+      devise (>= 4.9.0)
+      rails-i18n
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -217,8 +220,22 @@ GEM
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
+    highline (3.1.2)
+      reline
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.1.2)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 3.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      prism
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     io-console (0.8.2)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
@@ -370,6 +387,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.7.10)
       actionpack (= 6.1.7.10)
       activesupport (= 6.1.7.10)
@@ -470,6 +490,8 @@ GEM
     stringio (3.2.0)
     stripe (18.4.0)
     symbol-fstring (1.0.2)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     terser (1.2.6)
@@ -525,6 +547,7 @@ DEPENDENCIES
   capybara
   cuprite
   devise
+  devise-i18n
   dotenv-rails
   drb
   ed25519 (~> 1.4)
@@ -535,6 +558,7 @@ DEPENDENCIES
   foundation-rails (= 5.5.3.2)
   gallery!
   get_process_mem
+  i18n-tasks
   jbuilder
   jquery-rails
   json (>= 2.0)
@@ -551,6 +575,7 @@ DEPENDENCIES
   puma
   rails (~> 6.1)
   rails-controller-testing
+  rails-i18n
   redcarpet
   redis
   reline

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery prepend: true, with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_locale
   after_action :clear_ajax_flash
 
   helper Activeplay::Engine.helpers
@@ -36,8 +37,13 @@ class ApplicationController < ActionController::Base
   end
 
   protected
+    def set_locale
+      I18n.locale = current_user&.locale || I18n.default_locale
+    end
+
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:check_field, :terms_of_service])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:locale])
     end
 
     def check_quota

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
   after_validation :set_status, on: :create
 
   validates :status, presence: true
+  validates :locale, presence: true, inclusion: { in: %w[en nl it] }
 
   def honeypot_absence
     errors.add :check_field, "You should not fill in the invisible field" unless check_field.blank?

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -6,6 +6,9 @@
         <%= f.input :password, placeholder: "leave blank if you don't want to change it" %>
         <%= f.input :password_confirmation, placeholder: "confirm your new password" %>
         <%= f.input :current_password, required: true %>
+        <%= f.input :locale,
+            collection: [['English', 'en'], ['Nederlands', 'nl'], ['Italiano', 'it']],
+            include_blank: false %>
       </fieldset>
 
       <%= render "layouts/form/save" %>

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -7,7 +7,7 @@
         <%= f.input :password_confirmation, placeholder: "confirm your new password" %>
         <%= f.input :current_password, required: true %>
         <%= f.input :locale,
-            collection: [['English', 'en'], ['Nederlands', 'nl'], ['Italiano', 'it']],
+            collection: [[t("locales.en"), "en"], [t("locales.nl"), "nl"], [t("locales.it"), "it"]],
             include_blank: false %>
       </fieldset>
 

--- a/bin/i18n-tasks
+++ b/bin/i18n-tasks
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require "bundler/setup"
+require "logger" # Required explicitly for Ruby 3.3+ (moved from stdlib to bundled gem)
+load Gem.bin_path("i18n-tasks", "i18n-tasks")

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,9 @@ module Brasscore
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-    config.i18n.enforce_available_locales = false
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = %i[en nl it]
+    config.i18n.enforce_available_locales = true
 
     # config.action_dispatch.default_headers = {
     #  'Access-Control-Allow-Origin' => '*',

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,60 @@
+base_locale: en
+locales: [en, nl, it]
+
+search:
+  paths:
+    - app/
+    - engines/
+  only:
+    - "*.rb"
+    - "*.erb"
+    - "*.haml"
+  relative_roots:
+    - app/controllers
+    - app/helpers
+    - app/mailers
+    - app/presenters
+    - app/views
+    - engines/activeplay/app/controllers
+    - engines/activeplay/app/helpers
+    - engines/activeplay/app/views
+    - engines/billing/app/controllers
+    - engines/billing/app/helpers
+    - engines/billing/app/views
+    - engines/campaignmanager/app/controllers
+    - engines/campaignmanager/app/helpers
+    - engines/campaignmanager/app/views
+    - engines/entitybuilder/app/controllers
+    - engines/entitybuilder/app/helpers
+    - engines/entitybuilder/app/views
+    - engines/gallery/app/controllers
+    - engines/gallery/app/helpers
+    - engines/gallery/app/views
+    - engines/report/app/controllers
+    - engines/report/app/helpers
+    - engines/report/app/views
+    - engines/rulebuilder/app/controllers
+    - engines/rulebuilder/app/helpers
+    - engines/rulebuilder/app/views
+    - engines/storybuilder/app/controllers
+    - engines/storybuilder/app/helpers
+    - engines/storybuilder/app/views
+    - engines/support/app/controllers
+    - engines/support/app/helpers
+    - engines/support/app/views
+    - engines/worldbuilder/app/controllers
+    - engines/worldbuilder/app/helpers
+    - engines/worldbuilder/app/views
+
+ignore_missing:
+  # Suppress rails-i18n / devise-i18n keys loaded by gems (not in local yml files)
+  - '{devise,date,time,number,errors,activerecord,helpers,support}.*'
+  # Kaminari pagination keys are provided by the kaminari gem's own locale files
+  - 'views.pagination.*'
+
+ignore_unused:
+  - '{devise,date,time,number,errors,activerecord,helpers,support}.*'
+  # Kaminari pagination keys are provided by the kaminari gem's own locale files
+  - 'views.pagination.*'
+  # Placeholder key from the default Rails locale template
+  - 'hello'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,17 +1,19 @@
 ---
 en:
   campaignmanager:
-    navigation:
-      active_adventure: "Active Adventure"
     campaigns:
       features:
-        adventures: "Adventures"
+        adventures: Adventures
       form:
-        adventures_label: "Adventures in this campaign"
-        adventures_hint: "Check the adventures that are part of this campaign. They appear on the campaign overview."
-        active_adventure_label: "Active adventure"
-        active_adventure_hint: "The adventure currently being run. It is highlighted on the overview and linked in the campaign menu."
-        no_active_adventure: "None"
+        active_adventure_hint: The adventure currently being run. It is highlighted
+          on the overview and linked in the campaign menu.
+        active_adventure_label: Active adventure
+        adventures_hint: Check the adventures that are part of this campaign. They
+          appear on the campaign overview.
+        adventures_label: Adventures in this campaign
+        no_active_adventure: None
+    navigation:
+      active_adventure: Active Adventure
   errors:
     messages:
       invalid_privacy: is not valid.
@@ -45,3 +47,7 @@ en:
     topbar:
       manage_stock:
         title: Manage Stock
+  locales:
+    en: English
+    it: Italian
+    nl: Dutch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,58 +1,5 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
-  errors:
-    messages:
-      invalid_privacy: "is not valid."
-  layouts:
-    license:
-      attribution:
-        aria_label: "RPG system attribution"
-    navigation:
-      manage_stock:
-        game_master: "Game Master"
-        rule_builder: "Rule Builder"
-        creatures: "Creatures"
-        npcs: "NPCs"
-        rules: "Rules"
-        spells: "Spells"
-        items: "Items"
-        images: "Images"
-    topbar:
-      manage_stock:
-        title: "Manage Stock"
-    offcanvas:
-      manage_stock:
-        title: "Manage Stock"
-        back: "Back"
-  gallery:
-    images:
-      image_modal:
-        title: "Images"
-        my_images: "My Images"
-        stock_images: "Stock Images"
-        stock_images_admin: "Stock Images (Admin)"
-        map_images: "Map Images"
   campaignmanager:
     navigation:
       active_adventure: "Active Adventure"
@@ -65,3 +12,36 @@ en:
         active_adventure_label: "Active adventure"
         active_adventure_hint: "The adventure currently being run. It is highlighted on the overview and linked in the campaign menu."
         no_active_adventure: "None"
+  errors:
+    messages:
+      invalid_privacy: is not valid.
+  gallery:
+    images:
+      image_modal:
+        map_images: Map Images
+        my_images: My Images
+        stock_images: Stock Images
+        stock_images_admin: Stock Images (Admin)
+        title: Images
+  hello: Hello world
+  layouts:
+    license:
+      attribution:
+        aria_label: RPG system attribution
+    navigation:
+      manage_stock:
+        creatures: Creatures
+        game_master: Game Master
+        images: Images
+        items: Items
+        npcs: NPCs
+        rule_builder: Rule Builder
+        rules: Rules
+        spells: Spells
+    offcanvas:
+      manage_stock:
+        back: Back
+        title: Manage Stock
+    topbar:
+      manage_stock:
+        title: Manage Stock

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   campaignmanager:
     navigation:
@@ -11,3 +12,36 @@ it:
         active_adventure_label: "Avventura attiva"
         active_adventure_hint: "L'avventura attualmente in corso. Viene evidenziata nella panoramica e collegata nel menu della campagna."
         no_active_adventure: "Nessuna"
+  errors:
+    messages:
+      invalid_privacy: non è valido.
+  gallery:
+    images:
+      image_modal:
+        map_images: Immagini Mappa
+        my_images: Le Mie Immagini
+        stock_images: Immagini Stock
+        stock_images_admin: Immagini Stock (Admin)
+        title: Immagini
+  hello: Ciao mondo
+  layouts:
+    license:
+      attribution:
+        aria_label: Attribuzione sistema RPG
+    navigation:
+      manage_stock:
+        creatures: Creature
+        game_master: Game Master
+        images: Immagini
+        items: Oggetti
+        npcs: PNG
+        rule_builder: Costruttore di Regole
+        rules: Regole
+        spells: Incantesimi
+    offcanvas:
+      manage_stock:
+        back: Indietro
+        title: Gestione Inventario
+    topbar:
+      manage_stock:
+        title: Gestione Inventario

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,17 +1,19 @@
 ---
 it:
   campaignmanager:
-    navigation:
-      active_adventure: "Avventura attiva"
     campaigns:
       features:
-        adventures: "Avventure"
+        adventures: Avventure
       form:
-        adventures_label: "Avventure in questa campagna"
-        adventures_hint: "Seleziona le avventure che fanno parte di questa campagna. Appaiono nella panoramica della campagna."
-        active_adventure_label: "Avventura attiva"
-        active_adventure_hint: "L'avventura attualmente in corso. Viene evidenziata nella panoramica e collegata nel menu della campagna."
-        no_active_adventure: "Nessuna"
+        active_adventure_hint: L'avventura attualmente in corso. Viene evidenziata
+          nella panoramica e collegata nel menu della campagna.
+        active_adventure_label: Avventura attiva
+        adventures_hint: Seleziona le avventure che fanno parte di questa campagna.
+          Appaiono nella panoramica della campagna.
+        adventures_label: Avventure in questa campagna
+        no_active_adventure: Nessuna
+    navigation:
+      active_adventure: Avventura attiva
   errors:
     messages:
       invalid_privacy: non è valido.
@@ -45,3 +47,7 @@ it:
     topbar:
       manage_stock:
         title: Gestione Inventario
+  locales:
+    en: Inglese
+    it: Italiano
+    nl: Olandese

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,17 +1,19 @@
 ---
 nl:
   campaignmanager:
-    navigation:
-      active_adventure: "Actief avontuur"
     campaigns:
       features:
-        adventures: "Avonturen"
+        adventures: Avonturen
       form:
-        adventures_label: "Avonturen in deze campagne"
-        adventures_hint: "Vink de avonturen aan die onderdeel zijn van deze campagne. Ze verschijnen op het campagneoverzicht."
-        active_adventure_label: "Actief avontuur"
-        active_adventure_hint: "Het avontuur dat nu gespeeld wordt. Het wordt uitgelicht op het overzicht en gelinkt in het campagnemenu."
-        no_active_adventure: "Geen"
+        active_adventure_hint: Het avontuur dat nu gespeeld wordt. Het wordt uitgelicht
+          op het overzicht en gelinkt in het campagnemenu.
+        active_adventure_label: Actief avontuur
+        adventures_hint: Vink de avonturen aan die onderdeel zijn van deze campagne.
+          Ze verschijnen op het campagneoverzicht.
+        adventures_label: Avonturen in deze campagne
+        no_active_adventure: Geen
+    navigation:
+      active_adventure: Actief avontuur
   errors:
     messages:
       invalid_privacy: is niet geldig.
@@ -45,3 +47,7 @@ nl:
     topbar:
       manage_stock:
         title: Voorraad Beheren
+  locales:
+    en: Engels
+    it: Italiaans
+    nl: Nederlands

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   campaignmanager:
     navigation:
@@ -11,3 +12,36 @@ nl:
         active_adventure_label: "Actief avontuur"
         active_adventure_hint: "Het avontuur dat nu gespeeld wordt. Het wordt uitgelicht op het overzicht en gelinkt in het campagnemenu."
         no_active_adventure: "Geen"
+  errors:
+    messages:
+      invalid_privacy: is niet geldig.
+  gallery:
+    images:
+      image_modal:
+        map_images: Kaartafbeeldingen
+        my_images: Mijn Afbeeldingen
+        stock_images: Stockafbeeldingen
+        stock_images_admin: Stockafbeeldingen (Beheerder)
+        title: Afbeeldingen
+  hello: Hallo wereld
+  layouts:
+    license:
+      attribution:
+        aria_label: RPG systeem toeschrijving
+    navigation:
+      manage_stock:
+        creatures: Wezens
+        game_master: Spelleider
+        images: Afbeeldingen
+        items: Voorwerpen
+        npcs: NPC's
+        rule_builder: Regelenbouwer
+        rules: Regels
+        spells: Spreuken
+    offcanvas:
+      manage_stock:
+        back: Terug
+        title: Voorraad Beheren
+    topbar:
+      manage_stock:
+        title: Voorraad Beheren

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -1,0 +1,9 @@
+it:
+  simple_form:
+    "yes": 'Sì'
+    "no": 'No'
+    required:
+      text: 'obbligatorio'
+      mark: '*'
+    error_notification:
+      default_message: "Si prega di rivedere i problemi seguenti:"

--- a/config/locales/simple_form.nl.yml
+++ b/config/locales/simple_form.nl.yml
@@ -1,0 +1,9 @@
+nl:
+  simple_form:
+    "yes": 'Ja'
+    "no": 'Nee'
+    required:
+      text: 'verplicht'
+      mark: '*'
+    error_notification:
+      default_message: "Bekijk de onderstaande problemen:"

--- a/db/migrate/20260616000001_add_locale_to_users.rb
+++ b/db/migrate/20260616000001_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :locale, :string, null: false, default: "en"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_13_162630) do
+ActiveRecord::Schema.define(version: 2026_06_16_000001) do
 
   create_table "activeplay_notables", id: :string, force: :cascade do |t|
     t.string "name"
@@ -838,6 +838,7 @@ ActiveRecord::Schema.define(version: 2026_06_13_162630) do
     t.datetime "updated_at"
     t.string "status", default: "trial", null: false
     t.string "stripe_customer_token"
+    t.string "locale", default: "en", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
     rubocop:
       tags: rubocop
       glob: "*.{rb,rake}"
-      run: bundle exec rubocop --force-exclusion {staged_files}
+      run: rv run bundle exec rubocop --force-exclusion {staged_files}
 
 pre-push:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,4 +8,4 @@ pre-commit:
 pre-push:
   commands:
     pre_push_checks:
-      run: bin/pre_push_checks
+      run: rv run bin/pre_push_checks

--- a/test/integration/locale_settings_test.rb
+++ b/test/integration/locale_settings_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class LocaleSettingsTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "account settings render locale choices in the user's locale" do
+    user = users(:dan)
+    user.update!(locale: "it")
+
+    sign_in user
+    get edit_user_registration_path
+
+    assert_response :success
+    assert_select "option", text: "Inglese"
+    assert_select "option", text: "Olandese"
+    assert_select "option", text: "Italiano"
+  end
+end

--- a/test/lefthook_config_test.rb
+++ b/test/lefthook_config_test.rb
@@ -13,7 +13,7 @@ class LefthookConfigTest < ActiveSupport::TestCase
     commands = config.dig("pre-push", "commands")
     runs = commands.values.map { |command| command.fetch("run") }
 
-    assert_includes runs, "bin/pre_push_checks"
+    assert_includes runs, "rv run bin/pre_push_checks"
   end
 
   private


### PR DESCRIPTION
## Summary

- Adds `users.locale` DB column (string, not null, default `en`) and wires it to `ApplicationController` so every request runs in the user's chosen locale
- Translates all ~20 existing `en.yml` app keys to Dutch (`nl`) and Italian (`it`); adds matching `simple_form.nl.yml` / `simple_form.it.yml`; brings in `rails-i18n` and `devise-i18n` for framework strings
- Adds a locale selector dropdown to the Devise account settings form (`/users/edit`) so users can persist their preference
- Wires up `i18n-tasks` (gem + `config/i18n-tasks.yml` + `bin/i18n-tasks` binstub) and adds an `i18n_check` CI job that exits 1 on missing or unused keys
- Fixes `lefthook.yml` pre-commit and pre-push hooks to use `rv run` so they work with the project's Ruby version

## Test Plan

- [ ] Run `bin/rails db:migrate` — verify `users.locale` column added with default `en`
- [ ] Log in, go to `/users/edit`, confirm locale dropdown appears with English / Nederlands / Italiano options; save and verify it persists
- [ ] Switch locale to `nl` — verify navigation labels (Game Master → Spelleider, etc.) switch to Dutch
- [ ] Switch locale to `it` — verify Italian labels appear
- [ ] `bin/i18n-tasks health` exits 0 with no missing/unused keys
- [ ] Remove a key from `nl.yml`, re-run health, confirm it exits 1
- [ ] CI passes (all three jobs: lint_ruby, test, i18n_check)

## Scope note

This branch is infrastructure only — extracting the ~62 view files with hardcoded English strings is a follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)