### PR TITLE
Fix production NoMethodError: ensure locale column exists on users

### DIFF
--- a/db/migrate/20260622000001_ensure_locale_on_users.rb
+++ b/db/migrate/20260622000001_ensure_locale_on_users.rb
@@ -1,0 +1,9 @@
+class EnsureLocaleOnUsers < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :locale, :string, null: false, default: "en" unless column_exists?(:users, :locale)
+  end
+
+  def down
+    remove_column :users, :locale if column_exists?(:users, :locale)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_06_20_000001) do
+ActiveRecord::Schema.define(version: 2026_06_22_000001) do
 
   create_table "activeplay_notables", id: :text, default: "uuid()", force: :cascade do |t|
     t.text "name"


### PR DESCRIPTION
Production was crashing immediately after deploy with `NoMethodError (undefined method 'locale' for an instance of User)` in `ApplicationController#set_locale`. The `add_locale_to_users` migration was already recorded in `schema_migrations` on production (from a prior partial run) so `db:migrate` skipped it, leaving the column absent from the database.

This PR adds an idempotent migration (`EnsureLocaleOnUsers`) that uses `column_exists?` to add the `locale` column only if it is missing — safe to run regardless of the prior migration's state. Deploy and run `db:migrate` to recover production.