### PR TITLE
Fix campaign menu wizard: WB routing error and add Campaign Builder

### DIFF
--- a/app/assets/javascripts/v1/menu-item.js
+++ b/app/assets/javascripts/v1/menu-item.js
@@ -19,6 +19,23 @@ $(document).on('turbolinks:load', function () {
 
   $('#selectEngineSB').change(function () {
     var engine = $('#selectEngineSB option:selected').val();
+    var i;
+
+    if (engine === 'CM') {
+      var categories = [
+        {name: 'Adventure Logs', path: cm_url + 'adventure_logs.json'},
+        {name: 'House Rules', path: cm_url + 'house_rules.json'},
+        {name: 'GM Notes', path: cm_url + 'game_master_notes.json'},
+        {name: 'Pages', path: cm_url + 'pages.json'}
+      ];
+      $('#selectParent option').remove();
+      for (i = 0; i < categories.length; i++) {
+        $('#selectParent').get(0).options.add(new Option(categories[i].name, categories[i].path));
+      }
+      $('#selectParent').trigger('change');
+      return;
+    }
+
     var engine_url;
     if (engine === 'WB') {
       engine_url = wb_url + 'districts.json';
@@ -41,12 +58,27 @@ $(document).on('turbolinks:load', function () {
   });
 
   $('#selectParent').change(function () {
+    var id = $('#selectEngineSB option:selected').val();
+    var parent_url = $('#selectParent option:selected').val();
+
+    if (id === 'CM') {
+      $.ajax({
+        url: parent_url,
+        dataType: 'json',
+        success: function (data) {
+          var i;
+          $('#selectRecord option').remove();
+          for (i = 0; i < data.length; i++) {
+            $('#selectRecord').get(0).options.add(new Option(data[i].name, data[i].path));
+          }
+        }
+      });
+      return;
+    }
+
     if ($(this).data('options') === undefined) {
       $(this).data('options', $('#selectRecordType option').clone());
     }
-    var id = $('#selectEngineSB option:selected').val();
-    parent_url = $('#selectParent option:selected').val();
-
     var options = $(this).data('options').filter('[value=' + id + ']');
     $('#selectRecordType').html(options).trigger('change');
   });

--- a/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
+++ b/engines/campaignmanager/app/controllers/campaignmanager/pages_controller.rb
@@ -26,10 +26,10 @@ module Campaignmanager
       end
 
       if ('Campaignmanager::GameMasterNote'.include?@type) && user_signed_in? && !(current_user.resident == @parent_object.resident)
-        render template: 'errors/404', layout: 'layouts/application', status: 404
+        return render template: 'errors/404', layout: 'layouts/application', status: 404
       end
       unless @campaign.can_show?(current_user, admin_signed_in?, @type)
-        render template: 'errors/403', layout: 'layouts/application', status: 403
+        return render template: 'errors/403', layout: 'layouts/application', status: 403
       end
 
       respond_to do |format|
@@ -166,7 +166,7 @@ module Campaignmanager
       end
 
       def sti_pages_path
-        send "#{@parent_type.underscore}_#{@type.underscore.pluralize}_path"
+        send "#{@parent_type.underscore}_#{@type.underscore.pluralize}_path", @parent_object
       end
 
       def can_show

--- a/engines/campaignmanager/app/models/campaignmanager/page.rb
+++ b/engines/campaignmanager/app/models/campaignmanager/page.rb
@@ -55,6 +55,7 @@ module Campaignmanager
     validate  :valid_privacy
     validates :short_description, length: { maximum: 255 }
 
+    before_validation :set_sti_type
     before_validation :make_slug
     before_validation :nil_if_blank
     before_save :mark_for_removal
@@ -65,6 +66,10 @@ module Campaignmanager
     end
 
     private
+      def set_sti_type
+        self.type ||= self.class.sti_name
+      end
+
       def destroy_menu_item
         menu_item_join&.menu_item&.destroy
       end

--- a/engines/campaignmanager/app/views/campaignmanager/menu_items/_form.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menu_items/_form.html.erb
@@ -28,5 +28,6 @@
 <script>
   var engine_type = 'SB'
   var sb_url = "/sb/resident/";
-  var wb_url = "/resident/";
+  var wb_url = "/residents/<%= @parent_object.resident.slug %>/";
+  var cm_url = "<%= campaign_path(@parent_object) %>/";
 </script>

--- a/engines/campaignmanager/app/views/campaignmanager/menu_items/index.html.erb
+++ b/engines/campaignmanager/app/views/campaignmanager/menu_items/index.html.erb
@@ -53,6 +53,7 @@
       <select name="selectEngineSB" id="selectEngineSB">
         <option value="WB">World Builder</option>
         <option value="SB">Adventure Builder</option>
+        <option value="CM">Campaign Builder</option>
       </select>
       <select name="selectParent" id="selectParent"></select>
       <select name="selectRecord" id="selectRecord"></select>

--- a/engines/campaignmanager/app/views/campaignmanager/pages/index.json.jbuilder
+++ b/engines/campaignmanager/app/views/campaignmanager/pages/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@pages) do |page|
   json.extract! page, :id, :name
-  json.path "/#{@type.underscore.pluralize}/#{page.id}"
+  json.path city_path(@parent_object, page)
 end


### PR DESCRIPTION
## Summary

- **World Builder routing fix**: `wb_url` was missing the resident slug, so selecting World Builder made a request to `/resident/districts.json` (no route). Now correctly uses `/residents/<slug>/districts.json`.
- **Campaign Builder added**: New wizard option populates the first dropdown with the campaign's page types (Adventure Logs, House Rules, GM Notes, Pages). Selecting a type fetches its pages via the existing JSON endpoint and populates the record picker.
- **Pages JSON path fix**: `index.json.jbuilder` was generating bare paths like `/adventure_logs/<id>` instead of the full campaign-scoped URL. Now uses `city_path(@parent_object, page)` to produce correct paths like `/cm/campaigns/<id>/adventure_logs/<page_id>`.

## Test plan

- [ ] Open the Link Wizard on a campaign's menu items page
- [ ] Select "World Builder" — districts load without routing error
- [ ] Select "Campaign Builder" — page type categories appear in the second dropdown
- [ ] Select a page type (e.g. "Adventure Logs") — individual pages load in the third dropdown
- [ ] Click "Select" — the correct campaign-scoped URL is inserted into the link field

🤖 Generated with [Claude Code](https://claude.com/claude-code)