### PR TITLE
Update footer copyright notice for GPLv3 accuracy

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="row full-width">
     <div class="medium-12 columns text-center">
       <span class="copy">
-        &copy; <%= DateTime.now.year %> <a href="https://www.embersds.com" target="_blank">Embers Design Studios, LLC</a>. All rights reserved.
+        &copy; 2018 Embers Design Studios, LLC (GPLv3). Modified by Etienne van Delden de la Haije <%= DateTime.now.year %>.
         | <a href="/scrolls/privacy_policy">Privacy Policy</a>
       </span>
     </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class="row full-width">
     <div class="medium-12 columns text-center">
       <span class="copy">
-        &copy; 2018 Embers Design Studios, LLC (GPLv3). Modified by Etienne van Delden de la Haije <%= DateTime.now.year %>.
-        | <a href="/scrolls/privacy_policy">Privacy Policy</a>
+        &copy; <%= t("layouts.footer.copyright_notice", year: DateTime.now.year) %>
+        | <a href="/scrolls/privacy_policy"><%= t("layouts.footer.privacy_policy") %></a>
       </span>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,10 @@ en:
       running: Running
       succeeded: Succeeded
   layouts:
+    footer:
+      copyright_notice: 2018 Embers Design Studios, LLC (GPLv3). Modified by Etienne
+        van Delden de la Haije %{year}.
+      privacy_policy: Privacy Policy
     form:
       options:
         confirm_delete: Are you sure you want to delete "%{name}"? This cannot be

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -145,6 +145,10 @@ it:
       running: In corso
       succeeded: Riuscito
   layouts:
+    footer:
+      copyright_notice: 2018 Embers Design Studios, LLC (GPLv3). Modificato da Etienne
+        van Delden de la Haije %{year}.
+      privacy_policy: Informativa sulla privacy
     form:
       options:
         confirm_delete: Sei sicuro di voler eliminare "%{name}"? Questa operazione

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -145,6 +145,10 @@ nl:
       running: Bezig
       succeeded: Geslaagd
   layouts:
+    footer:
+      copyright_notice: 2018 Embers Design Studios, LLC (GPLv3). Aangepast door Etienne
+        van Delden de la Haije %{year}.
+      privacy_policy: Privacybeleid
     form:
       options:
         confirm_delete: Weet je zeker dat je "%{name}" wilt verwijderen? Dit kan niet

--- a/test/views/footer_test.rb
+++ b/test/views/footer_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class FooterTest < ActionView::TestCase
+  test "renders localized copyright notice" do
+    I18n.with_locale(:nl) do
+      render partial: "layouts/footer"
+    end
+
+    assert_match(/Aangepast door Etienne van Delden de la Haije/, rendered)
+    assert_no_match(/Modified by Etienne van Delden de la Haije/, rendered)
+  end
+end


### PR DESCRIPTION
Fixes the footer copyright notice to be accurate and consistent with the project's GPLv3 license.

- Replaces the dynamic year (wrongly implying Embers DS is active in 2026) with the correct 2018 origin year
- Removes the stale link to embersds.com
- Removes "All rights reserved" which contradicts the GPLv3 license
- Adds modification credit for the current maintainer with a dynamic year