### PR TITLE
Fix XML upload rejection: detect by content, not Content-Type header

### DIFF
--- a/engines/importer/app/models/importer/preview.rb
+++ b/engines/importer/app/models/importer/preview.rb
@@ -7,9 +7,6 @@ module Importer
     GAME_MASTER_5_XML = "game_master_5_xml"
     MODES = [ RESIDENT_CONTENT, ADMIN_STOCK ].freeze
     STATUSES = %w[parsing ready expired].freeze
-    XML_CONTENT_TYPES = %w[application/xml text/xml].freeze
-    PLAIN_TEXT_CONTENT_TYPE = "text/plain"
-
     belongs_to :resident, optional: true
     has_many :preview_files, dependent: :destroy
     has_one :import, dependent: :nullify
@@ -65,14 +62,7 @@ module Importer
     end
 
     def xml_upload?(file)
-      return true if XML_CONTENT_TYPES.include?(upload_content_type(file))
-      return false unless upload_content_type(file) == PLAIN_TEXT_CONTENT_TYPE
-
       valid_xml?(file_io(file))
-    end
-
-    def upload_content_type(file)
-      file.content_type.to_s.split(";").first
     end
 
     def valid_xml?(io)

--- a/engines/importer/test/models/importer/preview_test.rb
+++ b/engines/importer/test/models/importer/preview_test.rb
@@ -11,19 +11,19 @@ class ImporterPreviewTest < ActiveSupport::TestCase
     assert_equal 0, preview.preview_files.count
   end
 
-  test "add_uploads accepts xml files detected as plain text" do
+  test "add_uploads accepts xml files regardless of content type" do
     preview = Importer::Preview.create!(resident: residents(:razune), mode: "resident_content", source: "game_master_5_xml",
                                         status: "parsing")
 
-    assert preview.add_uploads([ text_plain_xml_upload ])
+    assert preview.add_uploads([ octet_stream_xml_upload ])
     assert_equal "ready", preview.reload.status
     assert_equal 1, preview.preview_files.count
   end
 
-  test "add_uploads rejects plain text files without xml content" do
+  test "add_uploads rejects non-xml content regardless of content type" do
     preview = Importer::Preview.create!(resident: residents(:razune), mode: "resident_content", source: "game_master_5_xml",
                                         status: "parsing")
-    file = plain_text_upload
+    file = octet_stream_plain_text_upload
 
     assert_not preview.add_uploads([ file ])
     assert_includes preview.errors[:base], "must be an XML file"
@@ -48,15 +48,15 @@ class ImporterPreviewTest < ActiveSupport::TestCase
 
   private
 
-  def text_plain_xml_upload
-    Rack::Test::UploadedFile.new(importer_fixture_file("sample_compendium.xml"), "text/plain")
+  def octet_stream_xml_upload
+    Rack::Test::UploadedFile.new(importer_fixture_file("sample_compendium.xml"), "application/octet-stream")
   end
 
-  def plain_text_upload
+  def octet_stream_plain_text_upload
     file = Tempfile.new([ "plain-import", ".txt" ])
     file.write("not xml")
     file.rewind
-    Rack::Test::UploadedFile.new(file.path, "text/plain")
+    Rack::Test::UploadedFile.new(file.path, "application/octet-stream")
   ensure
     file&.close
   end


### PR DESCRIPTION
## Summary
- Replace the header-based gate in `xml_upload?` with a single Nokogiri content-based parse — browser-supplied Content-Type is unreliable (falls back to `application/octet-stream` for files without a strong MIME association, silently rejecting valid XML)
- Remove now-unused `XML_CONTENT_TYPES`, `PLAIN_TEXT_CONTENT_TYPE` constants and `upload_content_type` method
- Update tests to use `application/octet-stream` (the real failure case)

## Test plan
- [x] `engines/importer/test/models/importer/preview_test.rb` — 5 runs, 0 failures
- [ ] Manually upload a real DnDAppFiles compendium via admin stock import — should reach preview step
- [ ] Confirm a plain prose `.txt` file is still rejected