### PR TITLE
Tune SQLite database configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,14 @@
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  pool: <%= ENV.fetch("MAX_THREADS", 5) %>
   timeout: 5000
+  pragmas:
+    journal_mode: wal
+    synchronous: normal
+    temp_store: memory
+    mmap_size: 134217728
+    cache_size: -20000
+    wal_autocheckpoint: 10000
 
 development:
   <<: *default
@@ -9,6 +16,14 @@ development:
 
 test:
   <<: *default
+  timeout: 20000
+  pragmas:
+    journal_mode: wal
+    synchronous: "off"
+    temp_store: memory
+    mmap_size: 134217728
+    cache_size: -20000
+    wal_autocheckpoint: 0
   database: db/test.sqlite3
 
 production:


### PR DESCRIPTION
Updates SQLite configuration to align the Active Record pool with Puma MAX_THREADS setting and adds Rails 7.1+ pragma configuration for WAL mode and related tuning. Test gets a longer busy timeout plus test-specific pragma values for safer concurrent system test access. The pragma block is intentionally inert on Rails 6.1 and will take effect after the planned Rails 7 rebase. Validation from the prior run covered YAML parsing, migration status, unit tests, and system tests.