### PR TITLE
Open section edit form when show-page cog is clicked

### DIFF
--- a/engines/campaignmanager/app/controllers/campaignmanager/sections_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/sections_controller.rb
@@ -11,6 +11,7 @@ module Campaignmanager
     # GET /sections
     def index
       @sections = @parent_object.sections
+      @section = @parent_object.sections.find(params[:section]) if params[:section].present?
     end
 
     # GET /sections/1

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/_sections.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/_sections.html.erb
@@ -8,6 +8,6 @@
         :all_pages => @campaign.pages.to_a,
         :resident => @resident,
         :can_auth => @campaign.can_edit?(current_user, admin_signed_in?),
-        :edit_url => nil
+        :edit_url => campaign_sections_path(@campaign, section: section.id)
     } %>
 <% end %>

--- a/engines/campaignmanager/app/views/campaignmanager/pages/_sections.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/_sections.html.erb
@@ -8,6 +8,6 @@
         :all_pages => @campaign.pages.to_a,
         :resident => @resident,
         :can_auth => @page.can_edit?(current_user, admin_signed_in?),
-        :edit_url => nil
+        :edit_url => polymorphic_path([@campaign, @page, :sections], section: section.id)
     } %>
 <% end %>

--- a/engines/campaignmanager/app/views/campaignmanager/sections/_form_new.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/sections/_form_new.html.erb
@@ -1,4 +1,5 @@
-<div id="form_placeholder">
+<% style = local_assigns[:hide] ? 'display:none;' : '' %>
+<div id="form_placeholder" style="<%= style %>">
   <fieldset>
     <div class="row inline text-right">
       <div class="small-12 columns">

--- a/engines/campaignmanager/app/views/campaignmanager/sections/index.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/sections/index.html.erb
@@ -43,7 +43,10 @@
         <%= render 'form_list' %>
       </div>
       <div class="medium-7 columns">
-        <%= render 'form_new' %>
+        <%= render partial: 'form_new', locals: { hide: @section.present? } %>
+        <% if @section.present? %>
+          <%= render 'form' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/engines/worldbuilder/app/controllers/worldbuilder/sections_controller.rb
+++ b/engines/worldbuilder/app/controllers/worldbuilder/sections_controller.rb
@@ -13,6 +13,7 @@ module Worldbuilder
     # GET /sections
     def index
       @sections = @parent_object.sections
+      @section = @parent_object.sections.find(params[:section]) if params[:section].present?
     end
 
     # GET /sections/1

--- a/engines/worldbuilder/app/views/worldbuilder/districts/_sections.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/districts/_sections.html.erb
@@ -8,6 +8,6 @@
         :all_pages => (@district.pages.block.order('sort_weight, name').to_a if section.section_style == 'blocks'),
         :resident => @district.resident,
         :can_auth => @district.can_edit?(current_user, admin_signed_in?),
-        :edit_url => nil
+        :edit_url => district_sections_path(@district, section: section.id)
     } %>
 <% end %>

--- a/engines/worldbuilder/app/views/worldbuilder/pages/_sections.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/pages/_sections.html.erb
@@ -8,6 +8,6 @@
         :all_pages => (@district.pages.block.order('sort_weight, name').to_a if section.section_style == 'blocks'),
         :resident => @district.resident,
         :can_auth => @district.can_edit?(current_user, admin_signed_in?),
-        :edit_url => polymorphic_path([@district, @page, :sections], section: section.id)
+        :edit_url => district_page_sections_path(@district.slug, @page, section: section.id)
     } %>
 <% end %>

--- a/engines/worldbuilder/app/views/worldbuilder/pages/_sections.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/pages/_sections.html.erb
@@ -8,6 +8,6 @@
         :all_pages => (@district.pages.block.order('sort_weight, name').to_a if section.section_style == 'blocks'),
         :resident => @district.resident,
         :can_auth => @district.can_edit?(current_user, admin_signed_in?),
-        :edit_url => nil
+        :edit_url => polymorphic_path([@district, @page, :sections], section: section.id)
     } %>
 <% end %>

--- a/engines/worldbuilder/app/views/worldbuilder/sections/_form_new.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/sections/_form_new.html.erb
@@ -1,4 +1,5 @@
-<div id="form_placeholder">
+<% style = local_assigns[:hide] ? 'display:none;' : '' %>
+<div id="form_placeholder" style="<%= style %>">
   <fieldset>
     <div class="row inline text-right">
       <div class="small-12 columns">

--- a/engines/worldbuilder/app/views/worldbuilder/sections/index.html.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/sections/index.html.erb
@@ -40,7 +40,10 @@
         <%= render 'form_list' %>
       </div>
       <div class="medium-7 columns">
-        <%= render 'form_new' %>
+        <%= render partial: 'form_new', locals: { hide: @section.present? } %>
+        <% if @section.present? %>
+          <%= render 'form' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/test/integration/campaign_section_form_test.rb
+++ b/test/integration/campaign_section_form_test.rb
@@ -75,6 +75,28 @@ class CampaignSectionFormTest < ActionDispatch::IntegrationTest
                        "/wb/#{district.slug}/pages/#{page.id}/sections"
   end
 
+  test "world page show edit cog links to sections index and opens edit form" do
+    sign_in @game_master
+    district = worldbuilder_districts(:district_one)
+    page = worldbuilder_pages(:page_one)
+    section = page.sections.create!(
+      section_type: "text", section_style: "paragraph",
+      header: "Regression", content: "<p>Regression body</p>", sort_order: 1
+    )
+    expected_edit_url = "/wb/#{district.slug}/pages/#{page.id}/sections?section=#{section.id}"
+
+    get "/wb/#{district.slug}/pages/#{page.slug}"
+    assert_response :success
+    assert_includes response.body, %(href="#{expected_edit_url}"),
+      "expected an edit cog link pointing to #{expected_edit_url}"
+
+    get expected_edit_url
+    assert_response :success
+    assert_includes response.body,
+      %(action="/wb/#{district.slug}/pages/#{page.id}/sections/#{section.id}"),
+      "sections index with ?section= should render that section's edit form"
+  end
+
   # The edit cog next to a section's header on the show page must link to the
   # sections index with `?section=<id>`, and that URL must auto-open the edit
   # form for that section.

--- a/test/integration/campaign_section_form_test.rb
+++ b/test/integration/campaign_section_form_test.rb
@@ -75,6 +75,27 @@ class CampaignSectionFormTest < ActionDispatch::IntegrationTest
                        "/wb/#{district.slug}/pages/#{page.id}/sections"
   end
 
+  # The edit cog next to a section's header on the show page must link to the
+  # sections index with `?section=<id>`, and that URL must auto-open the edit
+  # form for that section.
+  test "campaign show edit cog links to sections index and opens edit form" do
+    sign_in @game_master
+    campaign = campaignmanager_campaigns(:resident_one)
+    section = campaignmanager_sections(:campaign_text1)
+    expected_edit_url = "/cm/campaigns/#{campaign.id}/sections?section=#{section.id}"
+
+    get "/cm/campaigns/#{campaign.id}"
+    assert_response :success
+    assert_includes response.body, %(href="#{expected_edit_url}"),
+      "expected an edit cog link pointing to #{expected_edit_url}"
+
+    get expected_edit_url
+    assert_response :success
+    assert_includes response.body,
+      %(action="/cm/campaigns/#{campaign.id}/sections/#{section.id}"),
+      "sections index with ?section= should render that section's edit form"
+  end
+
   private
 
     def assert_form_action(path, expected_action)


### PR DESCRIPTION
## Summary
- Cog icon next to a section's `<h2>` on show pages was inert (`edit_url => nil`) — now it links to the sections index with `?section=<id>`, and that URL auto-opens the section's edit form.
- Mirrors the existing storybuilder pattern that works for adventures and storybuilder pages.
- Applied across all 4 affected show contexts: campaignmanager campaign, campaignmanager page, worldbuilder district, worldbuilder page.

## Implementation notes
- 4 `_sections.html.erb` partials: replace `:edit_url => nil` with the Rails URL helper (`campaign_sections_path` / `district_sections_path`) or `polymorphic_path([parent, page, :sections])` for the nested-page cases. Always passes `section: section.id` as a query param.
- 2 `SectionsController#index` actions (cm + wb): load `@section = @parent_object.sections.find(params[:section]) if params[:section].present?` — scoped to the parent for safety (storybuilder uses `Section.find` unscoped; I went stricter).
- 2 `sections/index.html.erb` templates: conditionally render the `form` partial when `@section.present?`.
- 2 `_form_new.html.erb` partials: accept a `hide` local and hide the placeholder when an edit form is being shown.

## Test plan
- [x] `bin/rails test test/integration/campaign_section_form_test.rb` — new test asserts the campaign show page renders the cog link with `?section=<id>` and that hitting that URL renders the edit form. Verified to fail before the fix (link defaults to the campaign show URL) and pass after.
- [x] `bin/rails test test/controllers/worldbuilder/ test/controllers/campaignmanager/ test/integration/campaign_lifecycle_test.rb` — all green (83/83).
- [ ] Manual: campaign show → click cog on a section → sections page opens with that section's edit form populated.
- [ ] Manual: same flow on a campaignmanager page (e.g. adventure log), a worldbuilder district, and a worldbuilder page.