### PR TITLE
Show inline descriptions in creature preview modal and add page link

### DIFF
--- a/engines/entitybuilder/app/views/entitybuilder/attacks/sheet/_show_detail.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/attacks/sheet/_show_detail.html.erb
@@ -1,1 +1,7 @@
-<%= attack_display_profile(@parent_object.core_rules, attack, @parent_object.ability_scores, @parent_object.modifiers, @parent_object.base_values).html_safe %><%= ", " unless attack == last %>
+<% attack_html = attack_display_profile(@parent_object.core_rules, attack, @parent_object.ability_scores, @parent_object.modifiers, @parent_object.base_values) %>
+<%= attack_html.html_safe %>
+<% if attack.description.present? %>
+  <%= link_to "<i class='fa fa-expand'></i>".html_safe, "#", class: "cogs125", onclick: "$('#attack_desc_#{attack.id}').toggle(); return false;" %>
+  <div id="attack_desc_<%= attack.id %>" style="display:none;" class="indent"><small><%= attack.description %></small></div>
+<% end %>
+<%= ", " unless attack == last %>

--- a/engines/entitybuilder/app/views/entitybuilder/entities/_show_remote.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/_show_remote.html.erb
@@ -6,6 +6,7 @@
           :icon => @entity.icon,
           :main => @entity.name,
           :sub => @entity.title,
+          :new_tab_link => route_path(@entity),
           :view_link_remote => route_path(@entity),
           :profile_link_remote => ("#{route_path(@entity)}/profile" if @entity.can_sheet?(current_user, admin_signed_in?, @type))
         }

--- a/engines/entitybuilder/app/views/entitybuilder/known_spells/layouts/_level_list.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/known_spells/layouts/_level_list.html.erb
@@ -4,10 +4,11 @@
   <% known_spells.each do |known_spell| %>
     <% unless known_spell.used == true %>
       <%= link_to "<i class='fa fa-minus-circle'></i>".html_safe, "#{entitybuilder.polymorphic_path(entity)}/known_spells/#{known_spell.id}/use_spell", title: "Use Spell", class: "cogs125 delete", method: :patch, :remote => true if can_edit %>
-      <%= link_to_if clickable, known_spell.spell.name, "#{entitybuilder.polymorphic_path(entity)}/known_spells/#{known_spell.id}", "data-reveal-id" => "known_spell_modal", :remote => true %><%= " (#{known_spell.detail})" if known_spell.detail.present? %><%= ", " unless known_spell == known_spells.last %>
+      <%= link_to_if clickable, known_spell.spell.name, "#{entitybuilder.polymorphic_path(entity)}/known_spells/#{known_spell.id}", "data-reveal-id" => "known_spell_modal", :remote => true %><%= " (#{known_spell.detail})" if known_spell.detail.present? %>
     <% else %>
       <%= link_to "<i class='fa fa-plus-circle'></i>".html_safe, "#{entitybuilder.polymorphic_path(entity)}/known_spells/#{known_spell.id}/use_spell", title: "Reset Spell", class: "cogs125 add", method: :patch, :remote => true if can_edit %>
-      <%= link_to_if clickable, known_spell.spell.name, "#{entitybuilder.polymorphic_path(entity)}/known_spells/#{known_spell.id}", "data-reveal-id" => "known_spell_modal", :remote => true, :class => "iconlink" %><%= " (#{known_spell.detail})" if known_spell.detail.present? %><%= ", " unless known_spell == known_spells.last %>
+      <%= link_to_if clickable, known_spell.spell.name, "#{entitybuilder.polymorphic_path(entity)}/known_spells/#{known_spell.id}", "data-reveal-id" => "known_spell_modal", :remote => true, :class => "iconlink" %><%= " (#{known_spell.detail})" if known_spell.detail.present? %>
     <% end %>
+    <% if known_spell.spell.short_description.present? %><div class="indent"><small><%= known_spell.spell.short_description %></small></div><% end %>
   <% end %>
 </div>

--- a/engines/entitybuilder/app/views/entitybuilder/linked_rules/layouts/_profile.html.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/linked_rules/layouts/_profile.html.erb
@@ -1,14 +1,15 @@
-<% rule_types = CoreRules::Rule.rule_types(entity.core_rules)%>
+<% rule_types = CoreRules::Rule.rule_types(entity.core_rules) %>
 <% rule_types.each do |rule_type| %>
   <% linked_rules_selected = linked_rules.select { |i| i.rule_type == rule_type } %>
   <% if linked_rules_selected.present? %>
-
     <div class="indent">
-    <strong><%= rule_type.pluralize %>:</strong>
+      <strong><%= rule_type.pluralize %>:</strong>
       <% linked_rules_selected.each do |linked_rule| %>
-        <%= link_to_if clickable, linked_rule.rule.name, "#{entitybuilder.polymorphic_path(entity)}/linked_rules/#{linked_rule.id}", "data-reveal-id" => "linked_rule_modal", :remote => true %><%= " (#{linked_rule.detail})" if linked_rule.detail.present? %><%= ", " unless linked_rule == linked_rules_selected.last %>
+        <div class="indent">
+          <strong><%= link_to_if clickable, linked_rule.rule.name, "#{entitybuilder.polymorphic_path(entity)}/linked_rules/#{linked_rule.id}", "data-reveal-id" => "linked_rule_modal", :remote => true %><%= " (#{linked_rule.detail})" if linked_rule.detail.present? %></strong>
+          <% if linked_rule.rule.short_description.present? %> - <%= linked_rule.rule.short_description %><% end %>
+        </div>
       <% end %>
     </div>
-
   <% end %>
 <% end %>


### PR DESCRIPTION
## Summary

- Abilities and feats in the creature preview modal now show their `short_description` inline below the name, replacing the compact comma-separated format
- Spells follow the same pattern, with `short_description` shown below each spell name
- Attacks gain a `fa-expand` toggle icon that reveals the attack's `description` text on click
- The modal header gains a `fa-external-link-square` icon (top-right) that opens the creature's full page in a new tab

## Test plan

- [ ] Open a creature preview modal for a creature with abilities/feats — each should appear on its own line with description below the name
- [ ] Open a creature with spells — each spell should show with description below
- [ ] Open a creature with attacks that have descriptions — clicking the expand icon should toggle the description
- [ ] Confirm the external-link icon appears top-right in the modal header and opens the creature page in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)