### PR TITLE
Cap job container CPU/memory and reduce Sidekiq concurrency

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -8,7 +8,10 @@ servers:
   job:
     hosts:
       - 192.168.1.101
-    cmd: bundle exec sidekiq -c 8 -q imports -q default -q mailers -q paperclip
+    cmd: bundle exec sidekiq -c 1 -q imports -q default -q mailers -q paperclip
+    options:
+      cpus: "1.5"
+      memory: "1g"
 
 proxy:
   ssl: false


### PR DESCRIPTION
## Summary

- `job` shares a 2-core host with ~15 other services, with no Docker resource caps and Sidekiq running at `-c 8` concurrency.
- A large compendium import pegged the CPU enough that Sidekiq's own heartbeat thread starved (Redis RTT readings of ~100,000µs — Sidekiq's own diagnostic for "process is CPU-saturated"), dropping the job out of Sidekiq's Redis-side busy tracking while the `Import` record stayed stuck at `status: "running"`.
- Fix: cap the `job` container to `cpus: "1.5"` (guarantees `web` a reliable minimum share) and drop Sidekiq concurrency from 8 to 1 — with only 1.5 cores available and Ruby's GIL serializing CPU-bound work anyway, extra worker threads were mostly adding contention with the heartbeat thread rather than real parallelism.
- Also add `memory: "1g"` as a safety cap (confirmed via `docker inspect` that memory was not implicated in the observed restart — this is precautionary, not a fix for an observed OOM).

## Test plan

- [ ] Deploy and clear any stuck `Importer::Import` records (`Importer::Import.where(status: "running").update_all(status: "failed")`)
- [ ] Re-run a large compendium import and confirm no "Redis network connection performing extremely poorly" warnings in `bin/kamal accessory logs redis` / job logs
- [ ] Confirm the web app stays responsive during the import

🤖 Generated with [Claude Code](https://claude.com/claude-code)