### PR TITLE
Fix AJAX save notices invisible; show campaign short description

### DIFF
--- a/app/views/affiliations/update.js.erb
+++ b/app/views/affiliations/update.js.erb
@@ -1,5 +1,5 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 if ( $( "#affiliates_list" ).length ) {
   $('#affiliates_list').html("<%= j(render 'affiliations/all') %>");
 }

--- a/app/views/messages/update.js.erb
+++ b/app/views/messages/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j render('form') %>");

--- a/app/views/residents/update.js.erb
+++ b/app/views/residents/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j render('update') %>");

--- a/app/views/users/update.js.erb
+++ b/app/views/users/update.js.erb
@@ -1,4 +1,4 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#user_detail').html("<%= j render('details') %>");
 $('#user_form').html("<%= j render('form') %>");

--- a/engines/activeplay/app/views/activeplay/notables/update.js.erb
+++ b/engines/activeplay/app/views/activeplay/notables/update.js.erb
@@ -1,7 +1,7 @@
 <% if @notable.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#notables_form').html("<%= j(render 'form_list') %>");

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/show.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/show.html.erb
@@ -21,6 +21,9 @@
       }
     %>
     <hr class="faded">
+    <% if @campaign.short_description.present? %>
+      <p><em><%= @campaign.short_description %></em></p>
+    <% end %>
     <div class="row">
       <div class="medium-8 columns">
       <%= render 'features', campaign: @campaign %>

--- a/engines/campaignmanager/app/views/campaignmanager/campaigns/update.js.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/campaigns/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/campaignmanager/app/views/campaignmanager/features/update.js.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/features/update.js.erb
@@ -1,7 +1,7 @@
 <% if @feature.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/campaignmanager/app/views/campaignmanager/menu_items/update.js.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menu_items/update.js.erb
@@ -1,7 +1,7 @@
 <% if @menu_item.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/campaignmanager/app/views/campaignmanager/notables/update.js.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/notables/update.js.erb
@@ -1,7 +1,7 @@
 <% if @notable.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/campaignmanager/app/views/campaignmanager/pages/update.js.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/campaignmanager/app/views/campaignmanager/sections/update.js.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/sections/update.js.erb
@@ -1,7 +1,7 @@
 <% if @section.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/ability_scores/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/ability_scores/update.js.erb
@@ -1,7 +1,7 @@
 <% if @ability_score.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/attacks/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/attacks/update.js.erb
@@ -1,7 +1,7 @@
 <% if @attack.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/base_values/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/base_values/update.js.erb
@@ -1,7 +1,7 @@
 <% if @base_value.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/caster_levels/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/caster_levels/update.js.erb
@@ -1,7 +1,7 @@
 <% if @caster_level.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/class_levels/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/class_levels/update.js.erb
@@ -1,7 +1,7 @@
 <% if @class_level.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/currencies/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/currencies/update.js.erb
@@ -1,7 +1,7 @@
 <% if @currency.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/defenses/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/defenses/update.js.erb
@@ -1,7 +1,7 @@
 <% if @defense.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/descriptors/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/descriptors/update.js.erb
@@ -1,7 +1,7 @@
 <% if @descriptor.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/entities/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/entities/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/inventory_items/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/inventory_items/update.js.erb
@@ -1,7 +1,7 @@
 <% if @inventory_item.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/known_spells/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/known_spells/update.js.erb
@@ -1,7 +1,7 @@
 <% if @known_spell.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/linked_rules/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/linked_rules/update.js.erb
@@ -1,7 +1,7 @@
 <% if @linked_rule.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/modifiers/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/modifiers/update.js.erb
@@ -1,7 +1,7 @@
 <% if @modifier.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_modifier_div').remove();
   $('#form_modifier_placeholder').show();
 

--- a/engines/entitybuilder/app/views/entitybuilder/movements/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/movements/update.js.erb
@@ -1,7 +1,7 @@
 <% if @movement.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/notables/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/notables/update.js.erb
@@ -1,7 +1,7 @@
 <% if @notable.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#notables_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/saving_throws/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/saving_throws/update.js.erb
@@ -1,7 +1,7 @@
 <% if @saving_throw.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/entitybuilder/app/views/entitybuilder/skills/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/skills/update.js.erb
@@ -1,7 +1,7 @@
 <% if @skill.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_modifier_placeholder').remove();
   $('#form_placeholder').show();

--- a/engines/entitybuilder/app/views/entitybuilder/trackables/update.js.erb
+++ b/engines/entitybuilder/app/views/entitybuilder/trackables/update.js.erb
@@ -1,7 +1,7 @@
 <% if @trackable.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/rulebuilder/app/views/rulebuilder/items/update.js.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/items/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/rulebuilder/app/views/rulebuilder/rules/update.js.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/rules/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#rule_form').html("<%= j(render 'update') %>");

--- a/engines/rulebuilder/app/views/rulebuilder/spells/update.js.erb
+++ b/engines/rulebuilder/app/views/rulebuilder/spells/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/storybuilder/app/views/storybuilder/adventures/update.js.erb
+++ b/engines/storybuilder/app/views/storybuilder/adventures/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/storybuilder/app/views/storybuilder/features/update.js.erb
+++ b/engines/storybuilder/app/views/storybuilder/features/update.js.erb
@@ -1,7 +1,7 @@
 <% if @feature.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/storybuilder/app/views/storybuilder/menu_items/update.js.erb
+++ b/engines/storybuilder/app/views/storybuilder/menu_items/update.js.erb
@@ -1,7 +1,7 @@
 <% if @menu_item.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/storybuilder/app/views/storybuilder/notables/update.js.erb
+++ b/engines/storybuilder/app/views/storybuilder/notables/update.js.erb
@@ -1,7 +1,7 @@
 <% if @notable.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/storybuilder/app/views/storybuilder/pages/update.js.erb
+++ b/engines/storybuilder/app/views/storybuilder/pages/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/storybuilder/app/views/storybuilder/sections/update.js.erb
+++ b/engines/storybuilder/app/views/storybuilder/sections/update.js.erb
@@ -1,7 +1,7 @@
 <% if @section.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/support/app/views/support/core_faqs/update.js.erb
+++ b/engines/support/app/views/support/core_faqs/update.js.erb
@@ -1,7 +1,7 @@
 <% if @core_faq.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#core_faq_<%= @core_faq.id %>').replaceWith('<%= j render @core_faq %>')

--- a/engines/worldbuilder/app/views/worldbuilder/districts/update.js.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/districts/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/worldbuilder/app/views/worldbuilder/features/update.js.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/features/update.js.erb
@@ -1,7 +1,7 @@
 <% if @feature.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/worldbuilder/app/views/worldbuilder/menu_items/update.js.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/menu_items/update.js.erb
@@ -1,7 +1,7 @@
 <% if @menu_item.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");

--- a/engines/worldbuilder/app/views/worldbuilder/pages/update.js.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/pages/update.js.erb
@@ -1,3 +1,3 @@
 $('.alert-box').remove();
-$("body").append ("<%= j(render 'layouts/notices') %>");
+$("#main").prepend("<%= j(render 'layouts/notices') %>");
 $('#brass_form').html("<%= j(render 'update') %>");

--- a/engines/worldbuilder/app/views/worldbuilder/sections/update.js.erb
+++ b/engines/worldbuilder/app/views/worldbuilder/sections/update.js.erb
@@ -1,7 +1,7 @@
 <% if @section.errors.count == 0 %>
 
   $('.alert-box').remove();
-  $("body").append ("<%= j(render 'layouts/notices') %>");
+  $("#main").prepend("<%= j(render 'layouts/notices') %>");
   $('#form_div').remove();
   $('#form_placeholder').show();
   $('#brass_form').html("<%= j(render 'form_list') %>");


### PR DESCRIPTION
## Summary

- All 44 `update.js.erb` files used `$("body").append()` to inject flash notices after AJAX saves, placing them after the footer where they were never visible to the user. Changed to `$('#main').prepend()` to match the location where the layout renders notices on regular page loads.
- Added the campaign short description (rendered in italics) to the campaign show page — it was previously only shown on the campaign index listing.

## Test plan

- [ ] Save any AJAX form (campaign, entity, district, etc.) and confirm the "X has been updated" flash notice appears at the top of the page
- [ ] Edit a campaign's short description, save, and verify it appears in italics on the campaign show page

🤖 Generated with [Claude Code](https://claude.com/claude-code)