### PR TITLE
feat: add exception_notification with Campfire notifier (Sidekiq)

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,5 @@
+# Audit all gems listed in the Gemfile for known security problems by running bin/bundler-audit.
+# CVEs that are not relevant to the application can be enumerated on the ignore list below.
+
+ignore:
+  - CVE-THAT-DOES-NOT-APPLY

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -5,3 +5,4 @@ KAMAL_REGISTRY_PASSWORD=$(op read "op://Familie/CityOfBrass/KAMAL_REGISTRY_PASSW
 SECRET_KEY_BASE=$(op read "op://Familie/CityOfBrass/SECRET_KEY_BASE" --account vandelden.1password.com)
 SMTP_URL=$(op read "op://Familie/CityOfBrass/SMTP_URL" --account vandelden.1password.com 2>/dev/null || true)
 ACTIVEPLAY_SECRET=$(op read "op://Familie/CityOfBrass/ACTIVEPLAY_SECRET" --account vandelden.1password.com)
+CAMPFIRE_WEBHOOK_URL=$(op read "op://Familie/CityOfBrass/CAMPFIRE_WEBHOOK_URL" --account vandelden.1password.com)

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby file: ".ruby-version"
 gem "dotenv-rails" # We want dotenv to load before everything else.
 
 gem "rails", "~> 7.2"
+gem "exception_notification", ">= 5.0"
+gem "exception_notification-campfire-once", github: "eirvandelden/exception_notification-campfire-once", branch: "ai/reykjavik"
 gem "bootsnap", ">= 1.4.4"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1", force_ruby_platform: true

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "dotenv-rails" # We want dotenv to load before everything else.
 
 gem "rails", "~> 7.2"
 gem "exception_notification", ">= 5.0"
-gem "exception_notification-campfire-once", github: "eirvandelden/exception_notification-campfire-once", branch: "ai/reykjavik"
+gem "exception_notification-campfire-once", github: "eirvandelden/exception_notification-campfire-once"
 gem "bootsnap", ">= 1.4.4"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1", force_ruby_platform: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 GIT
   remote: https://github.com/eirvandelden/exception_notification-campfire-once.git
-  revision: 792e397c1e969f573267d839feb2d946e4689628
-  branch: ai/reykjavik
+  revision: 8472c724465015c8e2d9ed4535c5e6e2c9bb817a
   specs:
-    exception_notification-campfire-once (0.1.0.pre.git.792e397)
+    exception_notification-campfire-once (0.1.0.pre.git.8472c72)
       exception_notification (>= 5.0)
 
 PATH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/eirvandelden/exception_notification-campfire-once.git
+  revision: 792e397c1e969f573267d839feb2d946e4689628
+  branch: ai/reykjavik
+  specs:
+    exception_notification-campfire-once (0.1.0.pre.git.792e397)
+      exception_notification (>= 5.0)
+
 PATH
   remote: engines/activeplay
   specs:
@@ -212,6 +220,9 @@ GEM
     ed25519 (1.4.0)
     erb (6.0.4)
     erubi (1.13.1)
+    exception_notification (5.0.1)
+      actionmailer (>= 7.1, < 9)
+      activesupport (>= 7.1, < 9)
     execjs (2.10.0)
     ferrum (0.17.2)
       addressable (~> 2.5)
@@ -594,6 +605,8 @@ DEPENDENCIES
   drb
   ed25519 (~> 1.4)
   entitybuilder!
+  exception_notification (>= 5.0)
+  exception_notification-campfire-once!
   figaro
   font-awesome-rails
   foreman

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -53,6 +53,7 @@ env:
     - SECRET_KEY_BASE
     - SMTP_URL
     - ACTIVEPLAY_SECRET
+    - CAMPFIRE_WEBHOOK_URL
 
 aliases:
   apps: server exec docker exec kamal-proxy kamal-proxy list

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,7 @@
+if Rails.env.production?
+  ExceptionNotification::Once::Campfire.install!(
+    webhook_url: ENV.fetch("CAMPFIRE_WEBHOOK_URL"),
+    app_name: ENV.fetch("APP_NAME", Rails.application.class.module_parent_name),
+    background: :sidekiq
+  )
+end

--- a/test/lib/bundler_audit_config_test.rb
+++ b/test/lib/bundler_audit_config_test.rb
@@ -3,7 +3,7 @@ require "bundler/audit/scanner"
 
 class BundlerAuditConfigTest < ActiveSupport::TestCase
   test "loads project advisory exceptions by default" do
-    scanner = Bundler::Audit::Scanner.new(Rails.root)
+    scanner = Bundler::Audit::Scanner.new(Rails.root, "Gemfile.lock", nil)
 
     assert_includes scanner.config.ignore, "CVE-THAT-DOES-NOT-APPLY"
   end

--- a/test/lib/bundler_audit_config_test.rb
+++ b/test/lib/bundler_audit_config_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "bundler/audit/scanner"
+
+class BundlerAuditConfigTest < ActiveSupport::TestCase
+  test "loads project advisory exceptions by default" do
+    scanner = Bundler::Audit::Scanner.new(Rails.root)
+
+    assert_includes scanner.config.ignore, "CVE-THAT-DOES-NOT-APPLY"
+  end
+end


### PR DESCRIPTION
## Summary

- Add `exception_notification >= 5.0` and `exception_notification-campfire-once` (branch `ai/reykjavik`) gems
- Add production-only initializer using `Campfire.install!` with `background: :sidekiq` (City of Brass uses Sidekiq)
- Add `CAMPFIRE_WEBHOOK_URL` to Kamal secrets (1Password `op://Familie/CityOfBrass/CAMPFIRE_WEBHOOK_URL`) and `config/deploy.yml`

## Post-merge action required

- Update gem reference from `branch: "ai/reykjavik"` to `ref: "<merged SHA>"` after the gem PR merges
- Add `CAMPFIRE_WEBHOOK_URL` to 1Password Familie/CityOfBrass before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)