### PR TITLE
Make sessions persist ~1 year instead of expiring frequently

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < Devise::SessionsController
+  def create
+    params[resource_name][:remember_me] = "1"
+    super
+  end
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,11 +17,6 @@
             <% if flash[:alert] %>
               <label class="error" style="padding-bottom: .5em;"><%= alert %></label>
             <% end %>
-            <% if devise_mapping.rememberable? %>
-            <div style='margin-top:1em; margin-bottom:.7em;'>
-              <%= f.input :remember_me, label: "Remember me", as: :boolean %>
-            </div>
-            <% end %>
             <%= button_tag type: 'submit' do %>
               Login <i class='fa fa-sign-in'></i>
             <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -125,7 +125,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  config.remember_for = 14.days
+  config.remember_for = 1.year
 
   # If true, extends the user's remember period when remembered via cookie.
   config.extend_remember_period = true

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_cityofbrass_session'
+Rails.application.config.session_store :cookie_store, key: '_cityofbrass_session', expire_after: 1.year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ require "sidekiq/web"
 Rails.application.routes.draw do
   get "/up", to: ->(env) { [200, { "Content-Type" => "text/plain" }, ["OK"]] }
 
-  devise_for :admins, path_names: { sign_in: 'login', sign_out: 'logout' }
-  devise_for :users, path_names: { sign_in: 'login', sign_out: 'logout' }, skip: [:registrations]
+  devise_for :admins, path_names: { sign_in: 'login', sign_out: 'logout' }, controllers: { sessions: 'sessions' }
+  devise_for :users, path_names: { sign_in: 'login', sign_out: 'logout' }, skip: [:registrations], controllers: { sessions: 'sessions' }
 
   get 'sso/symposium' => 'sso#symposium'
 


### PR DESCRIPTION
## Summary
- Session cookie now sets `expire_after: 1.year` instead of expiring when the browser closes.
- Devise `remember_for` extended from 14 days to 1 year.
- Every login is now automatically "remembered" via a new `SessionsController` override, and the now-redundant "Remember me" checkbox was removed from the login form.

This is a single-user deployment, so frequent forced re-authentication was pure friction with negligible security benefit.

## Test plan
- [x] `bin/rails test test/system/sign_in_test.rb` passes for both user and admin sign-in
- [ ] Manually confirm the session/remember cookies have long expirations in the browser after logging in