### PR TITLE
Fix campaign pages: NOT NULL on type, destroy redirect, double-render

### DIFF
--- a/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
@@ -26,10 +26,10 @@ module Campaignmanager
       end
 
       if ('Campaignmanager::GameMasterNote'.include?@type) && user_signed_in? && !(current_user.resident == @parent_object.resident)
-        render template: 'errors/404', layout: 'layouts/application', status: 404
+        return render template: 'errors/404', layout: 'layouts/application', status: 404
       end
       unless @campaign.can_show?(current_user, admin_signed_in?, @type)
-        render template: 'errors/403', layout: 'layouts/application', status: 403
+        return render template: 'errors/403', layout: 'layouts/application', status: 403
       end
 
       respond_to do |format|
@@ -166,7 +166,7 @@ module Campaignmanager
       end
 
       def sti_pages_path
-        send "#{@parent_type.underscore}_#{@type.underscore.pluralize}_path"
+        send "#{@parent_type.underscore}_#{@type.underscore.pluralize}_path", @parent_object
       end
 
       def can_show

--- a/engines/campaignmanager/app/models/campaignmanager/page.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/page.rb
@@ -55,6 +55,7 @@ module Campaignmanager
     validate  :valid_privacy
     validates :short_description, length: { maximum: 255 }
 
+    before_validation :set_sti_type
     before_validation :make_slug
     before_validation :nil_if_blank
     before_save :mark_for_removal
@@ -65,6 +66,10 @@ module Campaignmanager
     end
 
     private
+      def set_sti_type
+        self.type ||= self.class.sti_name
+      end
+
       def destroy_menu_item
         menu_item_join&.menu_item&.destroy
       end


### PR DESCRIPTION
## Summary

- **Root cause fix**: Rails skips setting the `type` column for STI base-class records (`ensure_proper_type` only runs for subclasses). The `campaignmanager_pages` table has `type NOT NULL`, so creating a base `Campaignmanager::Page` raised a NOT NULL constraint violation (500 error). Fixed with a `before_validation` callback that sets `type` via `self.class.sti_name`.
- **Destroy redirect fix**: `sti_pages_path` was missing the campaign argument, which would raise `ActionController::UrlGenerationError` after deleting any page. Now passes `@parent_object`.
- **Double-render fix**: Added `return` before `render` calls in `index` to prevent `AbstractController::DoubleRenderError` when authorization checks fail.

## Test plan

- [ ] Navigate to a campaign → click "Campaign Pages" in the shortcut menu → empty list renders without error
- [ ] Click "Add" → fill in name, label, privacy → save → redirects to edit page (no 500)
- [ ] Page appears in the Campaign Pages index
- [ ] Delete the page → redirects back to the Campaign Pages index (no routing error)
- [ ] Run `bundle exec ruby -Itest test/controllers/campaignmanager/pages_controller_test.rb` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)