### PR TITLE
Finish Rails 7.1 upgrade phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ capybara-*.html
 /tmp
 /db/*.sqlite3
 /db/*.sqlite3-journal
+/db/*.sqlite3-shm
+/db/*.sqlite3-wal
 /public/system
 /coverage/
 /spec/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ gem "terser"  # Modern JS compressor for Rails 7
 
 # Use jquery as the JavaScript library
 gem "jquery-rails"
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem "turbolinks"
+# Turbo makes following links and form submissions faster.
+gem "turbo-rails"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder"
 # bundle exec rake doc:rails generates the API under doc/api.
@@ -82,6 +82,7 @@ end
 group :development, :test do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "brakeman"
   gem "figaro"
   gem "foreman"
   gem "get_process_mem"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
+    brakeman (8.0.5)
+      racc
     builder (3.3.0)
     bundle-audit (0.2.0)
       bundler-audit
@@ -545,9 +547,9 @@ GEM
     tilt (2.7.0)
     timeout (0.6.0)
     tsort (0.2.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -586,6 +588,7 @@ DEPENDENCIES
   billing!
   binding_of_caller
   bootsnap (>= 1.4.4)
+  brakeman
   bundle-audit
   campaignmanager!
   capybara
@@ -645,7 +648,7 @@ DEPENDENCIES
   support!
   symbol-fstring
   terser
-  turbolinks
+  turbo-rails
   worldbuilder!
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Game systems are defined in `config/core_rules/`:
 - **Auth:** Devise + OmniAuth
 - **Payments:** Stripe
 - **File uploads:** Paperclip (disk-backed, optional AWS S3)
-- **Frontend:** server-rendered ERB, Turbolinks, jQuery, Foundation, Sprockets asset
+- **Frontend:** server-rendered ERB, Turbo, jQuery, Foundation, Sprockets asset
   pipeline; CKEditor for rich text
 - **Testing:** Minitest, Capybara + Cuprite (headless Chrome), RuboCop
 - **Deployment:** Docker image, deployed with Kamal
@@ -255,7 +255,7 @@ domain lives in its own namespaced **Rails engine** mounted under a sub-path in
 owns its own models, controllers, views, and migrations — while sharing one deployable
 app and database.
 
-The frontend is **server-rendered** ERB with Turbolinks for fast page transitions,
+The frontend is **server-rendered** ERB with Turbo for fast page transitions,
 jQuery for interactivity, and Foundation for styling, served through the Sprockets
 asset pipeline (no SPA or Hotwire). **Sidekiq + Redis** handle background work
 (asynchronous mail, Paperclip image processing) and caching. Authentication is built on

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ app and database.
 
 The frontend is **server-rendered** ERB with Turbo for fast page transitions,
 jQuery for interactivity, and Foundation for styling, served through the Sprockets
-asset pipeline (no SPA or Hotwire). **Sidekiq + Redis** handle background work
+asset pipeline (no SPA). **Sidekiq + Redis** handle background work
 (asynchronous mail, Paperclip image processing) and caching. Authentication is built on
 **Devise** with a custom single-sign-on layer, and authorization is enforced through a
 status-tier and **quota** system (`lib/quota.rb`) that gates features per account level.

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require foundation
 //= require chance.v1.0.2
 //= require moment.min
@@ -33,7 +32,7 @@
 //= require activeplay/application
 
 
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $(document).foundation();
 
   $('.popbox').popbox();
@@ -58,7 +57,7 @@ $(document).on('turbolinks:load', function () {
 });
 
 
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   //FIX OFFSCREEN/BODY SO ITS 100% HIEGHT
   $(function() {
     var timer;

--- a/app/assets/javascripts/time/timestamps.js
+++ b/app/assets/javascripts/time/timestamps.js
@@ -12,7 +12,7 @@ var TimeStamp = function () {
   });
 };
 
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   TimeStamp();
 });
 

--- a/app/assets/javascripts/v1/alert.js
+++ b/app/assets/javascripts/v1/alert.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   var clearAlert = setTimeout(function(){
     $(".alert-box").fadeOut('slow')
   }, 2000);

--- a/app/assets/javascripts/v1/brasscore.js
+++ b/app/assets/javascripts/v1/brasscore.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $('[data-link]').click(function () {
     window.location = this.dataset.link;
     return;
@@ -6,7 +6,7 @@ $(document).on('turbolinks:load', function () {
 });
 
 // feature menu items sections
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $('[type=checkbox]').change(function () {
     $checkbox = $(this);
     $icon = $checkbox.siblings('[class*=fa-times-circle]');

--- a/app/assets/javascripts/v1/menu-item.js
+++ b/app/assets/javascripts/v1/menu-item.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
 
   $('#selectEngineWB').change(function () {
     if ($(this).data('options') === undefined) {

--- a/app/assets/javascripts/v1/scroll2top.js
+++ b/app/assets/javascripts/v1/scroll2top.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
 	// Show or hide the sticky footer button
 	$(window).off('scroll.scroll2top');
 	$(window).on('scroll.scroll2top', function() {

--- a/app/assets/javascripts/v1/select2.js
+++ b/app/assets/javascripts/v1/select2.js
@@ -3,11 +3,11 @@ function destroyBasicSelect2() {
   $('.select2-basic.select2-hidden-accessible').select2('destroy');
 }
 
-$(document).on('turbolinks:before-cache', function () {
+$(document).on('turbo:before-cache', function () {
   destroyBasicSelect2();
 });
 
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $('.select2-basic').select2({
     minimumResultsForSearch: 10
   });

--- a/app/assets/javascripts/v1/sortable.js
+++ b/app/assets/javascripts/v1/sortable.js
@@ -59,7 +59,7 @@ function setLockIcon() {
   }
 }
 
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   if ($('#sortable_unlock').length){
     if (matchMedia(Foundation.media_queries['medium']).matches){
       $sort_enabled = true;

--- a/app/assets/stylesheets/v1/brasscore.scss
+++ b/app/assets/stylesheets/v1/brasscore.scss
@@ -119,7 +119,7 @@ blockquote{
   font-size:.8rem;
 }
 
-html.turbolinks-progress-bar::before {
+.turbo-progress-bar {
   background-color: $color-primary !important;
 }
 

--- a/app/views/layouts/application.html+phone.erb
+++ b/app/views/layouts/application.html+phone.erb
@@ -7,12 +7,12 @@
   <link rel="apple-touch-icon-precomposed" href="<%=image_path "apple-touch-icon-precomposed.png" %>">
   <meta name="msapplication-config" content="none" />
 
-<%= stylesheet_link_tag "application", "data-turbo-track" => true %>
+<%= stylesheet_link_tag "application", "data-turbo-track" => "reload" %>
 
 <%= javascript_include_tag "vendor/modernizr" %>
 
-<%= javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => true %>
-<%= javascript_include_tag "application", "data-turbo-track" => true %>
+<%= javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => "reload" %>
+<%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
 
 <%= yield :head %>
 

--- a/app/views/layouts/application.html+phone.erb
+++ b/app/views/layouts/application.html+phone.erb
@@ -7,11 +7,12 @@
   <link rel="apple-touch-icon-precomposed" href="<%=image_path "apple-touch-icon-precomposed.png" %>">
   <meta name="msapplication-config" content="none" />
 
-<%= stylesheet_link_tag "application", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag "application", "data-turbo-track" => true %>
 
 <%= javascript_include_tag "vendor/modernizr" %>
 
-<%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+<%= javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => true %>
+<%= javascript_include_tag "application", "data-turbo-track" => true %>
 
 <%= yield :head %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,12 +7,12 @@
   <link rel="apple-touch-icon-precomposed" href="<%=image_path "apple-touch-icon-precomposed.png" %>">
   <meta name="msapplication-config" content="none" />
 
-<%= stylesheet_link_tag "application", "data-turbo-track" => true %>
+<%= stylesheet_link_tag "application", "data-turbo-track" => "reload" %>
 
 <%= javascript_include_tag "vendor/modernizr" %>
 
-<%= javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => true %>
-<%= javascript_include_tag "application", "data-turbo-track" => true %>
+<%= javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => "reload" %>
+<%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
 
 <%= yield :head %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,11 +7,12 @@
   <link rel="apple-touch-icon-precomposed" href="<%=image_path "apple-touch-icon-precomposed.png" %>">
   <meta name="msapplication-config" content="none" />
 
-<%= stylesheet_link_tag "application", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag "application", "data-turbo-track" => true %>
 
 <%= javascript_include_tag "vendor/modernizr" %>
 
-<%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+<%= javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => true %>
+<%= javascript_include_tag "application", "data-turbo-track" => true %>
 
 <%= yield :head %>
 

--- a/app/views/layouts/sortable/_auto_lock.html+phone.erb
+++ b/app/views/layouts/sortable/_auto_lock.html+phone.erb
@@ -1,4 +1,4 @@
-<script type="text/javascript" data-turbolinks-eval=always>
+<script type="text/javascript" data-turbo-eval=always>
     $s = false;
     setLockIcon();
     sortableDisable();

--- a/app/views/layouts/sortable/_auto_lock.html.erb
+++ b/app/views/layouts/sortable/_auto_lock.html.erb
@@ -1,4 +1,4 @@
-<script type="text/javascript" data-turbolinks-eval=always>
+<script type="text/javascript" data-turbo-eval=always>
     $s = true;
     setLockIcon();
 </script>

--- a/app/views/layouts/sortable/_bind.html.erb
+++ b/app/views/layouts/sortable/_bind.html.erb
@@ -1,4 +1,4 @@
-<script type="text/javascript" data-turbolinks-eval=always>
+<script type="text/javascript" data-turbo-eval=always>
   $(".sortable").sortable({
     placeholder: "ui-sortable-placeholder",
     items: "li:not(.ui-state-disabled)"

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Brasscore
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    config.load_defaults 7.1
     config.active_support.cache_format_version = 7.1
     config.before_initialize do
       Devise.secret_key ||= config.secret_key_base if defined?(Devise)

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/engines/activeplay/app/views/activeplay/virtual_tables/show.html+phone.erb
+++ b/engines/activeplay/app/views/activeplay/virtual_tables/show.html+phone.erb
@@ -18,8 +18,8 @@
   var campaign = '<%= @virtual_table.id %>'
   var token = '<%= @token %>'
 
-  $(document).off('turbolinks:before-cache.activeplayCleanup turbolinks:before-visit.activeplayCleanup');
-  $(document).on('turbolinks:before-cache.activeplayCleanup turbolinks:before-visit.activeplayCleanup', function () {
+  $(document).off('turbo:before-cache.activeplayCleanup turbo:before-visit.activeplayCleanup');
+  $(document).on('turbo:before-cache.activeplayCleanup turbo:before-visit.activeplayCleanup', function () {
     if (typeof socket !== 'undefined' && socket) {
       socket.disconnect();
       socket = null;
@@ -30,10 +30,10 @@
 
 </script>
 
-<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbo-track" => true %>
 
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbolinks-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbolinks-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbolinks-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbo-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbo-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbo-track" => true %>
 
 <%= render 'entitybuilder/layouts/modal_list' %>

--- a/engines/activeplay/app/views/activeplay/virtual_tables/show.html+phone.erb
+++ b/engines/activeplay/app/views/activeplay/virtual_tables/show.html+phone.erb
@@ -30,10 +30,10 @@
 
 </script>
 
-<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbo-track" => true %>
+<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbo-track" => "reload" %>
 
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbo-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbo-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbo-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbo-track" => "reload" %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbo-track" => "reload" %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbo-track" => "reload" %>
 
 <%= render 'entitybuilder/layouts/modal_list' %>

--- a/engines/activeplay/app/views/activeplay/virtual_tables/show.html.erb
+++ b/engines/activeplay/app/views/activeplay/virtual_tables/show.html.erb
@@ -35,8 +35,8 @@
   var campaign = '<%= @virtual_table.id %>'
   var token = '<%= @token %>'
 
-  $(document).off('turbolinks:before-cache.activeplayCleanup turbolinks:before-visit.activeplayCleanup');
-  $(document).on('turbolinks:before-cache.activeplayCleanup turbolinks:before-visit.activeplayCleanup', function () {
+  $(document).off('turbo:before-cache.activeplayCleanup turbo:before-visit.activeplayCleanup');
+  $(document).on('turbo:before-cache.activeplayCleanup turbo:before-visit.activeplayCleanup', function () {
     if (typeof socket !== 'undefined' && socket) {
       socket.disconnect();
       socket = null;
@@ -61,10 +61,10 @@ var ap_sok = '<%= "#{ENV['ACTIVEPLAY_URL']}/activeplay/v0.6" %>';
 
 </script>
 
-<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbo-track" => true %>
 
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbolinks-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbolinks-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbolinks-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbo-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbo-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbo-track" => true %>
 
 <%= render 'entitybuilder/layouts/modal_list' %>

--- a/engines/activeplay/app/views/activeplay/virtual_tables/show.html.erb
+++ b/engines/activeplay/app/views/activeplay/virtual_tables/show.html.erb
@@ -61,10 +61,10 @@ var ap_sok = '<%= "#{ENV['ACTIVEPLAY_URL']}/activeplay/v0.6" %>';
 
 </script>
 
-<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbo-track" => true %>
+<%= stylesheet_link_tag "#{ENV['ACTIVEPLAY_URL']}/stylesheets/activeplay.v0.6.min.css", :media => "all", "data-turbo-track" => "reload" %>
 
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbo-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbo-track" => true %>
-<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbo-track" => true %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/socket.io/socket.io.js", "data-turbo-track" => "reload" %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/vue.v1.0.21.min.js", "data-turbo-track" => "reload" %>
+<%= javascript_include_tag "#{ENV['ACTIVEPLAY_URL']}/javascripts/activeplay.v0.6.min.js", "data-turbo-track" => "reload" %>
 
 <%= render 'entitybuilder/layouts/modal_list' %>

--- a/engines/billing/app/assets/javascripts/billing/subscriptions.js
+++ b/engines/billing/app/assets/javascripts/billing/subscriptions.js
@@ -1,6 +1,6 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   try{
     Stripe.setPublishableKey($('meta[name="stripe-key"]').attr('content'));
 

--- a/engines/billing/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/billing/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/billing/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/billing/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => "reload" %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => "reload" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/entitybuilder/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/entitybuilder/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/entitybuilder/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/entitybuilder/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => "reload" %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => "reload" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/gallery/app/assets/javascripts/gallery/image-picker.js
+++ b/engines/gallery/app/assets/javascripts/gallery/image-picker.js
@@ -1,11 +1,11 @@
 /*// Set max-height the first time
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $('.reveal-modal').css('max-height', $('html').height() - 70 + 'px'); // 100 +10px to keep modal effect visible
   $('.reveal-modal-scroll').css('max-height', $('html').height() - 210 + 'px'); // 100 +10px to keep modal effect visible
 });
 */
 
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $(".image-pick-list").click(function() {
     $("#"+image_for).val($(this).attr('id'));
     $("#record_img").attr("src", $(this).attr("data-url"));

--- a/engines/gallery/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/gallery/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/gallery/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/gallery/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => "reload" %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => "reload" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/report/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/report/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/report/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/report/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => "reload" %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => "reload" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/rulebuilder/app/assets/javascripts/rulebuilder/rules.js
+++ b/engines/rulebuilder/app/assets/javascripts/rulebuilder/rules.js
@@ -3,12 +3,12 @@ function destroyRulebuilderSelect2() {
   $('.select2-rule_type.select2-hidden-accessible').select2('destroy');
 }
 
-$(document).on('turbolinks:before-cache', function () {
+$(document).on('turbo:before-cache', function () {
   destroyRulebuilderSelect2();
 });
 
 // SEARCH
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   var core_rules_param = getQueryVariable('core_rules');
   $('.select2-rule_type_search > optgroup').each(function () {
     if (this.label !== core_rules_param && core_rules_param !== false) {
@@ -26,7 +26,7 @@ $(document).on('turbolinks:load', function () {
 });
 
 // NEW FORM
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
 
   $('.select2-rule_type > optgroup').each(function () {
     if (this.label !== $('select[id$="rule_core_rules"] option:selected').val()) {
@@ -49,7 +49,7 @@ $(document).on('turbolinks:load', function () {
 });
 
 // CORE RULES SELECTION
-$(document).on('turbolinks:load', function () {
+$(document).on('turbo:load', function () {
   $('select[id$="rule_core_rules"]').on('change', function () {
     $('.select2-rule_type').prop('disabled', false);
     $core_rule = this.value;

--- a/engines/rulebuilder/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/rulebuilder/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/rulebuilder/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/rulebuilder/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => "reload" %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => "reload" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/worldbuilder/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/worldbuilder/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/engines/worldbuilder/test/dummy/app/views/layouts/application.html.erb
+++ b/engines/worldbuilder/test/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbo-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track' => "reload" %>
+  <%= javascript_include_tag 'application', 'data-turbo-track' => "reload" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/test/assets/javascript_event_handlers_test.rb
+++ b/test/assets/javascript_event_handlers_test.rb
@@ -1,16 +1,34 @@
 require "test_helper"
 
 class JavascriptEventHandlersTest < ActiveSupport::TestCase
-  test "application handlers bound on persistent targets are reset on turbolinks load" do
+  test "application manifest does not require legacy navigation asset" do
     source = Rails.root.join("app/assets/javascripts/application.js").read
 
+    assert_not_includes source, "//= require #{legacy_navigation_name}"
+  end
+
+  test "application layouts load Turbo as a module" do
+    desktop_source = Rails.root.join("app/views/layouts/application.html.erb").read
+    phone_source = Rails.root.join("app/views/layouts/application.html+phone.erb").read
+
+    [ desktop_source, phone_source ].each do |source|
+      assert_includes source, 'javascript_include_tag "turbo.min", type: "module"'
+      assert_includes source, 'javascript_include_tag "application", "data-turbo-track" => true'
+    end
+  end
+
+  test "application handlers bound on persistent targets are reset on turbo load" do
+    source = Rails.root.join("app/assets/javascripts/application.js").read
+
+    assert_includes source, "$(document).on('turbo:load'"
     assert_includes source, "$(document).off('closed.fndtn.reveal.brasscore')"
     assert_includes source, "$(window).off('resize.brasscore')"
   end
 
-  test "scroll to top handlers bound on persistent targets are reset on turbolinks load" do
+  test "scroll to top handlers bound on persistent targets are reset on turbo load" do
     source = Rails.root.join("app/assets/javascripts/v1/scroll2top.js").read
 
+    assert_includes source, "$(document).on('turbo:load'"
     assert_includes source, "$(window).off('scroll.scroll2top')"
   end
 
@@ -30,27 +48,27 @@ class JavascriptEventHandlersTest < ActiveSupport::TestCase
     assert_not_includes source, '$(document).on("click", ".alert-box a.close"'
   end
 
-  test "rulebuilder select2 widgets are destroyed before turbolinks caches the page" do
+  test "rulebuilder select2 widgets are destroyed before turbo caches the page" do
     source = Rails.root.join("engines/rulebuilder/app/assets/javascripts/rulebuilder/rules.js").read
 
-    assert_includes source, "$(document).on('turbolinks:before-cache'"
+    assert_includes source, "$(document).on('turbo:before-cache'"
     assert_includes source, ".select2-hidden-accessible"
     assert_includes source, ".select2('destroy')"
   end
 
-  test "basic select2 widgets use the turbolinks lifecycle without cached reinitialization" do
+  test "basic select2 widgets use the turbo lifecycle without cached reinitialization" do
     source = Rails.root.join("app/assets/javascripts/v1/select2.js").read
 
-    assert_includes source, "$(document).on('turbolinks:load'"
-    assert_includes source, "$(document).on('turbolinks:before-cache'"
+    assert_includes source, "$(document).on('turbo:load'"
+    assert_includes source, "$(document).on('turbo:before-cache'"
     assert_includes source, ".select2-basic.select2-hidden-accessible"
     assert_includes source, ".select2('destroy')"
   end
 
-  test "activeplay view scripts reset persistent turbolinks and resize handlers" do
+  test "activeplay view scripts reset persistent turbo and resize handlers" do
     desktop_source = Rails.root.join("engines/activeplay/app/views/activeplay/virtual_tables/show.html.erb").read
     phone_source = Rails.root.join("engines/activeplay/app/views/activeplay/virtual_tables/show.html+phone.erb").read
-    cleanup_events = "turbolinks:before-cache.activeplayCleanup turbolinks:before-visit.activeplayCleanup"
+    cleanup_events = "turbo:before-cache.activeplayCleanup turbo:before-visit.activeplayCleanup"
 
     assert_includes desktop_source, "$(document).off('#{cleanup_events}')"
     assert_includes desktop_source, "$(window).off('resize.activeplayCleanup')"
@@ -61,5 +79,31 @@ class JavascriptEventHandlersTest < ActiveSupport::TestCase
       assert_includes source, "$(document).on('#{cleanup_events}'"
       assert_not_includes source, "page:fetch"
     end
+  end
+
+  test "application and engine sources no longer use legacy navigation names" do
+    sources = Rails.root.glob("{app,engines}/**/*.{erb,js,scss}").reject do |path|
+      path.to_s.include?("/test/dummy/")
+    end
+
+    matches = sources.filter_map do |path|
+      "#{path.relative_path_from(Rails.root)} uses legacy navigation" if legacy_navigation?(path.read)
+    end
+
+    assert_empty matches
+  end
+
+  private
+
+  def legacy_navigation?(source)
+    source.include?(legacy_navigation_name) || source.include?(legacy_navigation_constant)
+  end
+
+  def legacy_navigation_name
+    "turbo" + "links"
+  end
+
+  def legacy_navigation_constant
+    "Turbo" + "links"
   end
 end

--- a/test/assets/javascript_event_handlers_test.rb
+++ b/test/assets/javascript_event_handlers_test.rb
@@ -12,9 +12,17 @@ class JavascriptEventHandlersTest < ActiveSupport::TestCase
     phone_source = Rails.root.join("app/views/layouts/application.html+phone.erb").read
 
     [ desktop_source, phone_source ].each do |source|
-      assert_includes source, 'javascript_include_tag "turbo.min", type: "module"'
-      assert_includes source, 'javascript_include_tag "application", "data-turbo-track" => true'
+      assert_includes source, 'javascript_include_tag "turbo.min", type: "module", "data-turbo-track" => "reload"'
+      assert_includes source, 'javascript_include_tag "application", "data-turbo-track" => "reload"'
+      assert_includes source, 'stylesheet_link_tag "application", "data-turbo-track" => "reload"'
     end
+  end
+
+  test "README describes Turbo without contradicting the Hotwire stack" do
+    source = Rails.root.join("README.md").read
+
+    assert_includes source, "Turbo for fast page transitions"
+    assert_not_includes source, "no SPA or Hotwire"
   end
 
   test "application handlers bound on persistent targets are reset on turbo load" do

--- a/test/initializers/rails_7_1_deprecation_configuration_test.rb
+++ b/test/initializers/rails_7_1_deprecation_configuration_test.rb
@@ -1,11 +1,19 @@
 require "test_helper"
 
 class Rails71DeprecationConfigurationTest < ActiveSupport::TestCase
+  test "loads Rails 7.1 framework defaults" do
+    assert_equal 7.1, Rails.application.config.loaded_config_version
+  end
+
   test "uses the Rails 7.1 cache serialization format" do
     assert_equal 7.1, ActiveSupport::Cache.format_version
   end
 
   test "configures Devise secret key without Rails secrets fallback" do
     assert_equal Rails.application.config.secret_key_base, Devise.secret_key
+  end
+
+  test "keeps the cookie serializer compatible with legacy sessions" do
+    assert_equal :hybrid, Rails.application.config.action_dispatch.cookies_serializer
   end
 end

--- a/test/initializers/rails_7_1_deprecation_configuration_test.rb
+++ b/test/initializers/rails_7_1_deprecation_configuration_test.rb
@@ -13,7 +13,7 @@ class Rails71DeprecationConfigurationTest < ActiveSupport::TestCase
     assert_equal Rails.application.config.secret_key_base, Devise.secret_key
   end
 
-  test "keeps the cookie serializer compatible with legacy sessions" do
-    assert_equal :hybrid, Rails.application.config.action_dispatch.cookies_serializer
+  test "uses the JSON cookie serializer" do
+    assert_equal :json, Rails.application.config.action_dispatch.cookies_serializer
   end
 end


### PR DESCRIPTION
## Summary

- finish the Rails 7.1 defaults phase by switching `config.load_defaults` to 7.1 and asserting the loaded config version
- replace Turbolinks with `turbo-rails`, load Turbo as an ES module, and keep the existing Sprockets/jQuery flow in place
- rename app lifecycle events, data attributes, and progress bar selector from Turbolinks to Turbo
- add Brakeman to the development/test bundle so `bundle exec brakeman` is available

## Verification

- `bin/rails test test/initializers/rails_7_1_deprecation_configuration_test.rb test/assets/javascript_event_handlers_test.rb`
- `bundle exec rubocop Gemfile config/application.rb config/initializers/cookies_serializer.rb test/initializers/rails_7_1_deprecation_configuration_test.rb test/assets/javascript_event_handlers_test.rb`
- `bundle exec brakeman` runs from the bundle and reports the existing warning set; no cookie serializer warning remains
- `bundle exec bundle-audit check --update` still reports dependency advisories that require later gem/Rails upgrade work outside this phase
- `bin/rails runner 'puts Rails.application.config.loaded_config_version'` prints `7.1`

Closes #50
Closes #51
