### PR TITLE
Fix activestorage Sprockets require

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,7 +23,7 @@
 //= require_tree ./v1
 //= require_tree ./time
 //= require_tree ./roller
-//= require @rails/activestorage/app/assets/javascripts/activestorage
+//= require activestorage
 //= require trix/dist/trix
 //= require actiontext/attachment_upload
 //= require gallery/image-picker


### PR DESCRIPTION
## Summary

Fixes a `Sprockets::FileNotFound` error when loading pages with rich text editors (e.g. `/residents/:slug`):

```
couldn't find file '@rails/activestorage/app/assets/javascripts/activestorage' with type 'application/javascript'
```

The CKEditor → ActionText/Trix migration added this require line to `app/assets/javascripts/application.js`:

```js
//= require @rails/activestorage/app/assets/javascripts/activestorage
```

That path reaches into `node_modules/@rails/activestorage/...`, but `@rails/activestorage` is **not** declared in `package.json` — only `@rails/actiontext` and `trix` are. It happened to resolve in some environments where `@rails/activestorage` was pulled in as a transitive dependency, but breaks where it isn't.

The fix uses the `activestorage` Ruby gem's Sprockets-registered asset instead — already in the bundle at 6.1.7.10, and the canonical Rails 6 Sprockets-only convention:

```js
//= require activestorage
```

No node_modules dependency for Active Storage at all.

## Test plan

- [ ] Pull the branch locally
- [ ] Restart the Rails server
- [ ] Open `/residents/etienne` (or any other resident/section/page with a rich text editor) and confirm the Sprockets error is gone
- [ ] Confirm Active Storage direct uploads still work (e.g. attach an image in a Trix editor and save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)