### PR TITLE
Restore page creation and auto-add pages to navigation menu

### DIFF
--- a/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
@@ -73,6 +73,7 @@ module Campaignmanager
 
       respond_to do |format|
         if @page.save
+          auto_create_menu_item
           format.html { redirect_to sti_edit_page_path(@page), notice: @page.name + ' was successfully created.' }
         else
           format.html { render action: 'new' }
@@ -140,6 +141,16 @@ module Campaignmanager
         if @page.nil? || !@page.can_show?(current_user, admin_signed_in?, @type)
           render template: 'errors/404', layout: 'layouts/application', status: 404
         end
+      end
+
+      def auto_create_menu_item
+        sort_order = @campaign.menu_items.maximum(:sort_order).to_i + 1
+        menu_item = @campaign.menu_items.create!(
+          sort_order: sort_order,
+          item_label: @page.name.to_s.truncate(25),
+          item_link: helpers.city_path(@campaign, @page)
+        )
+        Storybuilder::MenuItemJoin.create!(menu_item: menu_item, menu_item_joinable: @page)
       end
 
       def sti_edit_page_path(page)

--- a/engines/campaignmanager/app/models/campaignmanager/page.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/page.rb
@@ -25,6 +25,11 @@ module Campaignmanager
     has_many :notables, -> { order(:sort_order) }, :as => :notableable, :dependent => :destroy
     has_many :entities, -> { select('id, type, name') }, :through => :notables, :source => :entity, :class_name => "Entitybuilder::Entity"
 
+    has_one :menu_item_join,
+            as: :menu_item_joinable,
+            class_name: "Storybuilder::MenuItemJoin",
+            dependent: :destroy
+
     has_one :gallery_image_join,
             :as => :imageable,
             :class_name => "Gallery::ImageJoin",
@@ -51,12 +56,17 @@ module Campaignmanager
     before_validation :make_slug
     before_validation :nil_if_blank
     before_save :mark_for_removal
+    before_destroy :destroy_menu_item
 
     def icon
       'icon-docs'
     end
 
     private
+      def destroy_menu_item
+        menu_item_join&.menu_item&.destroy
+      end
+
       def make_slug
         self.slug = self.name.parameterize
       end

--- a/engines/campaignmanager/app/views/campaignmanager/pages/new.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/new.html.erb
@@ -25,7 +25,7 @@
     </div>
     <hr class="faded">
     <div id="brass_form">
-      <%= simple_form_for @page, url: "#{polymorphic_path(@parent_object)}/#{@type.tableize}" do |f| %>
+      <%= simple_form_for @page, url: nested_resource_form_path(@parent_object, @page, @type.tableize) do |f| %>
         <%= render :partial => 'form', :locals => { :f => f } %>
       <% end %>
     </div>

--- a/engines/storybuilder/app/controllers/storybuilder/pages_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/pages_controller.rb
@@ -75,6 +75,7 @@ module Storybuilder
 
       respond_to do |format|
         if @page.save
+          auto_create_menu_item unless @page.menu_item_join.present?
           format.html { redirect_to storybuilder.edit_polymorphic_path([@parent_object, @page]), notice: @page.name + ' was successfully created.' }
         else
           format.html { render action: 'new' }
@@ -140,6 +141,16 @@ module Storybuilder
         unless @page.can_show?(current_user, admin_signed_in?)
           render template: 'errors/403', layout: 'layouts/application', status: 403
         end
+      end
+
+      def auto_create_menu_item
+        sort_order = @parent_object.menu_items.maximum(:sort_order).to_i + 1
+        menu_item = @parent_object.menu_items.create!(
+          sort_order: sort_order,
+          item_label: @page.name.to_s.truncate(25),
+          item_link: storybuilder.polymorphic_path([@parent_object, @page])
+        )
+        Storybuilder::MenuItemJoin.create!(menu_item: menu_item, menu_item_joinable: @page)
       end
 
       # Never trust parameters from the scary internet, only allow the white list through.

--- a/engines/storybuilder/app/controllers/storybuilder/pages_controller.rb
+++ b/engines/storybuilder/app/controllers/storybuilder/pages_controller.rb
@@ -75,7 +75,7 @@ module Storybuilder
 
       respond_to do |format|
         if @page.save
-          auto_create_menu_item unless @page.menu_item_join.present?
+          auto_create_menu_item unless @page.menu_item_join&.persisted?
           format.html { redirect_to storybuilder.edit_polymorphic_path([@parent_object, @page]), notice: @page.name + ' was successfully created.' }
         else
           format.html { render action: 'new' }
@@ -148,7 +148,7 @@ module Storybuilder
         menu_item = @parent_object.menu_items.create!(
           sort_order: sort_order,
           item_label: @page.name.to_s.truncate(25),
-          item_link: storybuilder.polymorphic_path([@parent_object, @page])
+          item_link: "/pages/#{@page.id}"
         )
         Storybuilder::MenuItemJoin.create!(menu_item: menu_item, menu_item_joinable: @page)
       end

--- a/engines/storybuilder/app/views/storybuilder/pages/_update.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/_update.html.erb
@@ -1,3 +1,3 @@
-<%= simple_form_for @page, url: polymorphic_path([@parent_object, @page]), :remote => true, :html => {'data-no-transition-cache' => ''} do |f| %>
+<%= simple_form_for @page, url: nested_resource_form_path(@parent_object, @page, 'pages'), :remote => true, :html => {'data-no-transition-cache' => ''} do |f| %>
   <%= render :partial => 'form', :locals => { :f => f } %>
 <% end %>

--- a/engines/storybuilder/app/views/storybuilder/pages/index.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/index.html.erb
@@ -17,14 +17,14 @@
       :locals => {
         :main => @parent_object.name,
         :sub => "Pages #{@sub}",
-        :add_link  => new_polymorphic_path([@adventure, :page]),
+        :add_link  => storybuilder.new_polymorphic_path([@adventure, :page]),
         :can_auth => @parent_object.can_edit?(current_user, admin_signed_in?, @type)
       }
     %>
     <hr class="faded">
     <div class="row">
       <div class="small-10 small-centered columns">
-        <%= render 'layouts/form/search', url: polymorphic_path([@adventure, :pages]) %>
+        <%= render 'layouts/form/search', url: storybuilder.polymorphic_path([@adventure, :pages]) %>
       </div>
     </div>
     <div class="row">

--- a/engines/storybuilder/app/views/storybuilder/pages/new.html.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/new.html.erb
@@ -25,7 +25,7 @@
     </div>
     <hr class="faded">
     <div id="brass_form">
-      <%= simple_form_for @page, url: polymorphic_path([@parent_object, :pages]) do |f| %>
+      <%= simple_form_for @page, url: nested_resource_form_path(@parent_object, @page, 'pages') do |f| %>
         <%= render :partial => 'form', :locals => { :f => f } %>
       <% end %>
     </div>

--- a/test/integration/page_creation_test.rb
+++ b/test/integration/page_creation_test.rb
@@ -9,8 +9,6 @@ class PageCreationTest < ActionDispatch::IntegrationTest
     @campaign    = campaignmanager_campaigns(:resident_one)
   end
 
-  # Part 1: form action URLs
-
   test "storybuilder new page form posts to pages collection" do
     sign_in @game_master
     get "/sb/resident/adventures/#{@adventure.id}/pages/new"
@@ -32,8 +30,6 @@ class PageCreationTest < ActionDispatch::IntegrationTest
     assert_match %r{\A/cm/campaigns/#{@campaign.id}/adventure_logs/?\z}, action,
                  "new adventure_log form must post to collection, got #{action.inspect}"
   end
-
-  # Part 2: auto-create menu item on create
 
   test "creating a storybuilder page without menu selection auto-creates a menu item" do
     sign_in @game_master

--- a/test/integration/page_creation_test.rb
+++ b/test/integration/page_creation_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class PageCreationTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @game_master = users(:dan)
+    @adventure   = storybuilder_adventures(:resident_one)
+    @campaign    = campaignmanager_campaigns(:resident_one)
+  end
+
+  # Part 1: form action URLs
+
+  test "storybuilder new page form posts to pages collection" do
+    sign_in @game_master
+    get "/sb/resident/adventures/#{@adventure.id}/pages/new"
+    assert_response :success
+
+    action = response.body[/<form[^>]*action=(?:"|\\")([^"\\]+)/, 1]
+    assert action, "no <form action=...> in response body"
+    assert_match %r{\A/sb/resident/adventures/#{@adventure.id}/pages/?\z}, action,
+                 "new-page form must post to the pages collection, got #{action.inspect}"
+  end
+
+  test "campaignmanager new adventure_log form posts to adventure_logs collection" do
+    sign_in @game_master
+    get "/cm/campaigns/#{@campaign.id}/adventure_logs/new"
+    assert_response :success
+
+    action = response.body[/<form[^>]*action=(?:"|\\")([^"\\]+)/, 1]
+    assert action, "no <form action=...> in response body"
+    assert_match %r{\A/cm/campaigns/#{@campaign.id}/adventure_logs/?\z}, action,
+                 "new adventure_log form must post to collection, got #{action.inspect}"
+  end
+
+  # Part 2: auto-create menu item on create
+
+  test "creating a storybuilder page without menu selection auto-creates a menu item" do
+    sign_in @game_master
+
+    assert_difference [ "Storybuilder::MenuItem.count", "Storybuilder::MenuItemJoin.count" ], 1 do
+      post "/sb/resident/adventures/#{@adventure.id}/pages", params: { page: {
+        name: "Auto Menu Page", privacy: "Residents",
+        short_description: "test", full_description: "<p>test</p>"
+      } }
+    end
+
+    page = Storybuilder::Page.find_by!(name: "Auto Menu Page")
+    assert page.menu_item_join.present?, "page should have a menu_item_join"
+
+    menu_item = page.menu_item_join.menu_item
+    assert_equal @adventure, menu_item.menu_itemable
+    assert_equal "Auto Menu Page", menu_item.item_label
+  end
+
+  test "creating a storybuilder page with an explicit menu selection does not create an extra menu item" do
+    sign_in @game_master
+
+    existing_menu_item = storybuilder_menu_items(:menu_item1)
+
+    assert_difference "Storybuilder::MenuItem.count", 0 do
+      post "/sb/resident/adventures/#{@adventure.id}/pages", params: { page: {
+        name: "Explicit Menu Page", privacy: "Residents",
+        short_description: "test", full_description: "<p>test</p>",
+        menu_item_join_attributes: { menu_item_id: existing_menu_item.id }
+      } }
+    end
+  end
+
+  test "creating a campaignmanager adventure_log auto-creates a menu item" do
+    sign_in @game_master
+
+    assert_difference [ "Storybuilder::MenuItem.count", "Storybuilder::MenuItemJoin.count" ], 1 do
+      post "/cm/campaigns/#{@campaign.id}/adventure_logs", params: { adventure_log: {
+        name: "Auto Log", privacy: "Residents",
+        short_description: "test", full_description: "<p>test</p>"
+      } }
+    end
+
+    page = Campaignmanager::AdventureLog.find_by!(name: "Auto Log")
+    assert page.menu_item_join.present?, "adventure_log should have a menu_item_join"
+
+    menu_item = page.menu_item_join.menu_item
+    assert_equal @campaign, menu_item.menu_itemable
+    assert_equal "Auto Log", menu_item.item_label
+  end
+end

--- a/test/integration/page_creation_test.rb
+++ b/test/integration/page_creation_test.rb
@@ -41,7 +41,8 @@ class PageCreationTest < ActionDispatch::IntegrationTest
     assert_difference [ "Storybuilder::MenuItem.count", "Storybuilder::MenuItemJoin.count" ], 1 do
       post "/sb/resident/adventures/#{@adventure.id}/pages", params: { page: {
         name: "Auto Menu Page", privacy: "Residents",
-        short_description: "test", full_description: "<p>test</p>"
+        short_description: "test", full_description: "<p>test</p>",
+        menu_item_join_attributes: { menu_item_id: "" }
       } }
     end
 
@@ -51,6 +52,7 @@ class PageCreationTest < ActionDispatch::IntegrationTest
     menu_item = page.menu_item_join.menu_item
     assert_equal @adventure, menu_item.menu_itemable
     assert_equal "Auto Menu Page", menu_item.item_label
+    assert_equal "/pages/#{page.id}", menu_item.item_link
   end
 
   test "creating a storybuilder page with an explicit menu selection does not create an extra menu item" do


### PR DESCRIPTION
## Summary

- Fixes 404 on new-page form submission in storybuilder and campaignmanager by replacing bare `polymorphic_path` calls with `nested_resource_form_path` (same fix applied to sections in 9118c43/19e3411, now extended to page forms and the index add-link/search action).
- After a page is saved, the controller auto-creates a `Storybuilder::MenuItem` and `MenuItemJoin` so the page appears immediately in the adventure/campaign navigation menu, mirroring the importer's `create_page_menu_item` logic; storybuilder skips auto-creation when the user already selected a menu item in the form.
- `Campaignmanager::Page` gains `has_one :menu_item_join` with `before_destroy` cleanup so deleting a page removes its menu entry.

## Test plan

- [ ] Create a storybuilder page (leave menu item blank) → page appears in adventure menu
- [ ] Create a storybuilder page (select an existing menu item) → no duplicate top-level menu entry
- [ ] Create a campaignmanager adventure log → page appears in campaign menu
- [ ] Delete a campaignmanager page → its menu item is removed
- [ ] `bundle exec rails test test/integration/page_creation_test.rb` — 5 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)