### PR TITLE
Rails Upgrade Phase 1: remove dead paperclip patch and unused rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,10 +102,6 @@ group :test do
   gem "cuprite"
 end
 
-group :production do
-  gem "rails_12factor"
-end
-
 # gem "sqlite_extensions-uuid", "~> 1.0"  # Removed - using UuidPrimaryKey concern instead
 
 gem "minitest", "~> 5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.3)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -327,9 +326,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.3-aarch64-linux-musl)
@@ -402,11 +398,6 @@ GEM
     rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.1.7.10)
       actionpack (= 6.1.7.10)
       activesupport (= 6.1.7.10)
@@ -598,7 +589,6 @@ DEPENDENCIES
   rails (~> 6.1)
   rails-controller-testing
   rails-i18n
-  rails_12factor
   redcarpet
   redis
   reline

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,24 +1,3 @@
-# Patch Paperclip 6.1.0 for Ruby 3.x compatibility: URI.escape was removed in Ruby 3.0.
-# Use URI::DEFAULT_PARSER.escape as the replacement.
-module Paperclip
-  class UrlGenerator
-    def escape_url(url)
-      if url.respond_to?(:escape)
-        url.escape
-      else
-        URI::DEFAULT_PARSER.escape(url).gsub(/[\?\(\)\[\]\+]/) { |m| "%#{m.ord.to_s(16).upcase}" }
-      end
-    end
-  end
-
-  class HttpUrlProxyAdapter < UriAdapter
-    def initialize(target, options = {})
-      escaped = URI::DEFAULT_PARSER.escape(target)
-      super(URI(target == URI::DEFAULT_PARSER.unescape(target) ? escaped : target), options)
-    end
-  end
-end
-
 Paperclip.options[:content_type_mappings][:xml] = %w[application/xml text/xml]
 
 module Paperclip


### PR DESCRIPTION
This closes out Phase 1 of the Rails-upgrade epic (#10). Most of #48's originally-described scope (paperclip → kt-paperclip, delayed_paperclip removal, uglifier → terser) was already completed in earlier commits — this PR just cleans up two remaining regressions:

1. Removes a dead `URI::DEFAULT_PARSER` Ruby-3.x compat patch in `config/initializers/paperclip.rb` that was accidentally reintroduced by an unrelated commit (kt-paperclip 6.4.2 doesn't need it).
2. Drops the unused `rails_12factor` gem from `Gemfile`'s production group.

Closes #48. Also flagging that the epic (#10) checklist items for the paperclip swap and delayed_paperclip removal can be checked off, since they're already done.

## Verification
- `bin/rails test` — 1026 runs, 0 failures
- `bin/rails test:system TEST=test/system/gallery_upload_test.rb` — passes (confirms kt-paperclip synchronous style generation still works)
- `bin/rails assets:precompile RAILS_ENV=production` — succeeds with terser
- `bundle install` — clean, `Gemfile.lock` no longer lists `rails_12factor`
- App boots (`bin/rails runner 'puts "ok"'`)