### PR TITLE
Install file/shared-mime-info in production image for Paperclip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
       curl sqlite3 libsqlite3-0 libvips \
       libxml2 libxslt1.1 zlib1g \
-      imagemagick && \
+      imagemagick file shared-mime-info && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"


### PR DESCRIPTION
## Summary

- The production Docker image's runtime stage never installed the `file` command-line utility or `shared-mime-info` (only present in the discarded build stage). kt-paperclip's `ContentTypeDetector` shells out to `file` to determine an upload's real content type.
- Without it, every upload is detected as `application/octet-stream` regardless of actual content, failing `validates_attachment_content_type` on `PreviewFile`/`ImportFile` (XML importer) and on all `Gallery::*Image` models — silently, since it's a normal handled validation failure rather than a crash, which is why nothing showed up in the logs.
- Fix: add `file shared-mime-info` to the runtime stage's `apt-get install` in the Dockerfile.

Reproduced locally by stripping `file` from `PATH` and confirming `Paperclip::ContentTypeDetector` falls back to `application/octet-stream` for a real XML file (`Terrapin::CommandNotFoundError`, caught internally). Also verified via a direct 15MB multipart POST to production that the reverse proxy is not the bottleneck (reaches Rails in ~1s).

## Test plan

- [ ] Rebuild and deploy the image
- [ ] Upload a DnDAppFiles compendium XML via the admin stock import page in production — should succeed
- [ ] Upload a resident avatar / map image / FAQ image in production — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)