### PR TITLE
Skip Campfire notifier install when webhook URL is absent

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,4 +1,4 @@
-if Rails.env.production?
+if Rails.env.production? && ENV["CAMPFIRE_WEBHOOK_URL"].present?
   ExceptionNotification::Once::Campfire.install!(
     webhook_url: ENV.fetch("CAMPFIRE_WEBHOOK_URL"),
     app_name: ENV.fetch("APP_NAME", Rails.application.class.module_parent_name),


### PR DESCRIPTION
## Summary

- `config/initializers/exception_notification.rb` calls `ENV.fetch("CAMPFIRE_WEBHOOK_URL")` unconditionally in production
- `assets:precompile` boots the app in production mode during Docker image builds, before runtime secrets are injected — build fails with `KeyError: key not found: "CAMPFIRE_WEBHOOK_URL"`

## Fix

Only install the Campfire notifier when the webhook URL is actually present:
```
-if Rails.env.production?
+if Rails.env.production? && ENV["CAMPFIRE_WEBHOOK_URL"].present?
```

At real runtime (with the secret injected via 1Password) the notifier still installs as before.

## Test plan

- [ ] `SECRET_KEY_BASE=dummy_for_assets_precompile ./bin/rails assets:precompile` succeeds without `CAMPFIRE_WEBHOOK_URL` set
- [ ] Docker image builds successfully
- [ ] Runtime with `CAMPFIRE_WEBHOOK_URL` set still installs the Campfire notifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)